### PR TITLE
PHAR standalone broken, when packaging manually

### DIFF
--- a/package.php
+++ b/package.php
@@ -29,7 +29,7 @@ $dirs = array(
     './lib'                                 =>  '/Doctrine\/DBAL\/Migrations/',
     './lib/vendor/doctrine-dbal/lib'        =>  '/Doctrine/',
     './lib/vendor/doctrine-common/lib'      =>  '/Doctrine/',
-    './lib/vendor/doctrine-dbal/lib/vendor' =>  '/Symfony/'
+    './lib/vendor'                          =>  '/Symfony/'
 );
 
 foreach ($dirs as $dir => $filter) {


### PR DESCRIPTION
The PHAR standalone is broken, when packaged manually.

For instance:

```
$ git clone --reference https://github.com/doctrine/migrations.git 
$ cd migrations
$ php package.php
$ php build/doctrine-migrations.phar migrations:status
=> PHP Fatal error:  Call to undefined method Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand::getApplication() in phar:///Users/martin/workspace/doctrine-migrations2/build/doctrine-migrations.phar/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php on line 82
```

This fix changes the package.php file to use the symfony components in lib/vendor/ instead of lib/vendor/doctrine-dbal/lib/vendor.

Regards,
Martin
