### PR TITLE
Prefer the Injected Migrations Configuration Over Fallback Files

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -105,6 +105,8 @@ abstract class AbstractCommand extends Command
                 $class = $info['extension'] === 'xml' ? 'Doctrine\DBAL\Migrations\Configuration\XmlConfiguration' : 'Doctrine\DBAL\Migrations\Configuration\YamlConfiguration';
                 $configuration = new $class($this->getConnection($input), $this->getOutputWriter($output));
                 $configuration->load($input->getOption('configuration'));
+            } elseif ($this->configuration) {
+                $configuration = $this->configuration;
             } elseif (file_exists('migrations.xml')) {
                 $configuration = new XmlConfiguration($this->getConnection($input), $this->getOutputWriter($output));
                 $configuration->load('migrations.xml');
@@ -114,8 +116,6 @@ abstract class AbstractCommand extends Command
             } elseif (file_exists('migrations.yaml')) {
                 $configuration = new YamlConfiguration($this->getConnection($input), $this->getOutputWriter($output));
                 $configuration->load('migrations.yaml');
-            } elseif ($this->configuration) {
-                $configuration = $this->configuration;
             } else {
                 $configuration = new Configuration($this->getConnection($input), $this->getOutputWriter($output));
             }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migrations.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migrations.yml
@@ -1,0 +1,4 @@
+# tests the "fallback configuration"
+name: "name"
+table_name: "migrations_table_name"
+migrations_namespace: "migrations_namespace"


### PR DESCRIPTION
Closes #228 

The `configuration` command line option still trumps everything, but if a configuration was injected the commands will use that first.

This makes the most sense to me as a user: if the command line option is there, prefer that, otherwise use what was injected OR fallback to the `migrations.{xml,yml,yaml}` files if no config was injected.