### PR TITLE
Returns empty array when processing 0 of 0 instead of exception.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -131,7 +131,7 @@ class Migration
         $direction = $from > $to ? 'down' : 'up';
         $migrationsToExecute = $this->configuration->getMigrationsToExecute($direction, $to);
 
-        if ($from === $to && empty($migrationsToExecute) && $migrations) {
+        if ($from === $to && empty($migrationsToExecute) && empty($migrations)) {
             return array();
         }
 
@@ -139,10 +139,6 @@ class Migration
             $this->outputWriter->write(sprintf('Migrating <info>%s</info> to <comment>%s</comment> from <comment>%s</comment>', $direction, $to, $from));
         } else {
             $this->outputWriter->write(sprintf('Executing dry run of migration <info>%s</info> to <comment>%s</comment> from <comment>%s</comment>', $direction, $to, $from));
-        }
-
-        if (empty($migrationsToExecute)) {
-            throw MigrationException::noMigrationsToExecute();
         }
 
         $sql = array();

--- a/lib/Doctrine/DBAL/Migrations/MigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationException.php
@@ -39,11 +39,6 @@ class MigrationException extends \Exception
         return new self('Migrations directory must be configured in order to use Doctrine migrations.', 3);
     }
 
-    public static function noMigrationsToExecute()
-    {
-        return new self('Could not find any migrations to execute.', 4);
-    }
-
     public static function unknownMigrationVersion($version)
     {
         return new self(sprintf('Could not find migration version %s', $version), 5);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -26,6 +26,15 @@ class FunctionalTest extends \Doctrine\DBAL\Migrations\Tests\MigrationTestCase
         $this->config->setMigrationsDirectory('.');
     }
 
+    public function testMigrateWithoutMigrationsReturnsEmpty()
+    {
+        $migration = new \Doctrine\DBAL\Migrations\Migration($this->config);
+
+        $sql = $migration->migrate();
+
+        $this->assertEquals(array(), $sql);;
+    }
+
     public function testMigrateUp()
     {
         $version = new \Doctrine\DBAL\Migrations\Version($this->config, 1, 'Doctrine\DBAL\Migrations\Tests\Functional\MigrationMigrateUp');
@@ -244,12 +253,14 @@ class FunctionalTest extends \Doctrine\DBAL\Migrations\Tests\MigrationTestCase
         $this->config->registerMigration(2, 'Doctrine\DBAL\Migrations\Tests\Functional\MigrationMigrateFurther');
 
         $migration = new \Doctrine\DBAL\Migrations\Migration($this->config);
+
         $migration->migrate();
 
         $sql = $migration->migrate();
 
         $this->assertEquals(array(), $sql);;
     }
+
 }
 
 class MigrateAddSqlTest extends \Doctrine\DBAL\Migrations\AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -23,14 +23,4 @@ class MigrationTest extends MigrationTestCase
         $this->setExpectedException('Doctrine\DBAL\Migrations\MigrationException', 'Could not find migration version 1234');
         $migration->migrate('1234');
     }
-
-    /**
-     * @expectedException \Doctrine\DBAL\Migrations\MigrationException
-     */
-    public function testMigrateWithNoMigrationsThrowsException()
-    {
-        $migration = new Migration($this->config);
-
-        $sql = $migration->migrate();
-    }
 }


### PR DESCRIPTION
This is consistent with other application behaviour.

Processing "0 of 1" and "1 of 1" migrations throws no exception,
but simply passes on an array(). "0 of 0" would turn out an exception
code which makes the script return an exit code to the system.