### PR TITLE
Adds empty string return in AbstractMigration::getDescriopion

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -98,6 +98,7 @@ abstract class AbstractMigration
      */
     public function getDescription()
     {
+        return '';
     }
 
     /**


### PR DESCRIPTION
Just being strict on return type.
IDE (phpStorm) can use this to add return statement into method.