### PR TITLE
Adding new configuration-option "organize-migrations"

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
@@ -44,6 +44,19 @@ class XmlConfiguration extends AbstractFileConfiguration
         if (isset($xml->{'migrations-namespace'})) {
             $this->setMigrationsNamespace((string) $xml->{'migrations-namespace'});
         }
+        if (isset($xml->{'organize-migrations'})) {
+            $versions_organization = $xml->{'organize-migrations'};
+            if (strcasecmp($versions_organization, static::VERSIONS_ORGANIZATION_BY_YEAR) === 0) {
+                $this->setMigrationsAreOrganizedByYear();
+            } else if (strcasecmp($versions_organization, static::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH) === 0) {
+                $this->setMigrationsAreOrganizedByYearAndMonth();
+            } else {
+                trigger_error(
+                    'Unknown ' . var_export($versions_organization, true) . ' for configuration "organize-migrations".',
+                    E_USER_NOTICE
+                );
+            }
+        }
         if (isset($xml->{'migrations-directory'})) {
             $migrationsDirectory = $this->getDirectoryRelativeToFile($file, (string) $xml->{'migrations-directory'});
             $this->setMigrationsDirectory($migrationsDirectory);

--- a/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
@@ -47,6 +47,19 @@ class YamlConfiguration extends AbstractFileConfiguration
         if (isset($array['migrations_namespace'])) {
             $this->setMigrationsNamespace($array['migrations_namespace']);
         }
+        if (isset($array['organize_migrations'])) {
+            $versions_organization = $array['organize_migrations'];
+            if (strcasecmp($versions_organization, static::VERSIONS_ORGANIZATION_BY_YEAR) == 0) {
+                $this->setMigrationsAreOrganizedByYear();
+            } else if (strcasecmp($versions_organization, static::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH) == 0) {
+                $this->setMigrationsAreOrganizedByYearAndMonth();
+            } else {
+                trigger_error(
+                    'Unknown ' . var_export($versions_organization, true) . ' for configuration "organize_migrations".',
+                    E_USER_NOTICE
+                );
+            }
+        }
         if (isset($array['migrations_directory'])) {
             $migrationsDirectory = $this->getDirectoryRelativeToFile($file, $array['migrations_directory']);
             $this->setMigrationsDirectory($migrationsDirectory);

--- a/lib/Doctrine/DBAL/Migrations/Finder/MigrationDeepFinderInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/MigrationDeepFinderInterface.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Finder;
+
+/**
+ * A MigrationDeepFinderInterface is a MigrationFinderInterface, which locates
+ * migrations not only in a directory itself, but in subdirectories of this directory,
+ * too.
+ */
+interface MigrationDeepFinderInterface extends MigrationFinderInterface
+{
+}

--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -25,7 +25,7 @@ namespace Doctrine\DBAL\Migrations\Finder;
  *
  * @since   1.0.0-alpha3
  */
-final class RecursiveRegexFinder extends AbstractFinder
+final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeepFinderInterface
 {
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/MigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationException.php
@@ -19,6 +19,8 @@
 
 namespace Doctrine\DBAL\Migrations;
 
+use \Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
+
 /**
  * Class for Migrations specific exceptions
  *
@@ -62,5 +64,19 @@ class MigrationException extends \Exception
     public static function configurationFileAlreadyLoaded()
     {
         return new self(sprintf('Migrations configuration file already loaded'), 8);
+    }
+
+    public static function configurationIncompatibleWithFinder(
+        $configurationParameterName,
+        MigrationFinderInterface $finder
+    ) {
+        return new self(
+            sprintf(
+                'Configuration-parameter "%s" cannot be used with finder of type "%s"',
+                $configurationParameterName,
+                get_class($finder)
+            ),
+            9
+        );
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -118,11 +118,30 @@ EOT
         $dir = $configuration->getMigrationsDirectory();
         $dir = $dir ? $dir : getcwd();
         $dir = rtrim($dir, '/');
-        $path = $dir . '/Version' . $version . '.php';
 
         if ( ! file_exists($dir)) {
             throw new \InvalidArgumentException(sprintf('Migrations directory "%s" does not exist.', $dir));
         }
+
+        if ($configuration->areMigrationsOrganizedByYear() ||
+            $configuration->areMigrationsOrganizedByYearAndMonth()
+        ) {
+            $versionYear = substr($version, 0, 4);
+            $dir = $dir . DIRECTORY_SEPARATOR . $versionYear;
+            if (!file_exists($dir)) {
+                mkdir($dir, 0755);
+            }
+
+            if ($configuration->areMigrationsOrganizedByYearAndMonth()) {
+                $versionMonth = substr($version, 4, 2);
+                $versionMonthShortName = strtolower(date('M', mktime(0, 0, 0, $versionMonth, 1, $versionYear)));
+                $dir .= DIRECTORY_SEPARATOR . $versionMonth . $versionMonthShortName;
+                if (!file_exists($dir)) {
+                    mkdir($dir, 0755);
+                }
+            }
+        }
+        $path = $dir . '/Version' . $version . '.php';
 
         file_put_contents($path, $code);
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/XmlConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/XmlConfigurationTest.php
@@ -2,15 +2,28 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Configuration;
 
+use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Configuration\XmlConfiguration;
+use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
 
 class XmlConfigurationTest extends AbstractConfigurationTest
 {
-    public function loadConfiguration()
-    {
-        $config = new XmlConfiguration($this->getSqliteConnection());
-        $config->load(__DIR__ . "/_files/config.xml");
+    /**
+     * @inheritdoc
+     */
+    public function loadConfiguration(
+        $configFileSuffix = '',
+        OutputWriter $outputWriter = null,
+        MigrationFinderInterface $migrationFinder = null
+    ) {
+        $configFile = 'config.xml';
+        if ('' !== $configFileSuffix) {
+            $configFile = 'config_' . $configFileSuffix . '.xml';
+        }
 
-        return $config;
+        $configFileSuffix = new XmlConfiguration($this->getSqliteConnection(), $outputWriter, $migrationFinder);
+        $configFileSuffix->load(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile);
+
+        return $configFileSuffix;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/YamlConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/YamlConfigurationTest.php
@@ -2,15 +2,28 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Configuration;
 
+use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Configuration\YamlConfiguration;
+use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
 
 class YamlConfigurationTest extends AbstractConfigurationTest
 {
-    public function loadConfiguration()
-    {
-        $config = new YamlConfiguration($this->getSqliteConnection());
-        $config->load(__DIR__ . "/_files/config.yml");
+    /**
+     * @inheritdoc
+     */
+    public function loadConfiguration(
+        $configFileSuffix = '',
+        OutputWriter $outputWriter = null,
+        MigrationFinderInterface $migrationFinder = null
+    ) {
+        $configFile = 'config.yml';
+        if ('' !== $configFileSuffix) {
+            $configFile = 'config_' . $configFileSuffix . '.yml';
+        }
 
-        return $config;
+        $configFileSuffix = new YamlConfiguration($this->getSqliteConnection(), $outputWriter, $migrationFinder);
+        $configFileSuffix->load(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile);
+
+        return $configFileSuffix;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <organize-migrations>YEaR</organize-migrations>
+
+</doctrine-migrations>

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year.yml
@@ -1,0 +1,2 @@
+---
+organize_migrations: "year"

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year_and_month.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year_and_month.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <organize-migrations>YEAR_and_mONth</organize-migrations>
+
+</doctrine-migrations>

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year_and_month.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year_and_month.yml
@@ -1,0 +1,2 @@
+---
+organize_migrations: "year_AND_MOnth"

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_invalid.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_invalid.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <organize-migrations>bar-foo</organize-migrations>
+
+</doctrine-migrations>

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_invalid.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_invalid.yml
@@ -1,0 +1,2 @@
+---
+organize_migrations: "foo-bar"

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/CliTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/CliTest.php
@@ -81,16 +81,16 @@ class CliTest extends MigrationTestCase
         $this->assertRegExp('/available migrations:\s+2/im', $output);
     }
 
-    public function testGenerateCommandAddsNewVersionOrganizedByYearAndMonth()
+    public function testGenerateCommandAddsNewMigrationOrganizedByYearAndMonth()
     {
         $this->assertVersionCount(0, 'Should start with no versions');
         $this->executeCommand('migrations:generate', 'config_organize_by_year_and_month.xml');
         $this->assertSuccessfulExit();
         $this->assertVersionCount(1, 'generate command should add one version');
 
-        $output = $this->executeCommand('migrations:status');
+        $output = $this->executeCommand('migrations:status', 'config_organize_by_year_and_month.xml');
         $this->assertSuccessfulExit();
-        $this->assertRegExp('/available migrations:\s+2/im', $output);
+        $this->assertRegExp('/available migrations:\s+1/im', $output);
     }
 
     public function testMigrationDiffWritesNewMigrationWithExpectedSql()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/CliTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/CliTest.php
@@ -30,9 +30,11 @@ use Doctrine\ORM\Tools\Setup as OrmSetup;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Migrations\MigrationsVersion;
+use Doctrine\DBAL\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\DBAL\Migrations\Provider\SchemaProviderInterface;
 use Doctrine\DBAL\Migrations\Provider\StubSchemaProvider;
 use Doctrine\DBAL\Migrations\Tools\Console\Command as MigrationCommands;
+use Doctrine\DBAL\Migrations\Tests\Helper;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Symfony\Component\Console\Output\StreamOutput;
 
@@ -58,7 +60,7 @@ class CliTest extends MigrationTestCase
         $output = $this->executeCommand('migrations:latest');
         $this->assertContains('20150426000000', $output);
 
-        $this->executeCommand('migrations:migrate', array('--no-interaction'));
+        $this->executeCommand('migrations:migrate', 'config.yml', array('--no-interaction'));
         $this->assertSuccessfulExit();
 
         $output = $this->executeCommand('migrations:status');
@@ -79,6 +81,18 @@ class CliTest extends MigrationTestCase
         $this->assertRegExp('/available migrations:\s+2/im', $output);
     }
 
+    public function testGenerateCommandAddsNewVersionOrganizedByYearAndMonth()
+    {
+        $this->assertVersionCount(0, 'Should start with no versions');
+        $this->executeCommand('migrations:generate', 'config_organize_by_year_and_month.xml');
+        $this->assertSuccessfulExit();
+        $this->assertVersionCount(1, 'generate command should add one version');
+
+        $output = $this->executeCommand('migrations:status');
+        $this->assertSuccessfulExit();
+        $this->assertRegExp('/available migrations:\s+2/im', $output);
+    }
+
     public function testMigrationDiffWritesNewMigrationWithExpectedSql()
     {
         $this->withDiffCommand(new StubSchemaProvider($this->getSchema()));
@@ -91,11 +105,10 @@ class CliTest extends MigrationTestCase
         $this->assertSuccessfulExit();
         $this->assertRegExp('/available migrations:\s+2/im', $output);
 
-        $versions = $this->globVersions();
-        $contents = file_get_contents($versions[0]);
+        $versionClassContents = $this->getFileContentsForLatestVersion();
 
-        $this->assertContains('CREATE TABLE bar', $contents);
-        $this->assertContains('DROP TABLE bar', $contents);
+        $this->assertContains('CREATE TABLE bar', $versionClassContents);
+        $this->assertContains('DROP TABLE bar', $versionClassContents);
     }
 
     public function testMigrationDiffWithEntityManagerGeneratesMigrationFromEntities()
@@ -117,11 +130,9 @@ class CliTest extends MigrationTestCase
         $this->assertSuccessfulExit();
         $this->assertRegExp('/available migrations:\s+2/im', $output);
 
-        $versions = $this->globVersions();
-        $contents = file_get_contents($versions[0]);
-
-        $this->assertContains('CREATE TABLE sample_entity', $contents);
-        $this->assertContains('DROP TABLE sample_entity', $contents);
+        $versionClassContents = $this->getFileContentsForLatestVersion();
+        $this->assertContains('CREATE TABLE sample_entity', $versionClassContents);
+        $this->assertContains('DROP TABLE sample_entity', $versionClassContents);
     }
 
     public function testDiffCommandWithSchemaFilterOnlyWorksWithTablesThatMatchFilter()
@@ -141,12 +152,14 @@ class CliTest extends MigrationTestCase
         $this->assertSuccessfulExit();
         $this->assertVersionCount(1, 'diff command should add one version');
 
-        $versions = $this->globVersions();
-        $contents = file_get_contents($versions[0]);
-
-        $this->assertContains('CREATE TABLE bar', $contents);
-        $this->assertContains('DROP TABLE bar', $contents);
-        $this->assertNotContains('CREATE TABLE foo', $contents, 'should ignore the "foo" table due to schema asset filter');
+        $versionClassContents = $this->getFileContentsForLatestVersion();
+        $this->assertContains('CREATE TABLE bar', $versionClassContents);
+        $this->assertContains('DROP TABLE bar', $versionClassContents);
+        $this->assertNotContains(
+            'CREATE TABLE foo',
+            $versionClassContents,
+            'should ignore the "foo" table due to schema asset filter'
+        );
     }
 
     /**
@@ -175,21 +188,21 @@ class CliTest extends MigrationTestCase
         $this->assertSuccessfulExit();
         $this->assertVersionCount(1, 'diff command should add one version');
 
-        $versions = $this->globVersions();
-        $contents = file_get_contents($versions[0]);
-
-        $this->assertContains('CREATE TABLE FOO', $contents);
-        $this->assertContains('DROP TABLE FOO', $contents);
+        $versionClassContents = $this->getFileContentsForLatestVersion();
+        $this->assertContains('CREATE TABLE FOO', $versionClassContents);
+        $this->assertContains('DROP TABLE FOO', $versionClassContents);
     }
 
     protected function setUp()
     {
-        if (file_exists(__DIR__.'/_files/migrations.db')) {
-            @unlink(__DIR__.'/_files/migrations.db');
+        $migrationsDbFilePath =
+            __DIR__ . DIRECTORY_SEPARATOR . '_files ' . DIRECTORY_SEPARATOR . 'migrations.db';
+        if (file_exists($migrationsDbFilePath)) {
+            @unlink($migrationsDbFilePath);
         }
-        foreach ($this->globVersions() as $file) {
-            @unlink($file);
-        }
+        Helper::deleteDir(
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'migrations'
+        );
 
         $this->conn = $this->getSqliteConnection();
         $this->application = new Application('Doctrine Migrations Test', MigrationsVersion::VERSION());
@@ -214,12 +227,15 @@ class CliTest extends MigrationTestCase
         $this->application->add(new MigrationCommands\DiffCommand($provider));
     }
 
-    protected function executeCommand($commandName, array $args = array())
+    protected function executeCommand($commandName, $configFile = 'config.yml', array $args = array())
     {
-        $input = new ArrayInput(array_merge(array(
-            'command'               => $commandName,
-            '--configuration'       => __DIR__.'/_files/config.yml',
-        ), $args));
+        $input = new ArrayInput(array_merge(
+            array(
+                'command'         => $commandName,
+                '--configuration' => __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile,
+            ),
+            $args
+        ));
         $output = $this->getOutputStream();
 
         $this->lastExit = $this->application->run($input, $output);
@@ -234,12 +250,7 @@ class CliTest extends MigrationTestCase
 
     protected function assertVersionCount($count, $msg='')
     {
-        $this->assertCount($count, $this->globVersions(), $msg);
-    }
-
-    protected function globVersions()
-    {
-        return glob(__DIR__.'/_files/migrations/Version*.php');
+        $this->assertCount($count, $this->findMigrations(), $msg);
     }
 
     protected function getSchema()
@@ -263,6 +274,38 @@ class CliTest extends MigrationTestCase
     protected function isDbalOld()
     {
         return DbalVersion::compare('2.2.0') > 0;
+    }
+
+    /**
+     * @param string $namespace
+     * @return array|\string[]
+     */
+    private function findMigrations($namespace = 'TestMigrations')
+    {
+        $finder = new RecursiveRegexFinder();
+
+        return $finder->findMigrations(
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'migrations',
+            $namespace
+        );
+    }
+
+    /**
+     * @return string file content for latest version
+     */
+    private function getFileContentsForLatestVersion()
+    {
+        $versions = $this->findMigrations();
+        $this->assertCount(
+            1,
+            $versions,
+            'This method is designed to work for one existing version, you have ' . count($versions) . ' versions'
+        );
+
+        $versionClassName = reset($versions);
+        $versionClassReflected = new \ReflectionClass($versionClassName);
+
+        return file_get_contents($versionClassReflected->getFileName());
     }
 }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/_files/config_organize_by_year_and_month.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/_files/config_organize_by_year_and_month.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <name>some-name</name>
+    <migrations-namespace>TestMigrationsVersionsOrganized</migrations-namespace>
+    <table name="migrations_table_name" />
+    <migrations-directory>migrations</migrations-directory>
+    <organize-migrations>year_and_month</organize-migrations>
+
+</doctrine-migrations>

--- a/tests/Doctrine/DBAL/Migrations/Tests/Helper.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Helper.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests;
+
+class Helper
+{
+
+    /**
+     * Delete a directory.
+     *
+     * @see http://stackoverflow.com/a/8688278/1645517
+     *
+     * @param string $path
+     * @return bool
+     */
+    public static function deleteDir($path)
+    {
+        if ('' === $path) {
+            return false;
+        }
+        $class_func = [__CLASS__, __FUNCTION__];
+
+        return is_file($path) ?
+            @unlink($path) :
+            array_map($class_func, glob($path . '/*')) === @rmdir($path);
+    }
+}


### PR DESCRIPTION
This PR introduces an new configuration-option "organize-migrations", which can be set to "year" or "year_and_month". If set, the migration-classes (files) will be in appropriate sub-directories relative to "migrations-directory". For example, if you set "organize-migrations" to "year" in your doctrine-migration configuration, and generate a new migration, the new file will be placed in "migrations-directory"/2015/ (if the actual year is 2015).

This change is use-case-driven. When using doctrine-migration, having every version (98 by now) in the "migrations-directory" became ugly.