### PR TITLE
package.php now succeeds in building the package (with deps installed via composer)

### DIFF
--- a/package.php
+++ b/package.php
@@ -26,10 +26,11 @@ $p->setSignatureAlgorithm(Phar::SHA1);
 $p->startBuffering();
 
 $dirs = array(
-    './lib'                                 =>  '/Doctrine\/DBAL\/Migrations/',
-    './lib/vendor/doctrine-dbal/lib'        =>  '/Doctrine/',
-    './lib/vendor/doctrine-common/lib'      =>  '/Doctrine/',
-    './lib/vendor'                          =>  '/Symfony/'
+    './lib'                                =>  '/Doctrine\/DBAL\/Migrations/',
+    './vendor/doctrine/dbal/lib/'          =>  '/Doctrine/',
+    './vendor/doctrine/common/lib/'        =>  '/Doctrine/',
+    './vendor/symfony/console/'            =>  '/Symfony/',
+    './vendor/symfony/yaml/'               =>  '/Symfony/'
 );
 
 foreach ($dirs as $dir => $filter) {


### PR DESCRIPTION
It seems composer now installs stuff in directories different to those used before... I couldn't build the phar using the provided package.php file so I tweaked it and now it successfully builds!