### PR TITLE
Help the user know how to test a migration file

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -111,6 +111,11 @@ EOT
         $path = $this->generateMigration($configuration, $input, $version, $up, $down);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
+        $commandName = sprintf('%s:execute', $this->getApplication()->extractNamespace($this->getName()));
+        if (count($command = $this->getApplication()->find($commandName))) {
+          $output->writeln(sprintf('To run just this migration for testing purposes, you can use "<info>%s --up %s</info>"', $command->getName(), $version));
+        }
+
     }
 
     private function buildCodeFromSql(Configuration $configuration, array $sql)

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -93,6 +93,11 @@ EOT
         $path = $this->generateMigration($configuration, $input, $version);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
+
+        $commandName = sprintf('%s:execute', $this->getApplication()->extractNamespace($this->getName()));
+        if (count($command = $this->getApplication()->find($commandName))) {
+          $output->writeln(sprintf('To run just this migration for testing purposes, you can use "<info>%s --up %s</info>"', $command->getName(), $version));
+        }
     }
 
     protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)


### PR DESCRIPTION
Added a message to explain how to test the migration at the end of the
diff and generate commands :

```
To run just this migration for testing purposes, you can use migrations:execute --up 2014XXXXXXX
```

See #173
