### PR TITLE
Support special characters in migration table name

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -368,7 +368,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        $version = $this->connection->fetchColumn("SELECT version FROM " . $this->migrationsTableName . " WHERE version = ?", array($version->getVersion()));
+        $version = $this->connection->fetchColumn("SELECT version FROM `" . $this->migrationsTableName . "` WHERE version = ?", array($version->getVersion()));
 
         return $version !== false;
     }
@@ -382,7 +382,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        $ret = $this->connection->fetchAll("SELECT version FROM " . $this->migrationsTableName);
+        $ret = $this->connection->fetchAll("SELECT version FROM `" . $this->migrationsTableName . "`");
         $versions = array();
         foreach ($ret as $version) {
             $versions[] = current($version);
@@ -424,7 +424,7 @@ class Configuration
             $where = " WHERE version IN (" . implode(', ', $migratedVersions) . ")";
         }
 
-        $sql = sprintf("SELECT version FROM %s%s ORDER BY version DESC",
+        $sql = sprintf("SELECT version FROM `%s`%s ORDER BY version DESC",
             $this->migrationsTableName, $where
         );
 
@@ -443,7 +443,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        $result = $this->connection->fetchColumn("SELECT COUNT(version) FROM " . $this->migrationsTableName);
+        $result = $this->connection->fetchColumn("SELECT COUNT(version) FROM `" . $this->migrationsTableName . "`");
 
         return $result !== false ? $result : 0;
     }

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -147,13 +147,13 @@ class Version
     public function markMigrated()
     {
         $this->configuration->createMigrationTable();
-        $this->connection->executeQuery("INSERT INTO " . $this->configuration->getMigrationsTableName() . " (version) VALUES (?)", array($this->version));
+        $this->connection->executeQuery("INSERT INTO `" . $this->configuration->getMigrationsTableName() . "` (version) VALUES (?)", array($this->version));
     }
 
     public function markNotMigrated()
     {
         $this->configuration->createMigrationTable();
-        $this->connection->executeQuery("DELETE FROM " . $this->configuration->getMigrationsTableName() . " WHERE version = ?", array($this->version));
+        $this->connection->executeQuery("DELETE FROM `" . $this->configuration->getMigrationsTableName() . "` WHERE version = ?", array($this->version));
     }
 
     /**


### PR DESCRIPTION
Support special characters in migration table name like "!Migration_Versions". This is useful when the database contains hundreds of tables and one wants the migration versions table to be at the first position.