### PR TITLE
Support for non-transactional migrations.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -86,6 +86,19 @@ abstract class AbstractMigration
     }
 
     /**
+     * Indicates the transactional mode of this migration.
+     * Should return true to run migration in a transaction.
+     * Should return false to run migration not in a transaction.
+     * Extending class should override this function to alter the return value
+     *
+     * @return bool TRUE by default.
+     */
+    public function isTransactional()
+    {
+        return true;
+    }
+
+    /**
      * Get custom migration name
      *
      * @return string

--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -87,8 +87,9 @@ abstract class AbstractMigration
 
     /**
      * Indicates the transactional mode of this migration.
-     * Should return true to run migration in a transaction.
-     * Should return false to run migration not in a transaction.
+     * If this function returns true (default) the migration will be executed in one transaction,
+     * otherwise non-transactional state will be used to execute each of the migration SQLs.
+     *
      * Extending class should override this function to alter the return value
      *
      * @return bool TRUE by default.

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -307,7 +307,10 @@ class Version
 
             return $this->sql;
         } catch (SkipMigrationException $e) {
-            $this->connection->rollback();
+            if($this->transactional){
+                //only rollback transaction if in transactional mode
+                $this->connection->rollback();
+            }
 
             if ($dryRun == false) {
                 // now mark it as migrated
@@ -330,7 +333,10 @@ class Version
                 $this->version, $this->getExecutionState(), $e->getMessage()
             ));
 
-            $this->connection->rollback();
+            if($this->transactional){
+                //only rollback transaction if in transactional mode
+                $this->connection->rollback();
+            }
 
             $this->state = self::STATE_NONE;
             throw $e;


### PR DESCRIPTION
Some DB engines do not support ALTER statements inside a transaction. Added ability to disable transaction on individual migration level by overriding  the isTransactional() function.

EDIT 12/6/2014 (in reply to rjmunro):
One database which experiences this issue that I ran across is Pervasive SQL: http://www.pervasive.com/database