### PR TITLE
Bug/table versioning

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -239,15 +239,16 @@ class Version
                         $this->_outputWriter->write('     <comment>-></comment> ' . $query);
                         $this->_connection->executeQuery($query);
                     }
-
-                    if ($direction === 'up') {
-                        $this->markMigrated();
-                    } else {
-                        $this->markNotMigrated();
-                    }
                 } else {
                     $this->_outputWriter->write(sprintf('<error>Migration %s was executed but did not result in any SQL statements.</error>', $this->_version));
                 }
+
+                if ($direction === 'up') {
+                    $this->markMigrated();
+                } else {
+                    $this->markNotMigrated();
+                }
+
             } else {
                 foreach ($this->_sql as $query) {
                     $this->_outputWriter->write('     <comment>-></comment> ' . $query);


### PR DESCRIPTION
If either the up or down method did not contain SQL, then doctrine would not insert or delete the versioning entry in the database. This becomes a problem when you have a migration file below:

Migrating down would not remove the entry so if you were to upgrade again at a later date (a lot during development) doctrine would complain.

```
<?php

namespace DoctrineMigrations;

use Doctrine\DBAL\Migrations\AbstractMigration,
        Doctrine\DBAL\Schema\Schema;

class Version20101104022804 extends AbstractMigration
{
        public function up(Schema $schema)
        {
            $this->_addSql
            ('
                INSERT INTO news_contents (news_id, name, `order`, content)
                SELECT id, name, 1, content FROM news
            ');
        }

        public function down(Schema $schema)
        {

        }
}
```

Thank you.
