### PR TITLE
added a command to output the latest version

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/LatestCommand.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Outputs the latest version number.
+ *
+ * @author Kris Wallsmith <kris.wallsmith@gmail.com>
+ */
+class LatestCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('migrations:latest')
+            ->setDescription('Outputs the latest version number')
+        ;
+
+        parent::configure();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $configuration = $this->getMigrationConfiguration($input, $output);
+
+        $output->writeln($configuration->getLatestVersion());
+    }
+}

--- a/phar-cli-stub.php
+++ b/phar-cli-stub.php
@@ -62,6 +62,7 @@ $cli->addCommands(array(
     // Migrations Commands
     new \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand(),
     new \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand(),
+    new \Doctrine\DBAL\Migrations\Tools\Console\Command\LatestCommand(),
     new \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand(),
     new \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand(),
     new \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand()


### PR DESCRIPTION
This is useful when rolling back a release that included migrations.

```
cd $OLD
VERSION=`php ... migrations:latest`
cd $NEW
php ... migrations:migrate $VERSION
```
