### PR TITLE
Don't Use Normalized Table Names in Schema Filters

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -92,10 +92,9 @@ EOT
 
         //Not using value from options, because filters can be set from config.yml
         if ( ! $isDbalOld && $filterExpr = $conn->getConfiguration()->getFilterSchemaAssetsExpression()) {
-            $tableNames = $toSchema->getTableNames();
-            foreach ($tableNames as $tableName) {
-                $tableName = substr($tableName, strpos($tableName, '.') + 1);
-                if ( ! preg_match($filterExpr, $tableName)) {
+            foreach ($toSchema->getTables() as $table) {
+                $tableName = $table->getName();
+                if ( ! preg_match($filterExpr, $this->resolveTableName($tableName))) {
                     $toSchema->dropTable($tableName);
                 }
             }
@@ -149,5 +148,21 @@ EOT
         }
 
         return $this->schemaProvider;
+    }
+
+    /**
+     * Resolve a table name from its fully qualified name. The `$name` argument
+     * comes from Doctrine\DBAL\Schema\Table#getName which can sometimes return
+     * a namespaced name with the form `{namespace}.{tableName}`. This extracts
+     * the table name from that.
+     *
+     * @param   string $name
+     * @return  string
+     */
+    private function resolveTableName($name)
+    {
+        $pos = strpos($name, '.');
+
+        return false === $pos ? $name : substr($name, $pos + 1);
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/CliTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/CliTest.php
@@ -149,6 +149,10 @@ class CliTest extends MigrationTestCase
         $this->assertNotContains('CREATE TABLE foo', $contents, 'should ignore the "foo" table due to schema asset filter');
     }
 
+    /**
+     * @see https://github.com/doctrine/migrations/issues/179
+     * @group regression
+     */
     public function testDiffCommandSchemaFilterAreCaseSensitive()
     {
         if ($this->isDbalOld()) {


### PR DESCRIPTION
Closes #179 

If a user enters an uppercased table name into a schema (via the schema API itself or entity metadata) that value is used in the SQL dumped by the diff command. The lowercased table names that are used internally in doctrine are an implementation detail of the library itself.

See the docblock for [`AbstractAsset#getFullQualifiedName`](https://github.com/doctrine/dbal/blob/41e718eab32980697c876d217ff4413cf86a4d2b/lib/Doctrine/DBAL/Schema/AbstractAsset.php#L117-L120).

This changes the filter expression stuff to use the table name entered by the user, rather than the normalized version. Also adds a test case for the schema filters in general and a test case to reproduce the bug.