### PR TITLE
Add missing doctrine2 dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/dbal": "~2.0"
+        "doctrine/dbal": "~2.0",
+        "doctrine/orm": "~2.4"
     },
     "require-dev": {
         "symfony/console": "2.*",


### PR DESCRIPTION
lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
references
Doctrine\ORM\Tools\SchemaTool
which is included in doctrine/orm