### PR TITLE
Refactor the implicit call to "empty"

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -122,6 +122,9 @@ class Migration
      */
     public function migrate($to = null, $dryRun = false, $timeAllqueries=false)
     {
+        /**
+         * If no version to migrate to is given we default to the last available one.
+         */
         if ($to === null) {
             $to = $this->configuration->getLatestVersion();
         }
@@ -130,6 +133,10 @@ class Migration
         $from = (string) $from;
         $to = (string) $to;
 
+        /**
+         * Throw an error if we can't find the migration to migrate to in the registered
+         * migrations.
+         */
         $migrations = $this->configuration->getMigrations();
         if ( ! isset($migrations[$to]) && $to > 0) {
             throw MigrationException::unknownMigrationVersion($to);
@@ -138,7 +145,15 @@ class Migration
         $direction = $from > $to ? 'down' : 'up';
         $migrationsToExecute = $this->configuration->getMigrationsToExecute($direction, $to);
 
-        if ($from === $to && empty($migrationsToExecute) && $migrations) {
+        /**
+         * If
+         *  there are no migrations to execute
+         *  and there are migrations,
+         *  and the migration from and to are the same
+         * means we are already at the destination return an empty array()
+         * to signify that there is nothing left to do.
+         */
+        if ($from === $to && empty($migrationsToExecute) && !empty($migrations)) {
             return array();
         }
 
@@ -148,6 +163,9 @@ class Migration
             $this->outputWriter->write(sprintf('Executing dry run of migration <info>%s</info> to <comment>%s</comment> from <comment>%s</comment>', $direction, $to, $from));
         }
 
+        /**
+         * If there are no migrations to execute throw an exception.
+         */
         if (empty($migrationsToExecute)) {
             throw MigrationException::noMigrationsToExecute();
         }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -125,7 +125,7 @@ EOT
             $code[] = sprintf("\$this->addSql(%s);", var_export($query, true));
         }
 
-        if ($code) {
+        if (!empty($code)) {
             array_unshift(
                 $code,
                 sprintf(

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -97,7 +97,7 @@ EOT
             return 1;
         }
 
-        if ($executedUnavailableMigrations) {
+        if (!empty($executedUnavailableMigrations)) {
             $output->writeln(sprintf('<error>WARNING! You have %s previously executed migrations in the database that are not registered migrations.</error>', count($executedUnavailableMigrations)));
             foreach ($executedUnavailableMigrations as $executedUnavailableMigration) {
                 $output->writeln('    <comment>>></comment> ' . $configuration->getDateTime($executedUnavailableMigration) . ' (<comment>' . $executedUnavailableMigration . '</comment>)');
@@ -130,7 +130,7 @@ EOT
 
             $sql = $migration->migrate($version, $dryRun, $timeAllqueries);
 
-            if (! $sql) {
+            if (empty($sql)) {
                 $output->writeln('<comment>No migrations to execute.</comment>');
             }
         }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -111,7 +111,7 @@ EOT
                 $this->showVersions($migrations, $configuration, $output);
             }
 
-            if ($executedUnavailableMigrations) {
+            if (!empty($executedUnavailableMigrations)) {
                 $output->writeln("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
                 $this->showVersions($executedUnavailableMigrations, $configuration, $output);
             }

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -175,7 +175,7 @@ class Version
             }
         } else {
             $this->sql[] = $sql;
-            if ($params) {
+            if (!empty($params)) {
                 $this->params[count($this->sql) - 1] = $params;
                 $this->types[count($this->sql) - 1] = $types ?: array();
             }
@@ -263,7 +263,7 @@ class Version
             $this->addSql($fromSchema->getMigrateToSql($toSchema, $this->platform));
 
             if (! $dryRun) {
-                if ($this->sql) {
+                if (!empty($this->sql)) {
                     foreach ($this->sql as $key => $query) {
                         $queryStart = microtime(true);
                         if ( ! isset($this->params[$key])) {

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -26,6 +26,7 @@ class MigrationTest extends MigrationTestCase
 
     /**
      * @expectedException \Doctrine\DBAL\Migrations\MigrationException
+     * @expectedExceptionMessage Could not find any migrations to execute.
      */
     public function testMigrateWithNoMigrationsThrowsException()
     {


### PR DESCRIPTION
Explicitly calling empty instead of waiting for php to convert the array to a Boolean as a best practice.