### PR TITLE
Speed up status/migrate

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -356,6 +356,24 @@ class Configuration
     }
 
     /**
+     * Returns all migrated versions from the versions table, in an array.
+     *
+     * @return array $migrated
+     */
+    public function getMigratedVersions()
+    {
+        $this->createMigrationTable();
+
+        $ret = $this->connection->fetchAll("SELECT version FROM " . $this->migrationsTableName);
+        $versions = array();
+        foreach ($ret as $version) {
+            $versions[] = current($version);
+        }
+
+        return $versions;
+    }
+
+    /**
      * Returns the current migrated version from the versions table.
      *
      * @return bool $currentVersion
@@ -450,8 +468,9 @@ class Configuration
             $allVersions = $this->migrations;
         }
         $versions = array();
+        $migrated = $this->getMigratedVersions();
         foreach ($allVersions as $version) {
-            if ($this->shouldExecuteMigration($direction, $version, $to)) {
+            if ($this->shouldExecuteMigration($direction, $version, $to, $migrated)) {
                 $versions[$version->getVersion()] = $version;
             }
         }
@@ -465,17 +484,18 @@ class Configuration
      * @param string $direction   The direction we are migrating.
      * @param Version $version    The Version instance to check.
      * @param string $to          The version we are migrating to.
+     * @param array $migrated     Migrated versions array.
      * @return void
      */
-    private function shouldExecuteMigration($direction, Version $version, $to)
+    private function shouldExecuteMigration($direction, Version $version, $to, $migrated)
     {
         if ($direction === 'down') {
-            if ( ! $this->hasVersionMigrated($version)) {
+            if ( ! in_array($version->getVersion(), $migrated)) {
                 return false;
             }
             return $version->getVersion() > $to ? true : false;
         } else if ($direction === 'up') {
-            if ($this->hasVersionMigrated($version)) {
+            if (in_array($version->getVersion(), $migrated)) {
                 return false;
             }
             return $version->getVersion() <= $to ? true : false;

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -103,8 +103,9 @@ EOT
         if ($showVersions === true) {
             if ($migrations = $configuration->getMigrations()) {
                 $output->writeln("\n <info>==</info> Migration Versions\n");
+                $migratedVersions = $configuration->getMigratedVersions();
                 foreach ($migrations as $version) {
-                    $isMigrated = $version->isMigrated();
+                    $isMigrated = in_array($version->getVersion(), $migratedVersions);
                     $status = $isMigrated ? '<info>migrated</info>' : '<error>not migrated</error>';
                     $output->writeln('    <comment>>></comment> ' . $configuration->formatVersion($version->getVersion()) . ' (<comment>' . $version->getVersion() . '</comment>)' . str_repeat(' ', 30 - strlen($name)) . $status);
                 }


### PR DESCRIPTION
Hi folks,

I have 170 migrations (and growing), reading from the database whether they are executed or not is slow if done one by one. I added a method that returns the array of executed methods for easy compare. Speeds up migrations:status and migrations:migrate.

Regards!

Tom
