### PR TITLE
Allow editor-cmd to work with terminal-based editors

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -122,7 +122,7 @@ EOT
         file_put_contents($path, $code);
 
         if ($editorCmd = $input->getOption('editor-cmd')) {
-            shell_exec($editorCmd . ' ' . escapeshellarg($path));
+            proc_open($editorCmd . ' ' . escapeshellarg($path), array(), $pipes);
         }
 
         return $path;


### PR DESCRIPTION
This allows `--editor-cmd=vim` to work correctly in generate commands.

shell_exec captures the output, as a result a terminal-based editor cannot display anything on the terminal.

proc_open, when called with an empty $descriptorspec argument, lets the executed command inherit its file descriptors; as a result the editor can display itself in the terminal.