### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
         "psr-0": {
             "Doctrine\\DBAL\\Migrations": "lib"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Since comments in https://github.com/doctrine/migrations/issues/120 indicate that a stable tag isn't forthcoming, this adds a branch alias so it's possible to use stability flags on this library in composer files.
