### PR TITLE
Update lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand...

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -118,7 +118,7 @@ EOT
                     }
                 }
             }
-            if (!$sql) {
+            if (isset($sql) && !$sql) {
                 $output->writeln('<comment>No migrations to execute.</comment>');
             }
         }


### PR DESCRIPTION
Previously if you were in interactive mode and you said 'no' you would get a variable $sql is undefined exception.
Updated to suppress the "No migrations to execute" message if you said say no. Which could be misleading if you do have migrations but said no to execute them.
