### PR TITLE
Do not generate file if there are no changes

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -116,14 +116,16 @@ EOT
     private function buildCodeFromSql(Configuration $configuration, array $sql)
     {
         $currentPlatform = $configuration->getConnection()->getDatabasePlatform()->getName();
-        $code = array(
-            "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != \"$currentPlatform\", \"Migration can only be executed safely on '$currentPlatform'.\");", "",
-        );
+        $code = array();
         foreach ($sql as $query) {
             if (strpos($query, $configuration->getMigrationsTableName()) !== false) {
                 continue;
             }
             $code[] = "\$this->addSql(\"$query\");";
+        }
+
+        if ($code) {
+            array_unshift($code, "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() != \"$currentPlatform\", \"Migration can only be executed safely on '$currentPlatform'.\");", "");
         }
 
         return implode("\n", $code);


### PR DESCRIPTION
The following code in DiffCommand.php is never run because of the "Migration can only be executed safely on XXX"-warning that is always added:

```
        if ( ! $up && ! $down) {                                                                                        
            $output->writeln('No changes detected in your mapping information.', 'ERROR');

            return;                                                                                                     
        }                                                                                                               
```

This regression was introduced in February 2011: 14f6389c99e3a4c60085ce27fe608317db962e13

With this patch, the warning is only added when there are actual changes to migrate.
