### PR TITLE
Version : use exec instead of executeQuery when no parameter is bound

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -268,7 +268,7 @@ class Version
                         $queryStart = microtime(true);
                         if ( ! isset($this->params[$key])) {
                             $this->outputWriter->write('     <comment>-></comment> ' . $query);
-                            $this->connection->executeQuery($query);
+                            $this->connection->exec($query);
                         } else {
                             $this->outputWriter->write(sprintf('    <comment>-</comment> %s (with parameters)', $query));
                             $this->connection->executeQuery($query, $this->params[$key], $this->types[$key]);


### PR DESCRIPTION
Is there a reason for using prepared statements instead of executing the raw query when there is no parameters bound ?
