### PR TITLE
Ensure that $sql is set for all cases.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -103,6 +103,7 @@ EOT
             $path = is_bool($path) ? getcwd() : $path;
             $migration->writeSqlFile($path, $version);
         } else {
+            $sql = false;
             $dryRun = $input->getOption('dry-run') ? true : false;
             if ($dryRun === true) {
                 $sql = $migration->migrate($version, true);


### PR DESCRIPTION
Ensure that $sql is set for all cases. 

Could also be set in else clause on line 117, but I thought this was cleaner. 

This fixes a notice when canceling the migrate command.
