### PR TITLE
don't treat just pressing return as confirmation when executing a migration

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -90,7 +90,7 @@ EOT
             if ($noInteraction === true) {
                 $version->execute($direction, $input->getOption('dry-run') ? true : false);
             } else {
-                $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', 'y');
+                $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
                 if ($confirmation === true) {
                     $version->execute($direction, $input->getOption('dry-run') ? true : false);
                 } else {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -94,7 +94,7 @@ EOT
                 if ($noInteraction === true) {
                     $migration->migrate($version, $dryRun);
                 } else {
-                    $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', 'y');
+                    $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
                     if ($confirmation === true) {
                         $migration->migrate($version, $dryRun);
                     } else {


### PR DESCRIPTION
...which also occurs when accidentally hitting return twice in console
