### PR TITLE
[DMIG-30] Make :migrations:diff smart and generate Schema object changes, not SQL directly

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Generator/GeneratorInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/GeneratorInterface.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Generator;
+
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Defines the contract any migration generator must follow
+ */
+interface GeneratorInterface
+{
+    /**
+     * Generates a migration using a SchemaDiff
+     *
+     * @param Schema $fromSchema
+     * @param Schema $toSchema
+     *
+     * @return string Raw PHP code to be used as the body of a Migration
+     */
+    function generateMigration(Schema $fromSchema, Schema $toSchema);
+}

--- a/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
@@ -154,9 +154,9 @@ class PhpGenerator implements GeneratorInterface
                 $code[] = sprintf('$table->dropColumn(\'%s\');', $columnName);
             }
 
-            // TODO Should this be removed?
             foreach ($tableDiff->renamedColumns as $oldName => $column) {
-                $code[] = sprintf('$table->renameColumn(\'%s\', \'%s\'', $oldName, $column->getName());
+                $code[] = sprintf('$table->dropColumn(\'%s\');', $oldName);
+                $code[] = $this->getCreateColumnCode($column);
             }
 
             foreach ($tableDiff->addedIndexes as $indexName => $index) {

--- a/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
@@ -57,7 +57,7 @@ class PhpGenerator implements GeneratorInterface
      */
     public function generateMigration(Schema\Schema $fromSchema, Schema\Schema $toSchema)
     {
-        if (\Doctrine\DBAL\Version::compare('2.3.0') < 0) {
+        if (\Doctrine\DBAL\Version::compare('2.3.0') > 0) {
             throw new \RuntimeException('The PHP migration generator requires Doctrine DBAL 2.3.0 or later to function.');
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
@@ -21,7 +21,7 @@ namespace Doctrine\DBAL\Migrations\Generator;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Schema\Comparator;
-use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema;
 use Doctrine\DBAL\Types\Type;
 
 /**
@@ -67,12 +67,12 @@ class PhpGenerator implements GeneratorInterface
     /**
      * Generates a migration using a SchemaDiff
      *
-     * @param Schema $fromSchema
-     * @param Schema $toSchema
+     * @param \Doctrine\DBAL\Schema\Schema $fromSchema
+     * @param \Doctrine\DBAL\Schema\Schema $toSchema
      *
      * @return string Raw PHP code to be used as the body of a Migration
      */
-    public function generateMigration(Schema $fromSchema, Schema $toSchema)
+    public function generateMigration(Schema\Schema $fromSchema, Schema\Schema $toSchema)
     {
         $comparator = new Comparator();
         $schemaDiff = $comparator->compare($fromSchema, $toSchema);
@@ -206,7 +206,8 @@ class PhpGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Doctrine\DBAL\Schema\Column $column
+     * @param \Doctrine\DBAL\Schema\Column $column
+     *
      * @return string
      */
     protected function _getCreateColumnCode(Schema\Column $column)
@@ -219,7 +220,8 @@ class PhpGenerator implements GeneratorInterface
     }
 
     /**
-     * @param Doctrine\DBAL\Schema\Index $index
+     * @param \Doctrine\DBAL\Schema\Index $index
+     *
      * @return string
      */
     protected function _getCreateIndexCode(Schema\Index $index)
@@ -239,6 +241,7 @@ class PhpGenerator implements GeneratorInterface
 
     /**
      * @param string $indexName The name of the index to drop
+     *
      * @return string
      */
     protected function _getDropIndexCode($indexName)
@@ -254,7 +257,8 @@ END;
     }
 
     /**
-     * @param Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     * @param \Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     *
      * @return string
      */
     protected function _getCreateForeignKeyCode(Schema\ForeignKeyConstraint $foreignKey)
@@ -270,6 +274,7 @@ END;
 
     /**
      * @param string $indexName The name of the index to drop
+     *
      * @return string
      */
     protected function _getDropForeignKeyCode(Schema\ForeignKeyConstraint $foreignKey)
@@ -287,7 +292,8 @@ END;
     }
 
     /**
-     * @param Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     * @param \Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     *
      * @return array
      */
     protected function _getForeignKeyOptions(Schema\ForeignKeyConstraint $foreignKey)
@@ -296,7 +302,8 @@ END;
     }
 
     /**
-     * @param Doctrine\DBAL\Schema\Column $column
+     * @param \Doctrine\DBAL\Schema\Column $column
+     *
      * @return array
      */
     protected function _getColumnOptions(Schema\Column $column) {
@@ -350,7 +357,8 @@ END;
     }
 
     /**
-     * @param Doctrine\DBAL\Schema\AbstractAsset $asset
+     * @param \Doctrine\DBAL\Schema\AbstractAsset $asset
+     *
      * @return string
      */
     protected function _getQuotedIdentifier(Schema\AbstractAsset $asset)
@@ -360,6 +368,7 @@ END;
 
     /**
      * @param mixed $var
+     *
      * @return string
      */
     protected function _exportVar($var)

--- a/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
@@ -39,7 +39,7 @@ class PhpGenerator implements GeneratorInterface
     /**
      * Constructor
      *
-     * @param \Doctrine\DBAL\Migrations\Configuration\Configuration A Migration configuration
+     * @param \Doctrine\DBAL\Migrations\Configuration\Configuration $configuration A Migration configuration
      */
     public function __construct(Configuration $configuration)
     {
@@ -52,6 +52,7 @@ class PhpGenerator implements GeneratorInterface
      * @param \Doctrine\DBAL\Schema\Schema $fromSchema
      * @param \Doctrine\DBAL\Schema\Schema $toSchema
      *
+     * @throws \RuntimeException if Doctrine DBAL is not version 2.3.0 or later
      * @return string Raw PHP code to be used as the body of a Migration
      */
     public function generateMigration(Schema\Schema $fromSchema, Schema\Schema $toSchema)

--- a/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/PhpGenerator.php
@@ -1,0 +1,380 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Generator;
+
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Schema\Comparator;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Generates migrations using PHP-native DBAL methods
+ *
+ * @author Tyler Sommer <sommertm@gmail.com>
+ */
+class PhpGenerator implements GeneratorInterface
+{
+    /**
+     * @var Doctrine\DBAL\Migrations\Configuration\Configuration
+     */
+    protected $_configuration;
+
+    /**
+     * @var \ReflectionProperty A Reflection on Doctrine\DBAL\Schema\AbstractAsset#$_quoted
+     */
+    protected $_assetQuotedProperty;
+
+    /**
+     * @var \ReflectionProperty A Reflection on Doctrine\DBAL\Schema\ForeignKeyConstraint#$_options
+     */
+    protected $_foreignKeyOptionsProperty;
+
+    /**
+     * Constructor
+     *
+     * @param Doctrine\DBAL\Migrations\Configuration\Configuration A Migration configuration
+     */
+    public function __construct(Configuration $configuration)
+    {
+        $this->_configuration = $configuration;
+
+        $reflected = new \ReflectionClass('Doctrine\DBAL\Schema\AbstractAsset');
+        $this->_assetQuotedProperty = $reflected->getProperty('_quoted');
+        $this->_assetQuotedProperty->setAccessible(true);
+
+        $reflected = new \ReflectionClass('Doctrine\DBAL\Schema\ForeignKeyConstraint');
+        $this->_foreignKeyOptionsProperty = $reflected->getProperty('_options');
+        $this->_foreignKeyOptionsProperty->setAccessible(true);
+    }
+
+    /**
+     * Generates a migration using a SchemaDiff
+     *
+     * @param Schema $fromSchema
+     * @param Schema $toSchema
+     *
+     * @return string Raw PHP code to be used as the body of a Migration
+     */
+    public function generateMigration(Schema $fromSchema, Schema $toSchema)
+    {
+        $comparator = new Comparator();
+        $schemaDiff = $comparator->compare($fromSchema, $toSchema);
+
+        $code = array('');
+
+        foreach ($schemaDiff->changedSequences as $sequence) {
+            $code[] = sprintf('$sequence = $schema->getSequence(\'%s\');', $this->_getQuotedIdentifier($sequence));
+            $code[] = sprintf('$sequence->setAllocationSize(%s);', $sequence->getAllocationSize());
+            $code[] = sprintf('$sequence->setInitialValue(%s);', $sequence->getInitialValue());
+            $code[] = '';
+        }
+
+        foreach ($schemaDiff->removedSequences as $sequence) {
+            $code[] = sprintf('$schema->dropSequence(\'%s\');', $this->_getQuotedIdentifier($sequence));
+            $code[] = '';
+        }
+
+        foreach ($schemaDiff->newSequences as $sequence) {
+            $code[] = sprintf('$schema->createSequence(\'%s\', %s, %s);', $this->_getQuotedIdentifier($sequence), $sequence->getAllocationSize(), $sequence->getInitialValue());
+            $code[] = '';
+        }
+
+        foreach ($schemaDiff->newTables as $table) {
+            if ($table->getName() == $this->_configuration->getMigrationsTableName()) {
+                continue;
+            }
+
+            $code[] = '// Create table: ' . $table->getName();
+            $code[] = sprintf('$table = $schema->createTable(\'%s\');', $this->_getQuotedIdentifier($table));
+
+            foreach ($table->getOptions() as $name => $value) {
+                $code[] = sprintf('$table->addOption(\'%s\', \'%s\');');
+            }
+
+            foreach ($table->getColumns() as $column) {
+                $code[] = $this->_getCreateColumnCode($column);
+            }
+
+            foreach ($table->getIndexes() as $index) {
+                $code[] = $this->_getCreateIndexCode($index);
+            }
+
+            foreach ($table->getForeignKeys() as $foreignKey) {
+                $code[] = $this->_getCreateForeignKeyCode($foreignKey);
+            }
+
+            $code[] = '';
+        }
+
+        foreach ($schemaDiff->removedTables as $table) {
+            if ($table->getName() == $this->_configuration->getMigrationsTableName()) {
+                continue;
+            }
+
+            $code[] = '// Drop table: ' . $table->getName();
+            $code[] = sprintf('$schema->dropTable(\'%s\');', $this->_getQuotedIdentifier($table));
+            $code[] = '';
+        }
+
+        foreach ($schemaDiff->changedTables as $tableDiff) {
+            if ($tableDiff->name == $this->_configuration->getMigrationsTableName()) {
+                continue;
+            }
+
+            $code[] = '// Alter table: ' . $tableDiff->name;
+            $code[] = sprintf('$table = $schema->getTable(\'%s\');', $tableDiff->name);
+
+            if ($tableDiff->newName !== false) {
+                $code[] = sprintf('$table->setName(\'%s\');', $tableDiff->newName);
+            }
+
+            foreach ($tableDiff->addedColumns as $columnName => $column) {
+                $code[] = $this->_getCreateColumnCode($column);
+            }
+
+            foreach ($tableDiff->changedColumns as $oldName => $columnDiff) {
+                $code[] = sprintf('$column = $table->getColumn(\'%s\');', $oldName);
+                foreach ($columnDiff->changedProperties as $property) {
+                    $getter = "get{$property}";
+                    $value = call_user_func(array($columnDiff->column, $getter));
+
+                    if ($value instanceof Type) {
+                        $code[] = sprintf('$column->setType(\Doctrine\DBAL\Types\Type::getType(\'%s\'));', $value->getName());
+                    }
+                    else {
+                        $code[] = sprintf('$column->set%s(%s);', ucfirst($property), $this->_exportVar($value));
+                    }
+                }
+            }
+
+            foreach ($tableDiff->removedColumns as $columnName => $removed) {
+                $code[] = sprintf('$table->dropColumn(\'%s\');', $columnName);
+            }
+
+            foreach ($tableDiff->renamedColumns as $oldName => $column) {
+                $code[] = sprintf('$column = $table->getColumn(\'%s\');', $oldName);
+                $code[] = sprintf('$column->setName(\'%s\');', $column->getName());
+            }
+
+            foreach ($tableDiff->addedIndexes as $indexName => $index) {
+                $code[] = $this->_getCreateIndexCode($index);
+            }
+
+            foreach ($tableDiff->changedIndexes as $oldName => $index) {
+                $code[] = $this->_getDropIndexCode($oldName);
+                $code[] = $this->_getCreateIndexCode($index);
+            }
+
+            foreach ($tableDiff->removedIndexes as $indexName => $removed) {
+                $code[] = $this->_getDropIndexCode($indexName);
+            }
+
+            foreach ($tableDiff->addedForeignKeys as $foreignKey) {
+                $code[] = $this->_getCreateForeignKeyCode($foreignKey);
+            }
+
+            foreach ($tableDiff->changedForeignKeys as $foreignKey) {
+                $code[] = $this->_getDropForeignKeyCode($foreignKey);
+                $code[] = $this->_getCreateForeignKeyCode($foreignKey);
+            }
+
+            foreach ($tableDiff->removedForeignKeys as $foreignKey) {
+                $code[] = $this->_getDropForeignKeyCode($foreignKey);
+            }
+
+            $code[] = '';
+        }
+
+        return implode("\n", $code);
+    }
+
+    /**
+     * @param Doctrine\DBAL\Schema\Column $column
+     * @return string
+     */
+    protected function _getCreateColumnCode(Schema\Column $column)
+    {
+        return sprintf('$table->addColumn(\'%s\', \'%s\', %s);',
+            $this->_getQuotedIdentifier($column),
+            $column->getType()->getName(),
+            $this->_exportVar($this->_getColumnOptions($column))
+        );
+    }
+
+    /**
+     * @param Doctrine\DBAL\Schema\Index $index
+     * @return string
+     */
+    protected function _getCreateIndexCode(Schema\Index $index)
+    {
+        if ($index->isPrimary()) {
+            $str = '$table->setPrimaryKey(%s, \'%s\');';
+        }
+        else if ($index->isUnique()) {
+            $str = '$table->addUniqueIndex(%s, \'%s\');';
+        }
+        else {
+            $str = '$table->addIndex(%s, \'%s\');';
+        }
+
+        return sprintf($str, $this->_exportVar($index->getColumns()), $this->_getQuotedIdentifier($index));
+    }
+
+    /**
+     * @param string $indexName The name of the index to drop
+     * @return string
+     */
+    protected function _getDropIndexCode($indexName)
+    {
+        return <<<END
+\$reflected = new \ReflectionClass('Doctrine\DBAL\Schema\Table');
+\$indexesProperty = \$reflected->getProperty('_indexes');
+\$indexesProperty->setAccessible(true);
+\$indexes = \$indexesProperty->getValue(\$table);
+unset(\$indexes['{$indexName}']);
+\$indexesProperty->setValue(\$table, \$indexes);
+END;
+    }
+
+    /**
+     * @param Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     * @return string
+     */
+    protected function _getCreateForeignKeyCode(Schema\ForeignKeyConstraint $foreignKey)
+    {
+        return sprintf('$table->addForeignKeyConstraint(\'%s\', %s, %s, %s, \'%s\');',
+            $foreignKey->getForeignTableName(),
+            $this->_exportVar($foreignKey->getLocalColumns()),
+            $this->_exportVar($foreignKey->getForeignColumns()),
+            $this->_exportVar($this->_getForeignKeyOptions($foreignKey)),
+            $this->_getQuotedIdentifier($foreignKey)
+        );
+    }
+
+    /**
+     * @param string $indexName The name of the index to drop
+     * @return string
+     */
+    protected function _getDropForeignKeyCode(Schema\ForeignKeyConstraint $foreignKey)
+    {
+        $keyName = strtolower($foreignKey->getName());
+
+        return <<<END
+\$reflected = new \ReflectionClass('Doctrine\DBAL\Schema\Table');
+\$fkConstraintsProperty = \$reflected->getProperty('_fkConstraints');
+\$fkConstraintsProperty->setAccessible(true);
+\$fkConstraints = \$fkConstraintsProperty->getValue(\$table);
+unset(\$fkConstraints['{$keyName}']);
+\$fkConstraintsProperty->setValue(\$table, \$fkConstraints);
+END;
+    }
+
+    /**
+     * @param Doctrine\DBAL\Schema\ForeignKeyConstraint $foreignKey
+     * @return array
+     */
+    protected function _getForeignKeyOptions(Schema\ForeignKeyConstraint $foreignKey)
+    {
+        return $this->_foreignKeyOptionsProperty->getValue($foreignKey);
+    }
+
+    /**
+     * @param Doctrine\DBAL\Schema\Column $column
+     * @return array
+     */
+    protected function _getColumnOptions(Schema\Column $column) {
+        $options = array();
+
+        if ($column->getLength() !== null) {
+            $options['length'] = $column->getLength();
+        }
+
+        if ($column->getPrecision() !== 0) {
+            $options['precision'] = $column->getPrecision();
+        }
+
+        if ($column->getScale() !== 0) {
+            $options['scale'] = $column->getScale();
+        }
+
+        if ($column->getUnsigned() !== false) {
+            $options['unsigned'] = true;
+        }
+
+        if ($column->getFixed() !== false) {
+            $options['fixed'] = true;
+        }
+
+        if ($column->getNotNull() !== true) {
+            $options['notNull'] = false;
+        }
+
+        if ($column->getDefault() !== null) {
+            $options['default'] = $column->getDefault();
+        }
+
+        if ($column->getColumnDefinition() !== null) {
+            $options['columnDefinition'] = $column->getColumnDefinition();
+        }
+
+        if ($column->getPlatformOptions() !== array('version' => false) && $column->getPlatformOptions() !== array()) {
+            $options['platformOptions'] = $column->getPlatformOptions();
+        }
+
+        if ($column->getAutoincrement() !== false) {
+            $options['autoincrement'] = $column->getAutoincrement();
+        }
+
+        if ($column->getComment() !== null) {
+            $options['comment'] = $column->getComment();
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param Doctrine\DBAL\Schema\AbstractAsset $asset
+     * @return string
+     */
+    protected function _getQuotedIdentifier(Schema\AbstractAsset $asset)
+    {
+        return $this->_assetQuotedProperty->getValue($asset) ? '"' . $asset->getName() . '"' : $asset->getName();
+    }
+
+    /**
+     * @param mixed $var
+     * @return string
+     */
+    protected function _exportVar($var)
+    {
+        $export = var_export($var, true);
+
+        if (is_array($var)) {
+            $export = preg_replace('/[0-9+] \=\> /', '', $export);
+            $export = str_replace(array("array (\n)", "\n  ", 'array ('), array('array()', "\n    ", 'array('), $export);
+
+            if (count($var) == 1) {
+                $export = str_replace(array("\n", '    ', ',)'), array('', '', ')'), $export);
+            }
+        }
+
+        return $export;
+    }
+}

--- a/lib/Doctrine/DBAL/Migrations/Generator/SqlGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/SqlGenerator.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Generator;
+
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Generates platform-specific SQL migrations
+ *
+ * @author  Jonathan Wage <jonwage@gmail.com>
+ * @author  Tyler Sommer <sommertm@gmail.com>
+ */
+class SqlGenerator implements GeneratorInterface
+{
+    /**
+     * @var Doctrine\DBAL\Migrations\Configuration\Configuration
+     */
+    protected $_configuration;
+
+    /**
+     * Constructor
+     *
+     * @param Doctrine\DBAL\Migrations\Configuration\Configuration A Migration configuration
+     */
+    public function __construct(Configuration $configuration)
+    {
+        $this->_configuration = $configuration;
+    }
+
+    /**
+     * Generates a migration using a SchemaDiff
+     *
+     * @param Schema $fromSchema
+     * @param Schema $toSchema
+     *
+     * @return string Raw PHP code to be used as the body of a Migration
+     */
+    public function generateMigration(Schema $fromSchema, Schema $toSchema)
+    {
+        $platform = $this->_configuration->getConnection()->getDatabasePlatform();
+        $sql = $fromSchema->getMigrateToSql($toSchema, $platform);
+
+        $code = array(
+            "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != \"" . $platform->getName() . "\");", "",
+        );
+        foreach ($sql as $query) {
+            if (strpos($query, $this->_configuration->getMigrationsTableName()) !== false) {
+                continue;
+            }
+            $code[] = "\$this->addSql(\"$query\");";
+        }
+
+        return implode("\n", $code);
+    }
+}

--- a/lib/Doctrine/DBAL/Migrations/Generator/SqlGenerator.php
+++ b/lib/Doctrine/DBAL/Migrations/Generator/SqlGenerator.php
@@ -33,7 +33,7 @@ class SqlGenerator implements GeneratorInterface
     /**
      * @var Doctrine\DBAL\Migrations\Configuration\Configuration
      */
-    protected $_configuration;
+    protected $configuration;
 
     /**
      * Constructor
@@ -42,7 +42,7 @@ class SqlGenerator implements GeneratorInterface
      */
     public function __construct(Configuration $configuration)
     {
-        $this->_configuration = $configuration;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -55,14 +55,14 @@ class SqlGenerator implements GeneratorInterface
      */
     public function generateMigration(Schema $fromSchema, Schema $toSchema)
     {
-        $platform = $this->_configuration->getConnection()->getDatabasePlatform();
+        $platform = $this->configuration->getConnection()->getDatabasePlatform();
         $sql = $fromSchema->getMigrateToSql($toSchema, $platform);
 
         $code = array(
             "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != \"" . $platform->getName() . "\");", "",
         );
         foreach ($sql as $query) {
-            if (strpos($query, $this->_configuration->getMigrationsTableName()) !== false) {
+            if (strpos($query, $this->configuration->getMigrationsTableName()) !== false) {
                 continue;
             }
             $code[] = "\$this->addSql(\"$query\");";

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -26,6 +26,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
+use Doctrine\DBAL\Migrations\Generator\SqlGenerator;
+use Doctrine\DBAL\Migrations\Generator\PhpGenerator;
+
 /**
  * Command for generate migration classes by comparing your current database schema
  * to your mapping information.
@@ -43,6 +46,7 @@ class DiffCommand extends GenerateCommand
 
         $this
             ->setName('migrations:diff')
+            ->addOption('generator', null, InputOption::VALUE_OPTIONAL, 'Specify which generator to use. Available generators: <comment>php, sql</comment>', 'sql')
             ->setDescription('Generate a migration by comparing your current database to your mapping information.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command generates a migration by comparing your current database to your mapping information:
@@ -98,8 +102,14 @@ EOT
             }
         }
 
-        $up = $this->buildCodeFromSql($configuration, $fromSchema->getMigrateToSql($toSchema, $platform));
-        $down = $this->buildCodeFromSql($configuration, $fromSchema->getMigrateFromSql($toSchema, $platform));
+        if ('php' == $input->getOption('generator')) {
+            $generator = new PhpGenerator($configuration);
+        } else {
+            $generator = new SqlGenerator($configuration);
+        }
+
+        $up = $generator->generateMigration($fromSchema, $toSchema);
+        $down = $generator->generateMigration($toSchema, $fromSchema);
 
         if ( ! $up && ! $down) {
             $output->writeln('No changes detected in your mapping information.', 'ERROR');
@@ -112,7 +122,6 @@ EOT
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
     }
-
     private function buildCodeFromSql(Configuration $configuration, array $sql)
     {
         $currentPlatform = $configuration->getConnection()->getDatabasePlatform()->getName();


### PR DESCRIPTION
See: http://www.doctrine-project.org/jira/browse/DMIG-30

I refactored the way `DiffCommand` generates migrations, moving the SQL generation into `Migrations\Generator\SqlGenerator`.

I then created `PhpGenerator` that iterates over the given `SchemaDiff` and generates PHP code for the migration, using `DBAL\Schema` and related.

Usage (with symfony and MigrationsBundle): `app/console doctrine:migrations:diff --generator=php`

**There are a couple of hitches, though**: dropping indexes and dropping foreign keys. 

`Table#dropIndex` was added in 2.2, but seeing as how migrations currently supports doctrine 2.0 and greater, I didn't want to rely on that.

So, the generator uses Reflection to get the `Table$_indexes` and `Table$_fkConstraints` property and then modify them. Terrible, I know, but I don't see a way around it.

I am thinking the generator should simply not support the removing of foreign keys. I've used this code exclusively for a production application for the past few months, and dropping foreign keys in MySQL requires careful ordering of the SQL commands. Modifying the Schema object doesn't really allow you to enforce an order, and much of the time it simply does not work-- complaining about "General error: 1025 Error on rename of ..."

As for dropping of indexes, I was thinking I could check the Doctrine version to see if `Table#dropIndex` is available, otherwise fallback to the reflection.

Otherwise, I realize it is pretty messy. It needs to be refactored and cleaned up quite a bit. I just wanted some input on how to move forward before I spend more time on it.

Thoughts or suggestions?
