### PR TITLE
Allow Custom Extended Configuration and Version Classes to be used 

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -290,10 +290,28 @@ class Configuration
         if (isset($this->migrations[$version])) {
             throw MigrationException::duplicateMigrationVersion($version, get_class($this->migrations[$version]));
         }
-        $version = new Version($this, $version, $class);
+        $version = $this->createVersion($version, $class);
         $this->migrations[$version->getVersion()] = $version;
         ksort($this->migrations);
 
+        return $version;
+    }
+
+    /**
+     * Creates a single migration version class be executed by a
+     * AbstractMigration class.
+     *
+     * @param string $version The version of the migration in the format YYYYMMDDHHMMSS.
+     * @param string $class   The migration class to execute for the version.
+     *
+     * @return Version
+     *
+     */
+    protected function createVersion($version, $class)
+    {
+        $version = (string) $version;
+        $class = (string) $class;
+        $version = new Version($this, $version, $class);
         return $version;
     }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -100,7 +100,10 @@ abstract class AbstractCommand extends Command
                 throw new \InvalidArgumentException('You have to specify a --db-configuration file or pass a Database Connection as a dependency to the Migrations.');
             }
 
-            if ($input->getOption('configuration')) {
+            if ($this->getApplication()->getHelperSet()->has('migration-configuration')) {
+                $configuration_helper = $this->getHelper('migration-configuration');
+                $configuration = $configuration_helper->getConfiguration($conn, $outputWriter, $input);
+            } else if ($input->getOption('configuration')) {
                 $info = pathinfo($input->getOption('configuration'));
                 $class = $info['extension'] === 'xml' ? 'Doctrine\DBAL\Migrations\Configuration\XmlConfiguration' : 'Doctrine\DBAL\Migrations\Configuration\YamlConfiguration';
                 $configuration = new $class($conn, $outputWriter);


### PR DESCRIPTION
These commits solve two issues I am faced with:

1. There is no way use a custom or extended Configuration class with the migration commands.
 - Based on the file name extension you only get the choice of:
    1. XmlConfiguration
    2. YamlConfiguration
    3. Configuration
 - (One work around is to use your own command and then use your custom configuration class)

2. There is no way to use a custom Version class
 - This would allow you to use your own code to mark a migration up or down.
 - However the Configuration base class is hard coded to use the Version class, and I can not overwrite because it uses private variables.

To solve the above issues I have made the following changes:
1. You can use a helper class, if defined, you can have a function to return your Configuration class instance.
2. You can override a new function in the configuration class to return your Version class instance.

Here is a simple example of what is possible with those changes:
https://gist.github.com/JeffPeters/7535348
This allows me to record when a migration was executed, but more options are possible.

I believe these changes would be useful to others.  Please let me know if you agree, and what changes I need to make to let have them ready to be merged in.