### PR TITLE
Migration description

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -86,11 +86,11 @@ abstract class AbstractMigration
     }
 
     /**
-     * Get custom migration name
+     * Get migration description
      *
      * @return string
      */
-    public function getName()
+    public function getDescription()
     {
     }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -111,7 +111,11 @@ EOT
                 foreach ($migrations as $version) {
                     $isMigrated = in_array($version->getVersion(), $migratedVersions);
                     $status = $isMigrated ? '<info>migrated</info>' : '<error>not migrated</error>';
-                    $output->writeln('    <comment>>></comment> ' . $configuration->formatVersion($version->getVersion()) . ' (<comment>' . $version->getVersion() . '</comment>)' . str_repeat(' ', 30 - strlen($name)) . $status);
+                    $migrationName = $version->getMigration()->getDescription();
+                    if ($migrationName) {
+                        $migrationName = str_repeat(' ', 10) . $migrationName;
+                    }
+                    $output->writeln('    <comment>>></comment> ' . $configuration->formatVersion($version->getVersion()) . ' (<comment>' . $version->getVersion() . '</comment>)' . str_repeat(' ', 30 - strlen($name)) . $status . $migrationName);
                 }
             }
 

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -112,7 +112,7 @@ class Version
         $this->sm = $this->connection->getSchemaManager();
         $this->platform = $this->connection->getDatabasePlatform();
         $this->migration = new $class($this);
-        $this->version = $this->migration->getName() ?: $version;
+        $this->version = $version;
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -22,17 +22,6 @@ class VersionTest extends MigrationTestCase
             'Doctrine\DBAL\Migrations\Tests\VersionTest_Migration');
         $this->assertEquals($versionName, $version->getVersion());
     }
-
-    /**
-     * Create migration with custom name
-     */
-    public function testCreateVersionWithCustomName()
-    {
-        $versionName = 'CustomVersionName';
-        $version = new Version(new Configuration($this->getSqliteConnection()), '003',
-            'Doctrine\DBAL\Migrations\Tests\VersionTest_MigrationCustom');
-        $this->assertEquals($versionName, $version->getVersion());
-    }
 }
 
 /**
@@ -44,15 +33,3 @@ class VersionTest_Migration extends AbstractMigration
     public function up(Schema $schema)   {}
 }
 
-/**
- * Migration with custom name
- */
-class VersionTest_MigrationCustom extends AbstractMigration
-{
-    public function getName()
-    {
-        return 'CustomVersionName';
-    }
-    public function down(Schema $schema) {}
-    public function up(Schema $schema)   {}
-}


### PR DESCRIPTION
In our company we encountered the need to give single migration a name. Unfortunately current implementation is heavily broken, because it allows you to change the version identifier `YYYYMMDDHHMMSS`, which is imho very dangerous.

Now the description is just an extra information, which is stored only in `getDescription()` method and displayed by status command with `--show-versions` argument. Method `getName()` was removed - **BC break!** Also removed the test method, simple getters are useless to test.

![Usage](http://i.imgur.com/AUhN3.png)