### PR TITLE
Using get-option('no-interaction') makes it unpossible for me to make it un-interactive

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -82,7 +82,7 @@ EOT
 
         $this->outputHeader($configuration, $output);
 
-        $noInteraction = $input->getOption('no-interaction') ? true : false;
+        $noInteraction = !$input->isInteractive();
 
         $executedMigrations = $configuration->getMigratedVersions();
         $availableMigrations = $configuration->getAvailableVersions();


### PR DESCRIPTION
I was implementing the doctrine:migrations:migrate command into another command and don't want the migrate command to act interactively. My code was:

```
    <?php
    $application = $this->getApplication();
    $command     = $application->find('doctrine:migrations:migrate');

    try {
        $environment = getenv('ENVIRONMENT');
        $configurationFile = getcwd() . '/db-config.ini';

        if (false === file_exists($configurationFile)) {
            throw new \RuntimeException('An INI configuration file is necessary.');
        }

        $configuration = parse_ini_file($configurationFile, true);

        if (false === array_key_exists('cli', $configuration)) {
            throw new \RuntimeException('The [cli] section is mandatory in the configuration file.');
        }

        $application->getHelperSet()->set(
            new ConnectionHelper(DriverManager::getConnection($configuration['cli'])),
            'db'
        );

    } catch (\RuntimeException $e) {
        $output->writeLn(sprintf('<error>%s</error>', $e->getMessage()));
        exit(1);
    }

    $input = new ArrayInput(array(
        null,
        '--force',
    ));
    $input->setInteractive(false);
    //$input->setOption('no-interaction', true);

    $command->run($input, $output);
    ?>
```

And symfony/console was still asking me if I really want to run migrations or not. I even tried setOption('no-interaction', true), but then Symfony complains it doesn't reconize the option 'no-interaction'. 

After some debugging in the code I found that the $noInteraction variable wasn't looking at the isInteractive method  in the input classes but to the no-interaction option it self from the console. I am assuming this works when you run the command from the command line but if you want to integrate it doesn't work. 
