### PR TITLE
getDateTime does not understand 24h format

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -188,7 +188,7 @@ class Configuration
     public function getDateTime($version)
     {
         $datetime = str_replace('Version', '', $version);
-        $datetime = \DateTime::createFromFormat('Ymdhis', $datetime);
+        $datetime = \DateTime::createFromFormat('YmdHis', $datetime);
 
         if ($datetime === false){
             return '';

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -197,6 +197,7 @@ class ConfigurationTest extends MigrationTestCase
             ['0000254Version', ''],
             ['0000254BaldlfqjdVersion', ''],
             ['20130101123545Version', '2013-01-01 12:35:45'],
+            ['20150202162811', '2015-02-02 04:28:11']
         ];
     }
 }


### PR DESCRIPTION
Hi guys, please review.

before: http://2ka.by/tmp/screenshots/2015-06-16-ccd7c77.png
after: http://2ka.by/tmp/screenshots/2015-06-16-67b7a06.png

fyi: vendor/doctrine/migrations/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php line 108 looks strange, nope? (see the screen no.2, `Previously Executed Unavailable Migration Versions`)