### PR TITLE
Support version aliases in migrations:migrate

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -434,6 +434,85 @@ class Configuration
     }
 
     /**
+     * Returns the version prior to the current version.
+     *
+     * @return string|null  A version string, or null if the current version is
+     *                      the first.
+     */
+    public function getPrevVersion()
+    {
+        return $this->getRelativeVersion($this->getCurrentVersion(), -1);
+    }
+
+    /**
+     * Returns the version following the current version.
+     *
+     * @return string|null  A version string, or null if the current version is
+     *                      the latest.
+     */
+    public function getNextVersion()
+    {
+        return $this->getRelativeVersion($this->getCurrentVersion(), 1);
+    }
+
+    /**
+     * Returns the version with the specified offset to the specified version.
+     *
+     * @return string|null  A version string, or null if the specified version
+     *                      is unknown or the specified delta is not within the
+     *                      list of available versions.
+     */
+    public function getRelativeVersion($version, $delta)
+    {
+        $versions = array_keys($this->migrations);
+        array_unshift($versions, 0);
+        $offset = array_search($version, $versions);
+        if ($offset === false || !isset($versions[$offset + $delta])) {
+            // Unknown version or delta out of bounds.
+            return null;
+        }
+        return (string) $versions[$offset + $delta];
+    }
+
+    /**
+     * Returns the version number from an alias.
+     *
+     * Supported aliases are:
+     * - first: The very first version before any migrations have been run.
+     * - current: The current version.
+     * - prev: The version prior to the current version.
+     * - next: The version following the current version.
+     * - latest: The latest available version.
+     *
+     * If an existing version number is specified, it is returned verbatimly.
+     *
+     * @return  string|null  A version number, or null if the specified alias
+     *                       does not map to an existing version, e.g. if "next"
+     *                       is passed but the current version is already the
+     *                       latest.
+     */
+    public function resolveVersionAlias($alias)
+    {
+        if ($this->hasVersion($alias)) {
+            return $alias;
+        }
+        switch ($alias) {
+            case 'first':
+                return '0';
+            case 'current':
+                return $this->getCurrentVersion();
+            case 'prev':
+                return $this->getPrevVersion();
+            case 'next':
+                return $this->getNextVersion();
+            case 'latest':
+                return $this->getLatestVersion();
+            default:
+                return null;
+        }
+    }
+
+    /**
      * Returns the total number of executed migration versions
      *
      * @return integer

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -40,7 +40,7 @@ class MigrateCommand extends AbstractCommand
         $this
             ->setName('migrations:migrate')
             ->setDescription('Execute a migration to a specified version or the latest available version.')
-            ->addArgument('version', InputArgument::OPTIONAL, 'The version to migrate to.', null)
+            ->addArgument('version', InputArgument::OPTIONAL, 'The version number (YYYYMMDDHHMMSS) or alias (first, prev, next, latest) to migrate to.', 'latest')
             ->addOption('write-sql', null, InputOption::VALUE_NONE, 'The path to output the migration SQL file instead of executing it.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Execute the migration as a dry run.')
             ->setHelp(<<<EOT
@@ -51,6 +51,10 @@ The <info>%command.name%</info> command executes a migration to a specified vers
 You can optionally manually specify the version you wish to migrate to:
 
     <info>%command.full_name% YYYYMMDDHHMMSS</info>
+
+You can specify the version you wish to migrate to using an alias:
+
+    <info>%command.full_name% prev</info>
 
 You can also execute the migration as a <comment>--dry-run</comment>:
 
@@ -72,8 +76,6 @@ EOT
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $version = $input->getArgument('version');
-
         $configuration = $this->getMigrationConfiguration($input, $output);
         $migration = new Migration($configuration);
 
@@ -84,6 +86,22 @@ EOT
         $executedMigrations = $configuration->getMigratedVersions();
         $availableMigrations = $configuration->getAvailableVersions();
         $executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
+
+        $versionAlias = $input->getArgument('version');
+        $version = $configuration->resolveVersionAlias($versionAlias);
+        if ($version === null) {
+            switch ($versionAlias) {
+                case 'prev':
+                    $output->writeln('<error>Already at first version.</error>');
+                    break;
+                case 'next':
+                    $output->writeln('<error>Already at latest version.</error>');
+                    break;
+                default:
+                    $output->writeln('<error>Unknown version: ' . $output->getFormatter()->escape($versionAlias) . '</error>');
+            }
+            return 1;
+        }
 
         if ($executedUnavailableMigrations) {
             $output->writeln(sprintf('<error>WARNING! You have %s previously executed migrations in the database that are not registered migrations.</error>', count($executedUnavailableMigrations)));


### PR DESCRIPTION
Sometimes you just want to rerun the migration you are working on or run the migrations one step it a time. This involves a lot of copy-pasting of version numbers.

I suggest we allow commands like this:
* console migrations:migrate previous
* console migrations:migrate next
* console migrations:migrate first

I have introduced "first" as an alias of "0". I think this is more user-friendly (I remember that it took me a while to figure out that I the name of the initial version is "0").

I would like some comments on the naming of the aliases. Other solutions include "initial"/"prev" instead of or in addition to "first"/"previous".