### PR TITLE
Default phpunit now generates code coverage and ignores vendor folders.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,18 @@
          syntaxCheck="false"
          bootstrap="tests/bootstrap.php"
 >
+
+     <filter>
+        <blacklist>
+            <directory suffix=".php">./lib/vendor</directory>
+        </blacklist>
+    </filter>
+
+    <logging>
+        <log type="coverage-html" target="build/coverage" title="Doctrine2 Database Migrations"
+             charset="UTF-8" />
+    </logging>
+
     <testsuites>
         <testsuite name="Doctrine2 Database Migrations Test Suite">
             <directory>./tests/Doctrine/</directory>


### PR DESCRIPTION
To promote improving the code coverage and to match other projects that use phpunit (https://github.com/sebastianbergmann/phpunit/blob/3.5/phpunit.xml.dist , https://github.com/sebastianbergmann/php-code-coverage/blob/1.0/phpunit.xml.dist) code coverage is now logged by default to build/coverage. The build directory is listed in .gitignore so the code coverage output will not show up as unversioned files.

Also, the vendor directory is ignored from code coverage since the code coverage of those vendor projects is not the responsibility of the migrations project. This allows the code coverage to be generated much quicker.
