### PR TITLE
added missing yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/dbal": ">=2.0,<2.5.x-dev"
+        "doctrine/dbal": ">=2.0,<2.5.x-dev",
+        "symfony/yaml": "2.3.4"
     },
     "require-dev": {
         "symfony/console": "2.*",


### PR DESCRIPTION
the symfony yaml component seems to be required for unit tests, added version 2.3.4
