### PR TITLE
Update migration_versions table when generating SQL

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -84,6 +84,8 @@ class Migration
             $to = $this->configuration->getLatestVersion();
         }
 
+        $direction = $from > $to ? 'down' : 'up';
+
         $string  = sprintf("# Doctrine Migration File Generated on %s\n", date('Y-m-d H:i:s'));
         $string .= sprintf("# Migrating from %s to %s\n", $from, $to);
 
@@ -92,7 +94,11 @@ class Migration
             foreach ($queries as $query) {
                 $string .= $query . ";\n";
             }
-            $string .= "INSERT INTO " . $this->configuration->getMigrationsTableName() . " (version) VALUES ('" . $version ."');\n";
+            if ($direction == "down") {
+                $string .= "DELETE FROM " . $this->configuration->getMigrationsTableName() . " WHERE version = '" . $version . "';\n";
+            } else {
+                $string .= "INSERT INTO " . $this->configuration->getMigrationsTableName() . " (version) VALUES ('" . $version . "');\n";
+            }
         }
         if (is_dir($path)) {
             $path = realpath($path);

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -92,6 +92,7 @@ class Migration
             foreach ($queries as $query) {
                 $string .= $query . ";\n";
             }
+            $string .= "INSERT INTO " . $this->configuration->getMigrationsTableName() . " (version) VALUES ('" . $version ."');\n";
         }
         if (is_dir($path)) {
             $path = realpath($path);

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -200,6 +200,11 @@ class Version
         foreach ($queries as $query) {
             $string .= $query . ";\n";
         }
+        if ($direction == "down") {
+            $string .= "DELETE FROM " . $this->configuration->getMigrationsTableName() . " WHERE version = '" . $this->version . "';\n";
+        } else {
+            $string .= "INSERT INTO " . $this->configuration->getMigrationsTableName() . " (version) VALUES ('" . $this->version . "');\n";
+        }
         if (is_dir($path)) {
             $path = realpath($path);
             $path = $path . '/doctrine_migration_' . date('YmdHis') . '.sql';


### PR DESCRIPTION
This means if you run the SQL generated in full, your migration_versions
table is consistent with your database, and migrations will continue
to work in future.