### PR TITLE
Prefer configuration from options

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -43,6 +43,21 @@ abstract class AbstractCommand extends Command
      */
     private $configuration;
 
+    /**
+     * @var Configuration
+     */
+    private $migrationConfiguration;
+
+    /**
+     * @var OutputWriter
+     */
+    private $outputWriter;
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    private $connection;
+
     protected function configure()
     {
         $this->addOption('configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a migrations configuration file.');
@@ -73,52 +88,80 @@ abstract class AbstractCommand extends Command
      */
     protected function getMigrationConfiguration(InputInterface $input, OutputInterface $output)
     {
-        $outputWriter = new OutputWriter(function ($message) use ($output) {
-            return $output->writeln($message);
-        });
-
-        if ($input->getOption('db-configuration')) {
-            if ( ! file_exists($input->getOption('db-configuration'))) {
-                throw new \InvalidArgumentException("The specified connection file is not a valid file.");
+        if (!$this->migrationConfiguration) {
+            if ($input->getOption('configuration')) {
+                $info = pathinfo($input->getOption('configuration'));
+                $class = $info['extension'] === 'xml' ? 'Doctrine\DBAL\Migrations\Configuration\XmlConfiguration' : 'Doctrine\DBAL\Migrations\Configuration\YamlConfiguration';
+                $configuration = new $class($this->getConnection($input), $this->getOutputWriter($output));
+                $configuration->load($input->getOption('configuration'));
+            } elseif (file_exists('migrations.xml')) {
+                $configuration = new XmlConfiguration($this->getConnection($input), $this->getOutputWriter($output));
+                $configuration->load('migrations.xml');
+            } elseif (file_exists('migrations.yml')) {
+                $configuration = new YamlConfiguration($this->getConnection($input), $this->getOutputWriter($output));
+                $configuration->load('migrations.yml');
+            } elseif (file_exists('migrations.yaml')) {
+                $configuration = new YamlConfiguration($this->getConnection($input), $this->getOutputWriter($output));
+                $configuration->load('migrations.yaml');
+            } elseif ($this->configuration) {
+                $configuration = $this->configuration;
+            } else {
+                $configuration = new Configuration($this->getConnection($input), $this->getOutputWriter($output));
             }
-
-            $params = include $input->getOption('db-configuration');
-            if ( ! is_array($params)) {
-                throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
-            }
-            $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-        } elseif (file_exists('migrations-db.php')) {
-            $params = include 'migrations-db.php';
-            if ( ! is_array($params)) {
-                throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
-            }
-            $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-        } elseif ($this->getHelperSet()->has('connection')) {
-            $conn = $this->getHelper('connection')->getConnection();
-        } else {
-            throw new \InvalidArgumentException('You have to specify a --db-configuration file or pass a Database Connection as a dependency to the Migrations.');
+            $this->migrationConfiguration = $configuration;
         }
 
-        if ($input->getOption('configuration')) {
-            $info = pathinfo($input->getOption('configuration'));
-            $class = $info['extension'] === 'xml' ? 'Doctrine\DBAL\Migrations\Configuration\XmlConfiguration' : 'Doctrine\DBAL\Migrations\Configuration\YamlConfiguration';
-            $configuration = new $class($conn, $outputWriter);
-            $configuration->load($input->getOption('configuration'));
-        } elseif (file_exists('migrations.xml')) {
-            $configuration = new XmlConfiguration($conn, $outputWriter);
-            $configuration->load('migrations.xml');
-        } elseif (file_exists('migrations.yml')) {
-            $configuration = new YamlConfiguration($conn, $outputWriter);
-            $configuration->load('migrations.yml');
-        } elseif (file_exists('migrations.yaml')) {
-            $configuration = new YamlConfiguration($conn, $outputWriter);
-            $configuration->load('migrations.yaml');
-        } elseif ($this->configuration) {
-            $configuration = $this->configuration;
-        } else {
-            $configuration = new Configuration($conn, $outputWriter);
+        return $this->migrationConfiguration;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
+     * @return \Doctrine\DBAL\Migrations\OutputWriter
+     */
+    private function getOutputWriter(OutputInterface $output)
+    {
+        if (!$this->outputWriter) {
+            $this->outputWriter = new OutputWriter(function ($message) use ($output) {
+                return $output->writeln($message);
+            });
         }
 
-        return $configuration;
+        return $this->outputWriter;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
+     * @return \Doctrine\DBAL\Connection
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private function getConnection(InputInterface $input)
+    {
+        if (!$this->connection) {
+            if ($input->getOption('db-configuration')) {
+                if (!file_exists($input->getOption('db-configuration'))) {
+                    throw new \InvalidArgumentException("The specified connection file is not a valid file.");
+                }
+
+                $params = include $input->getOption('db-configuration');
+                if (!is_array($params)) {
+                    throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
+                }
+                $this->connection = \Doctrine\DBAL\DriverManager::getConnection($params);
+            } elseif (file_exists('migrations-db.php')) {
+                $params = include 'migrations-db.php';
+                if (!is_array($params)) {
+                    throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
+                }
+                $this->connection = \Doctrine\DBAL\DriverManager::getConnection($params);
+            } elseif ($this->getHelperSet()->has('connection')) {
+                $this->connection = $this->getHelper('connection')->getConnection();
+            } else {
+                throw new \InvalidArgumentException('You have to specify a --db-configuration file or pass a Database Connection as a dependency to the Migrations.');
+            }
+        }
+
+        return $this->connection;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -93,7 +93,7 @@ abstract class AbstractCommand extends Command
                 throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
             }
             $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-        } elseif ($this->getApplication()->getHelperSet()->has('connection')) {
+        } elseif ($this->getHelperSet()->has('connection')) {
             $conn = $this->getHelper('connection')->getConnection();
         } else {
             throw new \InvalidArgumentException('You have to specify a --db-configuration file or pass a Database Connection as a dependency to the Migrations.');

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -73,53 +73,52 @@ abstract class AbstractCommand extends Command
      */
     protected function getMigrationConfiguration(InputInterface $input, OutputInterface $output)
     {
-        if (! $this->configuration) {
-            $outputWriter = new OutputWriter(function ($message) use ($output) {
-                return $output->writeln($message);
-            });
+        $outputWriter = new OutputWriter(function ($message) use ($output) {
+            return $output->writeln($message);
+        });
 
-            if ($input->getOption('db-configuration')) {
-                if ( ! file_exists($input->getOption('db-configuration'))) {
-                    throw new \InvalidArgumentException("The specified connection file is not a valid file.");
-                }
-
-                $params = include $input->getOption('db-configuration');
-                if ( ! is_array($params)) {
-                    throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
-                }
-                $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-            } elseif (file_exists('migrations-db.php')) {
-                $params = include 'migrations-db.php';
-                if ( ! is_array($params)) {
-                    throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
-                }
-                $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
-            } elseif ($this->getApplication()->getHelperSet()->has('connection')) {
-                $conn = $this->getHelper('connection')->getConnection();
-            } else {
-                throw new \InvalidArgumentException('You have to specify a --db-configuration file or pass a Database Connection as a dependency to the Migrations.');
+        if ($input->getOption('db-configuration')) {
+            if ( ! file_exists($input->getOption('db-configuration'))) {
+                throw new \InvalidArgumentException("The specified connection file is not a valid file.");
             }
 
-            if ($input->getOption('configuration')) {
-                $info = pathinfo($input->getOption('configuration'));
-                $class = $info['extension'] === 'xml' ? 'Doctrine\DBAL\Migrations\Configuration\XmlConfiguration' : 'Doctrine\DBAL\Migrations\Configuration\YamlConfiguration';
-                $configuration = new $class($conn, $outputWriter);
-                $configuration->load($input->getOption('configuration'));
-            } elseif (file_exists('migrations.xml')) {
-                $configuration = new XmlConfiguration($conn, $outputWriter);
-                $configuration->load('migrations.xml');
-            } elseif (file_exists('migrations.yml')) {
-                $configuration = new YamlConfiguration($conn, $outputWriter);
-                $configuration->load('migrations.yml');
-            } elseif (file_exists('migrations.yaml')) {
-                $configuration = new YamlConfiguration($conn, $outputWriter);
-                $configuration->load('migrations.yaml');
-            } else {
-                $configuration = new Configuration($conn, $outputWriter);
+            $params = include $input->getOption('db-configuration');
+            if ( ! is_array($params)) {
+                throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
             }
-            $this->configuration = $configuration;
+            $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
+        } elseif (file_exists('migrations-db.php')) {
+            $params = include 'migrations-db.php';
+            if ( ! is_array($params)) {
+                throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
+            }
+            $conn = \Doctrine\DBAL\DriverManager::getConnection($params);
+        } elseif ($this->getApplication()->getHelperSet()->has('connection')) {
+            $conn = $this->getHelper('connection')->getConnection();
+        } else {
+            throw new \InvalidArgumentException('You have to specify a --db-configuration file or pass a Database Connection as a dependency to the Migrations.');
         }
 
-        return $this->configuration;
+        if ($input->getOption('configuration')) {
+            $info = pathinfo($input->getOption('configuration'));
+            $class = $info['extension'] === 'xml' ? 'Doctrine\DBAL\Migrations\Configuration\XmlConfiguration' : 'Doctrine\DBAL\Migrations\Configuration\YamlConfiguration';
+            $configuration = new $class($conn, $outputWriter);
+            $configuration->load($input->getOption('configuration'));
+        } elseif (file_exists('migrations.xml')) {
+            $configuration = new XmlConfiguration($conn, $outputWriter);
+            $configuration->load('migrations.xml');
+        } elseif (file_exists('migrations.yml')) {
+            $configuration = new YamlConfiguration($conn, $outputWriter);
+            $configuration->load('migrations.yml');
+        } elseif (file_exists('migrations.yaml')) {
+            $configuration = new YamlConfiguration($conn, $outputWriter);
+            $configuration->load('migrations.yaml');
+        } elseif ($this->configuration) {
+            $configuration = $this->configuration;
+        } else {
+            $configuration = new Configuration($conn, $outputWriter);
+        }
+
+        return $configuration;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -20,7 +20,7 @@ class AbstractCommandTest extends MigrationTestCase
     {
         $class = new \ReflectionClass('Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand');
         $method = $class->getMethod('getMigrationConfiguration');
-        $method->setAccessible('true');
+        $method->setAccessible(true);
 
         /** @var \Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand $command */
         $command = $this->getMockForAbstractClass(

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
+
+use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Symfony\Component\Console\Helper\HelperSet;
+
+class AbstractCommandTest extends MigrationTestCase
+{
+    /**
+     * Invoke invisible migration configuration getter
+     *
+     * @param mixed $input
+     * @param mixed $configuration
+     *
+     * @return \Doctrine\DBAL\Migrations\Configuration\Configuration
+     */
+    public function invokeMigrationConfigurationGetter($input, $configuration = null)
+    {
+        $class = new \ReflectionClass('Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand');
+        $method = $class->getMethod('getMigrationConfiguration');
+        $method->setAccessible('true');
+
+        /** @var \Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand $command */
+        $command = $this->getMockForAbstractClass(
+            'Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand',
+            ['command']
+        );
+
+        $command->setHelperSet(new HelperSet(['connection' => new ConnectionHelper($this->getSqliteConnection())]));
+        if (null !== $configuration) {
+            $command->setMigrationConfiguration($configuration);
+        }
+
+        $output = $this->getMockBuilder('Symfony\Component\Console\Output\Output')
+            ->setMethods(['doWrite', 'writeln'])
+            ->getMock();
+
+        $output->expects($this->any())
+            ->method('doWrite');
+
+        return $method->invokeArgs($command, [$input, $output]);
+    }
+
+
+    /**
+     * Test if the returned migration configuration is the injected one
+     */
+    public function testInjectedMigrationConfigurationIsBeingReturned()
+    {
+        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+            ->setConstructorArgs([array()])
+            ->setMethods(['getOption'])
+            ->getMock();
+
+        $input->expects($this->any())
+            ->method('getOption')
+            ->with($this->logicalOr($this->equalTo('db-configuration'), $this->equalTo('configuration')))
+            ->will($this->returnValue(null));
+
+        $configuration = $this
+            ->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->assertEquals($configuration, $this->invokeMigrationConfigurationGetter($input, $configuration));
+    }
+
+    /**
+     * Test if the migration configuration returns the connection from the helper set
+     */
+    public function testMigrationConfigurationReturnsConnectionFromHelperSet()
+    {
+        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+            ->setConstructorArgs([array()])
+            ->setMethods(['getOption'])
+            ->getMock();
+
+        $input->expects($this->any())
+            ->method('getOption')
+            ->with($this->logicalOr($this->equalTo('db-configuration'), $this->equalTo('configuration')))
+            ->will($this->returnValue(null));
+
+        $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $actualConfiguration);
+        $this->assertEquals($this->getSqliteConnection(), $actualConfiguration->getConnection());
+    }
+
+    /**
+     * Test if the migration configuration returns the connection from the input option
+     */
+    public function testMigrationConfigurationReturnsConnectionFromInputOption()
+    {
+        $content = <<<EOF
+<?php
+
+return array('driver' => 'pdo_sqlite', 'memory' => true);
+EOF;
+        $filename = \tempnam(\sys_get_temp_dir(), 'migrations_test');
+        file_put_contents($filename, $content);
+
+        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+            ->setConstructorArgs([array()])
+            ->setMethods(['getOption'])
+            ->getMock();
+
+        $input->expects($this->any())
+            ->method('getOption')
+            ->with($this->logicalOr($this->equalTo('db-configuration'), $this->equalTo('configuration')))
+            ->will($this->returnCallback(function ($name) use ($filename) {
+                if ('db-configuration' === $name) {
+                    return $filename;
+                }
+                return null;
+            }));
+
+        $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $actualConfiguration);
+        $this->assertEquals($this->getSqliteConnection(), $actualConfiguration->getConnection());
+
+        unlink($filename);
+    }
+
+    /**
+     * Test if the migration configuration returns values from the configuration file
+     */
+    public function testMigrationConfigurationReturnsConfigurationFileOption()
+    {
+        $content = <<<EOF
+name: "name"
+table_name: "migrations_table_name"
+migrations_namespace: "migrations_namespace"
+EOF;
+        $filename = \sys_get_temp_dir() . '/' . uniqid('migrations') . '.yml';
+        file_put_contents($filename, $content);
+
+        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+            ->setConstructorArgs([array()])
+            ->setMethods(['getOption'])
+            ->getMock();
+
+        $input->expects($this->any())
+            ->method('getOption')
+            ->with($this->logicalOr($this->equalTo('db-configuration'), $this->equalTo('configuration')))
+            ->will($this->returnCallback(function ($name) use ($filename) {
+                if ('configuration' === $name) {
+                    return $filename;
+                }
+                return null;
+            }));
+
+        $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
+
+        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\YamlConfiguration', $actualConfiguration);
+        $this->assertEquals('name', $actualConfiguration->getName());
+        $this->assertEquals('migrations_table_name', $actualConfiguration->getMigrationsTableName());
+        $this->assertEquals('migrations_namespace', $actualConfiguration->getMigrationsNamespace());
+
+        unlink($filename);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -25,22 +25,24 @@ class AbstractCommandTest extends MigrationTestCase
         /** @var \Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand $command */
         $command = $this->getMockForAbstractClass(
             'Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand',
-            ['command']
+            array('command')
         );
 
-        $command->setHelperSet(new HelperSet(['connection' => new ConnectionHelper($this->getSqliteConnection())]));
+        $command->setHelperSet(new HelperSet(array(
+            'connection' => new ConnectionHelper($this->getSqliteConnection())
+        )));
         if (null !== $configuration) {
             $command->setMigrationConfiguration($configuration);
         }
 
         $output = $this->getMockBuilder('Symfony\Component\Console\Output\Output')
-            ->setMethods(['doWrite', 'writeln'])
+            ->setMethods(array('doWrite', 'writeln'))
             ->getMock();
 
         $output->expects($this->any())
             ->method('doWrite');
 
-        return $method->invokeArgs($command, [$input, $output]);
+        return $method->invokeArgs($command, array($input, $output));
     }
 
 
@@ -50,8 +52,8 @@ class AbstractCommandTest extends MigrationTestCase
     public function testInjectedMigrationConfigurationIsBeingReturned()
     {
         $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
-            ->setConstructorArgs([array()])
-            ->setMethods(['getOption'])
+            ->setConstructorArgs(array(array()))
+            ->setMethods(array('getOption'))
             ->getMock();
 
         $input->expects($this->any())
@@ -73,8 +75,8 @@ class AbstractCommandTest extends MigrationTestCase
     public function testMigrationConfigurationReturnsConnectionFromHelperSet()
     {
         $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
-            ->setConstructorArgs([array()])
-            ->setMethods(['getOption'])
+            ->setConstructorArgs(array(array()))
+            ->setMethods(array('getOption'))
             ->getMock();
 
         $input->expects($this->any())
@@ -102,8 +104,8 @@ EOF;
         file_put_contents($filename, $content);
 
         $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
-            ->setConstructorArgs([array()])
-            ->setMethods(['getOption'])
+            ->setConstructorArgs(array(array()))
+            ->setMethods(array('getOption'))
             ->getMock();
 
         $input->expects($this->any())
@@ -138,8 +140,8 @@ EOF;
         file_put_contents($filename, $content);
 
         $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
-            ->setConstructorArgs([array()])
-            ->setMethods(['getOption'])
+            ->setConstructorArgs(array(array()))
+            ->setMethods(array('getOption'))
             ->getMock();
 
         $input->expects($this->any())

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/config.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/config.yml
@@ -1,0 +1,3 @@
+name: "name"
+table_name: "migrations_table_name"
+migrations_namespace: "migrations_namespace"

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/db-config.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/db-config.php
@@ -1,0 +1,3 @@
+<?php
+
+return array('driver' => 'pdo_sqlite', 'memory' => true);


### PR DESCRIPTION
The configuration options from the command line should override the configuration property of all commands. Otherwise the specified options will have no effect on the command.

The background is, that we define our migrations and entities in different packages with different name spaces and must migrate with individual configuration files for every subset of affected entities or tables.