### PR TITLE
Simplify handling of --no-interaction and confirmation

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -436,8 +436,8 @@ class Configuration
     /**
      * Returns the version prior to the current version.
      *
-     * @return string|null  A version string, or null if the current version is
-     *                      the first.
+     * @return string|null A version string, or null if the current version is
+     *                     the first.
      */
     public function getPrevVersion()
     {
@@ -447,8 +447,8 @@ class Configuration
     /**
      * Returns the version following the current version.
      *
-     * @return string|null  A version string, or null if the current version is
-     *                      the latest.
+     * @return string|null A version string, or null if the current version is
+     *                     the latest.
      */
     public function getNextVersion()
     {
@@ -458,9 +458,9 @@ class Configuration
     /**
      * Returns the version with the specified offset to the specified version.
      *
-     * @return string|null  A version string, or null if the specified version
-     *                      is unknown or the specified delta is not within the
-     *                      list of available versions.
+     * @return string|null A version string, or null if the specified version
+     *                     is unknown or the specified delta is not within the
+     *                     list of available versions.
      */
     public function getRelativeVersion($version, $delta)
     {
@@ -471,6 +471,7 @@ class Configuration
             // Unknown version or delta out of bounds.
             return null;
         }
+
         return (string) $versions[$offset + $delta];
     }
 
@@ -486,10 +487,10 @@ class Configuration
      *
      * If an existing version number is specified, it is returned verbatimly.
      *
-     * @return  string|null  A version number, or null if the specified alias
-     *                       does not map to an existing version, e.g. if "next"
-     *                       is passed but the current version is already the
-     *                       latest.
+     * @return string|null A version number, or null if the specified alias
+     *                     does not map to an existing version, e.g. if "next"
+     *                     is passed but the current version is already the
+     *                     latest.
      */
     public function resolveVersionAlias($alias)
     {

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -135,7 +135,7 @@ class Migration
             return array();
         }
 
-        if ($dryRun === false) {
+        if (! $dryRun) {
             $this->outputWriter->write(sprintf('Migrating <info>%s</info> to <comment>%s</comment> from <comment>%s</comment>', $direction, $to, $from));
         } else {
             $this->outputWriter->write(sprintf('Executing dry run of migration <info>%s</info> to <comment>%s</comment> from <comment>%s</comment>', $direction, $to, $from));

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -82,14 +82,14 @@ EOT
             $path = is_bool($path) ? getcwd() : $path;
             $version->writeSqlFile($path, $direction);
         } else {
-            $noInteraction = $input->getOption('no-interaction') ? true : false;
-            if ($noInteraction === true) {
+            if ($input->getOption('no-interaction')) {
                 $confirmation = true;
             } else {
                 $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
             }
-            if ($confirmation === true) {
-                $version->execute($direction, $input->getOption('dry-run') ? true : false);
+
+            if ($confirmation) {
+                $version->execute($direction, (boolean) $input->getOption('dry-run'));
             } else {
                 $output->writeln('<error>Migration cancelled!</error>');
             }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -83,12 +83,12 @@ EOT
             $version->writeSqlFile($path, $direction);
         } else {
             if ($input->getOption('no-interaction')) {
-                $confirmation = true;
+                $execute = true;
             } else {
-                $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
+                $execute = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
             }
 
-            if ($confirmation) {
+            if ($execute) {
                 $version->execute($direction, (boolean) $input->getOption('dry-run'));
             } else {
                 $output->writeln('<error>Migration cancelled!</error>');

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -84,14 +84,14 @@ EOT
         } else {
             $noInteraction = $input->getOption('no-interaction') ? true : false;
             if ($noInteraction === true) {
-                $version->execute($direction, $input->getOption('dry-run') ? true : false);
+                $confirmation = true;
             } else {
                 $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)</question>', false);
-                if ($confirmation === true) {
-                    $version->execute($direction, $input->getOption('dry-run') ? true : false);
-                } else {
-                    $output->writeln('<error>Migration cancelled!</error>');
-                }
+            }
+            if ($confirmation === true) {
+                $version->execute($direction, $input->getOption('dry-run') ? true : false);
+            } else {
+                $output->writeln('<error>Migration cancelled!</error>');
             }
         }
     }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -123,7 +123,7 @@ EOT
             $path = is_bool($path) ? getcwd() : $path;
             $migration->writeSqlFile($path, $version);
         } else {
-            $dryRun = $input->getOption('dry-run') ? true : false;
+            $dryRun = (boolean) $input->getOption('dry-run');
 
             // warn the user if no dry run and interaction is on
             if (! $dryRun && ! $noInteraction) {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -100,6 +100,7 @@ EOT
                 default:
                     $output->writeln('<error>Unknown version: ' . $output->getFormatter()->escape($versionAlias) . '</error>');
             }
+
             return 1;
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -97,8 +97,7 @@ EOT
             $output->writeln('    <comment>>></comment> ' . $name . ': ' . str_repeat(' ', 50 - strlen($name)) . $value);
         }
 
-        $showVersions = $input->getOption('show-versions') ? true : false;
-        if ($showVersions === true) {
+        if ($input->getOption('show-versions')) {
             if ($migrations = $configuration->getMigrations()) {
                 $output->writeln("\n <info>==</info> Available Migration Versions\n");
                 $migratedVersions = $configuration->getMigratedVersions();

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/VersionCommand.php
@@ -85,7 +85,7 @@ EOT
     {
         $this->configuration = $this->getMigrationConfiguration($input, $output);
 
-        if ($input->getOption('add') === false && $input->getOption('delete') === false) {
+        if ( ! $input->getOption('add') && ! $input->getOption('delete')) {
             throw new \InvalidArgumentException('You must specify whether you want to --add or --delete the specified version.');
         }
 
@@ -95,7 +95,7 @@ EOT
             $this->markAllAvailableVersions($input);
         } else {
             $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to add, delete or synchronize migration versions from the version table that could result in data lost. Are you sure you wish to continue? (y/n)</question>', false);
-            if ($confirmation === true) {
+            if ($confirmation) {
                 $this->markAllAvailableVersions($input);
             } else {
                 $output->writeln('<error>Migration cancelled!</error>');

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/VersionCommand.php
@@ -89,7 +89,7 @@ EOT
             throw new \InvalidArgumentException('You must specify whether you want to --add or --delete the specified version.');
         }
 
-        $this->markMigrated = $input->getOption('add') ? true : false;
+        $this->markMigrated = (boolean) $input->getOption('add');
 
         if ($input->getOption('no-interaction')) {
             $this->markAllAvailableVersions($input);

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/VersionCommand.php
@@ -91,8 +91,7 @@ EOT
 
         $this->markMigrated = $input->getOption('add') ? true : false;
 
-        $noInteraction = $input->getOption('no-interaction') ? true : false;
-        if ($noInteraction === true) {
+        if ($input->getOption('no-interaction')) {
             $this->markAllAvailableVersions($input);
         } else {
             $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to add, delete or synchronize migration versions from the version table that could result in data lost. Are you sure you wish to continue? (y/n)</question>', false);

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -253,7 +253,7 @@ class Version
             $this->migration->$direction($toSchema);
             $this->addSql($fromSchema->getMigrateToSql($toSchema, $this->platform));
 
-            if ($dryRun === false) {
+            if (! $dryRun) {
                 if ($this->sql) {
                     foreach ($this->sql as $key => $query) {
                         if ( ! isset($this->params[$key])) {

--- a/phar-cli-stub.php
+++ b/phar-cli-stub.php
@@ -71,10 +71,10 @@ if ($helperSet->has('em')) {
 }
 
 $input = file_exists('migrations-input.php')
-       ? include 'migrations-input.php': null;
+       ? include 'migrations-input.php' : null;
 
 $output = file_exists('migrations-output.php')
-        ? include 'migrations-output.php': null;
+        ? include 'migrations-output.php' : null;
 
 $cli->run($input, $output);
 


### PR DESCRIPTION
If no interaction is set, pre-set confirmation to true, then only call execute from one place.

Reduces the number of places you have to update the code if you want to add more parameters to the execute method, e.g. --ignore-errors (https://github.com/doctrine/migrations/pull/188)