### PR TITLE
Documentation URL changed

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,4 +55,4 @@ To install dependencies issue the following commands:
 
 ## Official Documentation
 
-All available documentation can be found [here](http://www.doctrine-project.org/projects/migrations/2.0/docs/en).
+All available documentation can be found [here](http://docs.doctrine-project.org/projects/doctrine-migrations/en/latest/).


### PR DESCRIPTION
The documentation URL of the doctrine project changed. The old URL is also used in the github project description.
