### PR TITLE
Small fix in AbstractCommand

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -79,7 +79,7 @@ abstract class AbstractCommand extends Command
                 return $output->writeln($message);
             });
 
-            if ($this->getApplication()->getHelperSet()->has('db')) {
+            if ($this->getHelper('db')) {
                 $conn = $this->getHelper('db')->getConnection();
             } else if($input->getOption('db-configuration')) {
                 if (!file_exists($input->getOption('db-configuration'))) {


### PR DESCRIPTION
Getting Fatal error: Call to undefined method Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::getApplication() without this fix.
