### PR TITLE
updated deprecated use of Yaml::parse

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
@@ -36,7 +36,7 @@ class YamlConfiguration extends AbstractFileConfiguration
      */
     protected function doLoad($file)
     {
-        $array = Yaml::parse($file);
+        $array = Yaml::parse(file_get_contents($file));
 
         if (isset($array['name'])) {
             $this->setName($array['name']);


### PR DESCRIPTION
Parsing a filename has been deprecated. The preffered method is to pass the file's contents to Yaml::parse