### PR TITLE
Allow longer version names

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -441,7 +441,7 @@ class Configuration
         $schema = $this->connection->getSchemaManager()->createSchema();
         if ( ! $schema->hasTable($this->migrationsTableName)) {
             $columns = array(
-                'version' => new Column('version', Type::getType('string'), array('length' => 14)),
+                'version' => new Column('version', Type::getType('string'), array('length' => 255)),
             );
             $table = new Table($this->migrationsTableName, $columns);
             $table->setPrimaryKey(array('version'));


### PR DESCRIPTION
The current migration table schema restricts the version column to 14 characters. It is useful to be able to give migration versions more descriptive names (as broached in #22) and, depending upon the scheme used, these may be longer than 14 characters, resulting in unexpected behaviour.

In databases that enforce the defined column length, longer version names will be silently truncated, which causes Configuration::hasVersionMigrated() to always return false for these versions. This means the system will erroneously always try to apply the migration. This is an issue in itself, and there should probably be a warning put in place and/or better some special handling of long version names, but a fast fix that will cover most use cases is to increase the length of the column storing the version names.
