### PR TITLE
Avoid calling array_combine if migration list is empty.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -465,9 +465,13 @@ class Configuration
     public function getMigrationsToExecute($direction, $to)
     {
         if ($direction === 'down') {
-            $allVersions = array_reverse(array_keys($this->migrations));
-            $classes = array_reverse(array_values($this->migrations));
-            $allVersions = array_combine($allVersions, $classes);
+            if (count($this->migrations)) {
+                $allVersions = array_reverse(array_keys($this->migrations));
+                $classes = array_reverse(array_values($this->migrations));
+                $allVersions = array_combine($allVersions, $classes);
+            } else {
+                $allVersions = array();
+            }
         } else {
             $allVersions = $this->migrations;
         }


### PR DESCRIPTION
This is a quick patch to avoid a Warning being thrown on `array_combine()` if `$this->migrations` contains no entries.

This behavior was noted in #47. Although the usage was incorrect (assuming `''` would migrate down instead of `0`) the warning should probably be avoided.

I also thought I could put:

``` php
if (!count($this->migrations)) { return array(); }
```

... but I am not sure that we actually need to run the other stuff. Since `$allVersions` is going to be an empty array I'd assume not, but someone who knows better might be able to verify that. This was just a safer way to go without knowing all of the ramifications of short circuiting the rest of the method.
