### PR TITLE
Ignore specified tables

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -96,6 +96,13 @@ class Configuration
     private $migrations = array();
 
     /**
+     * Array of tables that can be ignored when running migrations
+     *
+     * @var array
+     */
+    private $ignoredTables = array();
+
+    /**
      * Construct a migration configuration object.
      *
      * @param Connection $connection      A Connection instance
@@ -242,6 +249,34 @@ class Configuration
     public function getMigrationsNamespace()
     {
         return $this->migrationsNamespace;
+    }
+
+    /**
+     * Set the ignored tables
+     *
+     * @param array $ignoredTables
+     */
+    public function setIgnoredTables(array $ignoredTables)
+    {
+        $this->ignoredTables = $ignoredTables;
+    }
+
+    /**
+     * @param string $table
+     */
+    public function addIgnoredTable($table)
+    {
+        $this->ignoredTables[] = $table;
+    }
+
+    /**
+     * Returns the ignored tables
+     *
+     * @return array
+     */
+    public function getIgnoredTables()
+    {
+        return $this->ignoredTables;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
@@ -44,8 +44,8 @@ class XmlConfiguration extends AbstractFileConfiguration
         if (isset($xml->{'migrations-namespace'})) {
             $this->setMigrationsNamespace((string) $xml->{'migrations-namespace'});
         }
-        if (isset($xml->{'ignored_tables'}->{'table'})) {
-            foreach ($xml->{'ignored_tables'}->{'table'} as $table) {
+        if (isset($xml->{'ignored-tables'}->{'table'})) {
+            foreach ($xml->{'ignored-tables'}->{'table'} as $table) {
                 $this->addIgnoredTable((string) $table);
             }
         }

--- a/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
@@ -44,6 +44,11 @@ class XmlConfiguration extends AbstractFileConfiguration
         if (isset($xml->{'migrations-namespace'})) {
             $this->setMigrationsNamespace((string) $xml->{'migrations-namespace'});
         }
+        if (isset($xml->{'ignored_tables'}->{'table'})) {
+            foreach ($xml->{'ignored_tables'}->{'table'} as $table) {
+                $this->addIgnoredTable((string) $table);
+            }
+        }
         if (isset($xml->{'migrations-directory'})) {
             $migrationsDirectory = $this->getDirectoryRelativeToFile($file, (string) $xml->{'migrations-directory'});
             $this->setMigrationsDirectory($migrationsDirectory);

--- a/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
@@ -47,6 +47,9 @@ class YamlConfiguration extends AbstractFileConfiguration
         if (isset($array['migrations_namespace'])) {
             $this->setMigrationsNamespace($array['migrations_namespace']);
         }
+        if (isset($array['ignored_tables'])) {
+            $this->setIgnoredTables($array['ignored_tables']);
+        }
         if (isset($array['migrations_directory'])) {
             $migrationsDirectory = $this->getDirectoryRelativeToFile($file, $array['migrations_directory']);
             $this->setMigrationsDirectory($migrationsDirectory);

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -87,6 +87,14 @@ EOT
         $fromSchema = $conn->getSchemaManager()->createSchema();
         $toSchema = $tool->getSchemaFromMetadata($metadata);
 
+        //Remove ignored tables from $fromSchema
+        foreach ($fromSchema->getTables() as $table) {
+            /** @var \Doctrine\DBAL\Schema\Table $table */
+            if (in_array($table->getName(), $configuration->getIgnoredTables())) {
+                $fromSchema->dropTable($table->getName());
+            }
+        }
+
         //Not using value from options, because filters can be set from config.yml
         if ( ! $isDbalOld && $filterExpr = $conn->getConfiguration()->getFilterSchemaAssetsExpression()) {
             $tableNames = $toSchema->getTableNames();

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -36,6 +36,6 @@ abstract class AbstractConfigurationTest extends \Doctrine\DBAL\Migrations\Tests
     public function testIgnoredTables()
     {
         $config = $this->loadConfiguration();
-        $this->assertContains('ignored_tables', $config->getIgnoredTables());
+        $this->assertContains('ignored_table', $config->getIgnoredTables());
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -36,6 +36,6 @@ abstract class AbstractConfigurationTest extends \Doctrine\DBAL\Migrations\Tests
     public function testIgnoredTables()
     {
         $config = $this->loadConfiguration();
-        $this->assertArray(array('ignored_tables'), $config->getIgnoredTables());
+        $this->assertContains('ignored_tables', $config->getIgnoredTables());
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -32,4 +32,10 @@ abstract class AbstractConfigurationTest extends \Doctrine\DBAL\Migrations\Tests
         $config = $this->loadConfiguration();
         $this->assertEquals('doctrine_migration_versions_test', $config->getMigrationsTableName());
     }
+
+    public function testIgnoredTables()
+    {
+        $config = $this->loadConfiguration();
+        $this->assertArray(array('ignored_tables'), $config->getIgnoredTables());
+    }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.xml
@@ -6,6 +6,9 @@
 
     <name>Doctrine Sandbox Migrations</name>
     <migrations-namespace>DoctrineMigrationsTest</migrations-namespace>
+    <ignored-tables>
+        <table>ignored_table</table>
+    </ignored-tables>
     <table name="doctrine_migration_versions_test" />
     <migrations-directory>/path/to/migrations/classes/DoctrineMigrations</migrations-directory>
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.yml
@@ -1,5 +1,6 @@
 ---
 name: Doctrine Sandbox Migrations
 migrations_namespace: DoctrineMigrationsTest
+ignored_tables: [ ignored_table ]
 table_name: doctrine_migration_versions_test
 migrations_directory: /path/to/migrations/classes/DoctrineMigrations


### PR DESCRIPTION
A developer, for whatever reason, may want to have tables that do not correspond to Doctrine entities. With this modification, developers are able to define in the config file which tables can be ignored. 

There are no backward compatibility issues.