### PR TITLE
Major createMigrationTable() performance improvement

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -477,11 +477,10 @@ class Configuration
 
             return true;
         }
-        else {
-            $this->migrationTableCreated = true;
 
-            return false;
-        }
+        $this->migrationTableCreated = true;
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
In the createMigrationTable() method in Configuration, the schema is re-created every time the method is called if the migration table already exists.

We were trying to run a fairly large set of migrations across multiple databases and this method is called many times, resulting in lots of createSchema() requests which really slows the migrations down.

Now it's only ever called once per database inside this method greatly improving performance.
