### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "doctrine/dbal": "~2.0"
     },
     "require-dev": {
-        "symfony/console": "2.*",
-        "symfony/yaml": "2.*"
+        "symfony/console": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0"
     },
     "suggest": {
         "symfony/console": "to run the migration from the console"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
             "Doctrine\\DBAL\\Migrations": "lib"
         }
     },
+    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0