### PR TITLE
Refactored the migrate code and fixed minor bugs.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -98,7 +98,7 @@ EOT
                 $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>Are you sure you wish to continue? (y/n)</question>', false);
                 if ( ! $confirmation) {
                     $output->writeln('<error>Migration cancelled!</error>');
-                    return;
+                    return 1;
                 }
             }
         }
@@ -114,7 +114,7 @@ EOT
                 $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
                 if ( ! $confirmation) {
                     $output->writeln('<error>Migration cancelled!</error>');
-                    return;
+                    return 1;
                 }
             }
 


### PR DESCRIPTION
Added immediate return calls when the user decides not to go through with the migration, right after a message is printed.
On the first case(unregistered migrations) input was just ignored.
On the second $sql was never set.
Cleaned up the nested if statements to make the code more readable and maintainable.
