### PR TITLE
fixed phpcs issues in migration files

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -51,12 +51,18 @@ use Doctrine\DBAL\Migrations\AbstractMigration,
  */
 class Version<version> extends AbstractMigration
 {
+    /**
+     * @param Schema $schema
+     */
     public function up(Schema $schema)
     {
         // this up() migration is auto-generated, please modify it to your needs
 <up>
     }
 
+    /**
+     * @param Schema $schema
+     */
     public function down(Schema $schema)
     {
         // this down() migration is auto-generated, please modify it to your needs


### PR DESCRIPTION
Fixed missing docblocks before up() and down() functions in the migrations scripts. This caused php codesniffer to give coding error on these files.

PHPCS error:

| ERROR   | Missing function doc comment