### PR TITLE
Check for Both EntityManagerInterface and EntityManager

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/OrmSchemaProvider.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations\Provider;
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 
@@ -34,8 +35,15 @@ final class OrmSchemaProvider implements SchemaProvider
      */
     private $entityManager;
 
-    public function __construct(EntityManagerInterface $em)
+    public function __construct($em)
     {
+        if (!$this->isEntityManager($em)) {
+            throw new \InvalidArgumentException(sprintf(
+                '$em is not a valid Doctrine ORM Entity Manager, got "%s"',
+                is_object($em) ? get_class($em) : gettype($em)
+            ));
+        }
+
         $this->entityManager = $em;
     }
 
@@ -52,5 +60,21 @@ final class OrmSchemaProvider implements SchemaProvider
         $tool = new SchemaTool($this->entityManager);
 
         return $tool->getSchemaFromMetadata($metadata);
+    }
+
+    /**
+     * Doctrine's EntityManagerInterface was introduced in version 2.4, since this
+     * library allows those older version we need to be able to check for those 
+     * old ORM versions. Hence the helper method.
+     *
+     * No need to check to see if EntityManagerInterface exists first here, PHP
+     * doesn't care.
+     *
+     * @param   mixed $manager Hopefully an entity manager, but it may be anything
+     * @return  boolean
+     */
+    private static function isEntityManager($manager)
+    {
+        return $manager instanceof EntityManagerInterface || $manager instanceof EntityManager;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -58,13 +58,13 @@ class OrmSchemaProviderTest extends MigrationTestCase
 
     public static function notEntityManagers()
     {
-        return [
-            [new \stdclass],
-            [false],
-            [1],
-            ['oops'],
-            [1.0],
-        ];
+        return array(
+            array(new \stdclass),
+            array(false),
+            array(1),
+            array('oops'),
+            array(1.0),
+        );
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -56,6 +56,26 @@ class OrmSchemaProviderTest extends MigrationTestCase
         $this->ormProvider->createSchema();
     }
 
+    public static function notEntityManagers()
+    {
+        return [
+            [new \stdclass],
+            [false],
+            [1],
+            ['oops'],
+            [1.0],
+        ];
+    }
+
+    /**
+     * @dataProvider notEntityManagers
+     * @expectedException InvalidArgumentException
+     */
+    public function testPassingAnInvalidEntityManagerToConstructorCausesError($em)
+    {
+        new OrmSchemaProvider($em);
+    }
+
     protected function setUp()
     {
         $this->conn = $this->getSqliteConnection();


### PR DESCRIPTION
Prevents some fatal errors when folks are using an old ORM version.

See the comments here: https://github.com/doctrine/migrations/commit/e9ef6385d0b5ae7d8177fc9194cf9b59e58c460a