### PR TITLE
Don't Allow ORM Verions Older than 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "doctrine/orm": "2.*",
         "phpunit/phpunit": "~4.0"
     },
+    "conflict": {
+        "doctrine/orm": "<2.4"
+    },
     "suggest": {
         "symfony/console": "to run the migration from the console"
     },


### PR DESCRIPTION
Prevents some fatal errors in `OrmSchemaProvider`.

See https://github.com/doctrine/migrations/pull/236#issuecomment-98735529