### PR TITLE
Don't create a diff if there are no mapping information changes

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -115,15 +115,21 @@ EOT
     private function buildCodeFromSql(Configuration $configuration, array $sql)
     {
         $currentPlatform = $configuration->getConnection()->getDatabasePlatform()->getName();
-        $code = array(
-            "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != \"$currentPlatform\");", "",
-        );
+        $abortCode = "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != \"$currentPlatform\");";
+
+        $code = array();
         foreach ($sql as $query) {
             if (strpos($query, $configuration->getMigrationsTableName()) !== false) {
                 continue;
             }
             $code[] = "\$this->addSql(\"$query\");";
         }
+
+        if (empty($code)) {
+            return;
+        }
+
+        array_unshift($code, $abortCode, "");
         return implode("\n", $code);
     }
 }


### PR DESCRIPTION
Although there is code to not generate a diff if there are no mapping information changes, there is always a statement (the abort statement if the database platform doesn't match) so a migration file is always created. This patch addresses that.

Mentioned in #41 and #104
