### PR TITLE
Show preview and next version in migrations:status

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -57,17 +57,20 @@ EOT
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
 
-        $currentVersion = $configuration->getCurrentVersion();
-        if ($currentVersion) {
-            $currentVersionFormatted = $configuration->formatVersion($currentVersion) . ' (<comment>'.$currentVersion.'</comment>)';
-        } else {
-            $currentVersionFormatted = 0;
-        }
-        $latestVersion = $configuration->getLatestVersion();
-        if ($latestVersion) {
-            $latestVersionFormatted = $configuration->formatVersion($latestVersion) . ' (<comment>'.$latestVersion.'</comment>)';
-        } else {
-            $latestVersionFormatted = 0;
+        $versionsFormatted = array();
+        foreach (array('prev', 'current', 'next', 'latest') as $alias) {
+            $version = $configuration->resolveVersionAlias($alias);
+            if ($version === null) {
+                if ($alias == 'next') {
+                    $versionsFormatted[$alias] = 'Already at latest version';
+                } elseif ($alias == 'prev') {
+                    $versionsFormatted[$alias] = 'Already at first version';
+                }
+            } elseif ($version === '0') {
+                $versionsFormatted[$alias] = '<comment>0</comment>';
+            } else {
+                $versionsFormatted[$alias] = $configuration->formatVersion($version) . ' (<comment>' . $version . '</comment>)';
+            }
         }
 
         $executedMigrations = $configuration->getMigratedVersions();
@@ -86,8 +89,10 @@ EOT
             'Version Table Name'                => $configuration->getMigrationsTableName(),
             'Migrations Namespace'              => $configuration->getMigrationsNamespace(),
             'Migrations Directory'              => $configuration->getMigrationsDirectory(),
-            'Current Version'                   => $currentVersionFormatted,
-            'Latest Version'                    => $latestVersionFormatted,
+            'Previous Version'                  => $versionsFormatted['prev'],
+            'Current Version'                   => $versionsFormatted['current'],
+            'Next Version'                      => $versionsFormatted['next'],
+            'Latest Version'                    => $versionsFormatted['latest'],
             'Executed Migrations'               => count($executedMigrations),
             'Executed Unavailable Migrations'   => $numExecutedUnavailableMigrations > 0 ? '<error>'.$numExecutedUnavailableMigrations.'</error>' : 0,
             'Available Migrations'              => count($availableMigrations),

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
@@ -8,6 +8,78 @@ use Symfony\Component\Console\Tester\CommandTester;
 class MigrationStatusTest extends MigrationTestCase
 {
     /**
+     * Tests the display of the previous/current/next/latest versions.
+     */
+    public function testVersions()
+    {
+        $this->assertVersion('prev',    '123', 'Previous Version', 'FORMATTED (123)');
+        $this->assertVersion('current', '234', 'Current Version',  'FORMATTED (234)');
+        $this->assertVersion('next',    '345', 'Next Version',     'FORMATTED (345)');
+        $this->assertVersion('latest',  '456', 'Latest Version',   'FORMATTED (456)');
+
+        // Initial version is not formatted as date.
+        $this->assertVersion('prev',    '0',   'Previous Version', '0');
+
+        // The initial version has no previous version, and the latest has no next.
+        $this->assertVersion('prev',    null,  'Previous Version', 'Already at first version');
+        $this->assertVersion('next',    null,  'Next Version',     'Already at latest version');
+    }
+
+    /**
+     * Asserts that one version is displayed correctly.
+     * @param  string      $alias   "prev", "current", "next", "latest".
+     * @param  string|null $version The version corresponding to the $alias.
+     * @param  string      $label   The expected row label.
+     * @param  string      $output  The expected row value.
+     */
+    protected function assertVersion($alias, $version, $label, $output)
+    {
+        $command = $this
+            ->getMockBuilder('Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand')
+            ->setConstructorArgs(array('migrations:status'))
+            ->setMethods(
+                array(
+                    'getMigrationConfiguration',
+                )
+            )
+            ->getMock();
+
+        $configuration = $this->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->setConstructorArgs(array($this->getSqliteConnection()))
+            ->setMethods(array('resolveVersionAlias', 'formatVersion'))
+            ->getMock();
+
+        $configuration
+            ->expects($this->exactly(4))
+            ->method('resolveVersionAlias')
+            ->will($this->returnCallback(function($argAlias) use ($alias, $version) {
+                return $argAlias === $alias ? $version : '999';
+            }));
+
+        $configuration
+            ->expects($this->any())
+            ->method('formatVersion')
+            ->will($this->returnValue('FORMATTED'));
+
+        $configuration->setMigrationsNamespace('DoctrineMigrations');
+        $configuration->setMigrationsDirectory(sys_get_temp_dir());
+
+        $command
+            ->expects($this->once())
+            ->method('getMigrationConfiguration')
+            ->will($this->returnValue($configuration));
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(
+            array(),
+            array()
+        );
+
+        $textOutput = $commandTester->getDisplay();
+        $this->assertRegexp('/\s+>> ' . $label . ':\s+' . preg_quote($output) . '/m', $textOutput);
+    }
+
+    /**
      * Tests if the amount of new migrations remains valid.
      *
      * This test prevents an incorrect amount of new migrations when unavailable migrations were executed. When there
@@ -41,7 +113,7 @@ class MigrationStatusTest extends MigrationTestCase
             ->will($this->returnValue(array(1234,1235,1239,1240)));
 
         $configuration
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getCurrentVersion')
             ->will($this->returnValue(1239));
 


### PR DESCRIPTION
This is PR adds some extra info to migrations:status. Nothing essential, just a nice-to-have.

PR #159 added aliases for previous, next, current and latest versions. 

migrations:status already shows the version numbers corresponding to current and latest. This PR adds previous and next to the output.

    >> Previous Version:                        2015-01-19 10:08:54 (20150119100854)
    >> Current Version:                         2015-01-20 14:17:00 (20150120141700)
    >> Next Version:                            Already at latest version
    >> Latest Version:                          2015-01-20 14:17:00 (20150120141700)
