### PR TITLE
migrationsTableName should be case insensitive

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -118,7 +118,7 @@ EOT
         $currentPlatform = $configuration->getConnection()->getDatabasePlatform()->getName();
         $code = array();
         foreach ($sql as $query) {
-            if (strpos($query, $configuration->getMigrationsTableName()) !== false) {
+            if (stripos($query, $configuration->getMigrationsTableName()) !== false) {
                 continue;
             }
             $code[] = sprintf("\$this->addSql(%s);", var_export($query, true));


### PR DESCRIPTION
Oracle returns all table names UPPERCASE, so this check fails and migrationsTable is included to every migration.