### PR TITLE
Automaticaly add bin into composer.json

### DIFF
--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -17,13 +17,13 @@
  * <http://www.doctrine-project.org>.
  */
 
-$autoloader = __DIR__ . '/../vendor/autoload.php';
+$autoloadFiles = array(__DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php');
 
-if ( ! file_exists($autoloader)) {
-    if (extension_loaded('phar') && ($uri = Phar::running())) {
-        echo 'The phar has been builded without the depedencies' . PHP_EOL;
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
     }
-    die('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
 }
 
 require $autoloader;

--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -26,8 +26,6 @@ foreach ($autoloadFiles as $autoloadFile) {
     }
 }
 
-require $autoloader;
-
 // Support for using the Doctrine ORM convention of providing a `cli-config.php` file.
 $configFile = getcwd() . DIRECTORY_SEPARATOR . 'cli-config.php';
 

--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,9 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
-    }
+    },
+    "bin": [
+        "bin/doctrine-migrations",
+        "bin/doctrine-migrations.php"
+    ]
 }


### PR DESCRIPTION
Changed composer bin section to automaticaly add `doctrine-migration` and `doctrine-migration.php` files into `bin` repository.