### PR TITLE
Adding php 5.5 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 
-before_script: "composer install --dev"
+install:
+  - "composer install --dev"


### PR DESCRIPTION
Also moved the composer install to Travis' "install" section instead of "before-command".
