### PR TITLE
Add --ignore-errors option to migrations:execute

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -42,6 +42,7 @@ class ExecuteCommand extends AbstractCommand
             ->addArgument('version', InputArgument::REQUIRED, 'The version to execute.', null)
             ->addOption('write-sql', null, InputOption::VALUE_NONE, 'The path to output the migration SQL file instead of executing it.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Execute the migration as a dry run.')
+            ->addOption('ignore-errors', null, InputOption::VALUE_NONE, 'Continue running the migration even if errors are encountered.')
             ->addOption('up', null, InputOption::VALUE_NONE, 'Execute the migration up.')
             ->addOption('down', null, InputOption::VALUE_NONE, 'Execute the migration down.')
             ->addOption('query-time', null, InputOption::VALUE_NONE, 'Time all the queries individually.')
@@ -65,6 +66,10 @@ You can output the would be executed SQL statements to a file with <comment>--wr
 Or you can also execute the migration without a warning message which you need to interact with:
 
     <info>%command.full_name% YYYYMMDDHHMMSS --no-interaction</info>
+
+If migrations fail part way through, you may want to retry running all queries anyway, even if they come after the query that caused the error:
+
+    <info>%command.full_name% YYYYMMDDHHMMSS --ignore-errors</info>
 EOT
         );
 
@@ -93,7 +98,7 @@ EOT
             }
 
             if ($execute) {
-                $version->execute($direction, (boolean) $input->getOption('dry-run'), $timeAllqueries);
+                $version->execute($direction, (boolean) $input->getOption('dry-run'), $timeAllqueries, (boolean) $input->getOption('ignore-errors'));
             } else {
                 $output->writeln('<error>Migration cancelled!</error>');
             }

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -414,7 +414,7 @@ class Version
                         }
                     }  catch (DBALException $e) {
                         if ($continueAfterErrors) {
-                            $this->outputWriter->write(sprintf('         <error>- failed</error>', $query));
+                            $this->outputWriter->write(sprintf('         <error>- %s</error>', $e->getMessage()));
                         } else {
                             // Reraise exception
                             throw $e;

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -19,11 +19,12 @@
 
 namespace Doctrine\DBAL\Migrations;
 
-use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Provider\LazySchemaDiffProvider;
 use Doctrine\DBAL\Migrations\Provider\SchemaDiffProvider;
 use Doctrine\DBAL\Migrations\Provider\SchemaDiffProviderInterface;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * Class which wraps a migration version and allows execution of the
@@ -260,7 +261,7 @@ class Version
      *
      * @throws \Exception when migration fails
      */
-    public function execute($direction, $dryRun = false, $timeAllQueries = false)
+    public function execute($direction, $dryRun = false, $timeAllQueries = false, $continueAfterErrors = false)
     {
         $this->sql = [];
 
@@ -291,7 +292,7 @@ class Version
 
             $this->addSql($this->schemaProvider->getSqlDiffToMigrate($fromSchema, $toSchema));
 
-            $this->executeRegisteredSql($dryRun, $timeAllQueries);
+            $this->executeRegisteredSql($dryRun, $timeAllQueries, $continueAfterErrors);
 
             $this->state = self::STATE_POST;
             $this->migration->{'post' . ucfirst($direction)}($toSchema);
@@ -396,19 +397,28 @@ class Version
         return $this->version;
     }
 
-    private function executeRegisteredSql($dryRun = false, $timeAllQueries = false)
+    private function executeRegisteredSql($dryRun = false, $timeAllQueries = false, $continueAfterErrors = false)
     {
         if (! $dryRun) {
             if (!empty($this->sql)) {
                 foreach ($this->sql as $key => $query) {
                     $queryStart = microtime(true);
 
-                    if ( ! isset($this->params[$key])) {
-                        $this->outputWriter->write('     <comment>-></comment> ' . $query);
-                        $this->connection->executeQuery($query);
-                    } else {
-                        $this->outputWriter->write(sprintf('    <comment>-</comment> %s (with parameters)', $query));
-                        $this->connection->executeQuery($query, $this->params[$key], $this->types[$key]);
+                    try {
+                        if (!isset($this->params[$key])) {
+                            $this->outputWriter->write('     <comment>-></comment> ' . $query);
+                            $this->connection->executeQuery($query);
+                        } else {
+                            $this->outputWriter->write(sprintf('    <comment>-</comment> %s (with parameters)', $query));
+                            $this->connection->executeQuery($query, $this->params[$key], $this->types[$key]);
+                        }
+                    }  catch (DBALException $e) {
+                        if ($continueAfterErrors) {
+                            $this->outputWriter->write(sprintf('         <error>- failed</error>', $query));
+                        } else {
+                            // Reraise exception
+                            throw $e;
+                        }
                     }
 
                     $this->outputQueryTime($queryStart, $timeAllQueries);


### PR DESCRIPTION
If a migration fails with an error part way through, even if you fix
the error in the migration code, you usually cannot reapply the
migration because it will fail trying to redo the original commands that
succeeded.

If you try to roll back, that will fail on any commands that undo things
that weren't successfully done the first time.

This adds an --ignore-errors option to the migrations:execute command
that will run all the commands in the migration, even after earlier
commands cause errors. It is not recommended to use this option unless
you fully understand it's implications, but it can save a lot of time
fixing a broken database migration.
