### PR TITLE
fixed undefined variable when migrating is cancelled

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -118,7 +118,7 @@ EOT
                     }
                 }
             }
-            if (!$sql) {
+            if (isset($sql) && !$sql) {
                 $output->writeln('<comment>No migrations to execute.</comment>');
             }
         }


### PR DESCRIPTION
Occurs when there actually are migrations to be executed, but the user declines the confirmation.
