### PR TITLE
refine status codes

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/MigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationException.php
@@ -34,36 +34,36 @@ class MigrationException extends \Exception
 {
     public static function migrationsNamespaceRequired()
     {
-        return new self('Migrations namespace must be configured in order to use Doctrine migrations.');
+        return new self('Migrations namespace must be configured in order to use Doctrine migrations.', 2);
     }
 
     public static function migrationsDirectoryRequired()
     {
-        return new self('Migrations directory must be configured in order to use Doctrine migrations.');
+        return new self('Migrations directory must be configured in order to use Doctrine migrations.', 3);
     }
 
     public static function noMigrationsToExecute()
     {
-        return new self('Could not find any migrations to execute.');
+        return new self('Could not find any migrations to execute.', 4);
     }
 
     public static function unknownMigrationVersion($version)
     {
-        return new self(sprintf('Could not find migration version %s', $version));
+        return new self(sprintf('Could not find migration version %s', $version), 5);
     }
 
     public static function alreadyAtVersion($version)
     {
-        return new self(sprintf('Database is already at version %s', $version), 2);
+        return new self(sprintf('Database is already at version %s', $version), 6);
     }
 
     public static function duplicateMigrationVersion($version, $class)
     {
-        return new self(sprintf('Migration version %s already registered with class %s', $version, $class));
+        return new self(sprintf('Migration version %s already registered with class %s', $version, $class), 7);
     }
 
     public static function configurationFileAlreadyLoaded()
     {
-        return new self(sprintf('Migrations configuration file already loaded'));
+        return new self(sprintf('Migrations configuration file already loaded'), 8);
     }
 }


### PR DESCRIPTION
If doctrine migations fail for some reason, the exit code is always 1. We deploy with hudson and want to ignore the fact that the migrations are at the latest level. This commit sets a different status code on every exception in MigrationException so they can  be checked for afterward.
