### PR TITLE
Fixed path names to use composer instaled vendors

### DIFF
--- a/package.php
+++ b/package.php
@@ -26,10 +26,11 @@ $p->setSignatureAlgorithm(Phar::SHA1);
 $p->startBuffering();
 
 $dirs = array(
-    './lib'                                 =>  '/Doctrine\/DBAL\/Migrations/',
-    './lib/vendor/doctrine-dbal/lib'        =>  '/Doctrine/',
-    './lib/vendor/doctrine-common/lib'      =>  '/Doctrine/',
-    './lib/vendor'                          =>  '/Symfony/'
+    './lib'                        =>  '/Doctrine\/DBAL\/Migrations/',
+    './vendor/doctrine/dbal/lib'   =>  '/Doctrine/',
+    './vendor/doctrine/common/lib' =>  '/Doctrine/',
+    './vendor/symfony/console'     =>  '/Symfony/',
+    './vendor/symfony/yaml'        =>  '/Symfony/',
 );
 
 foreach ($dirs as $dir => $filter) {


### PR DESCRIPTION
With these modifications I was able to run:

`php ../../migrations_doctrine/build/doctrine-migrations.phar migrations:status --db-configuration=db-config.php`

And got: 
![migrations](https://f.cloud.github.com/assets/915930/1521895/a30fac74-4b9c-11e3-8e01-5b4aa8287a28.png)
