### PR TITLE
Ability to set configuration via ConfigurationHelper in HelperSet

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -100,7 +100,11 @@ abstract class AbstractCommand extends Command
     protected function getMigrationConfiguration(InputInterface $input, OutputInterface $output)
     {
         if (!$this->migrationConfiguration) {
-            $configHelper = new ConfigurationHelper($this->getConnection($input), $this->configuration);
+            if ($this->getHelperSet()->has('configuration')) {
+                $configHelper = $this->getHelperSet()->get('configuration');
+            } else {
+                $configHelper = new ConfigurationHelper($this->getConnection($input), $this->configuration);
+            }
             $this->migrationConfiguration = $configHelper->getMigrationConfig($input, $this->getOutputWriter($output));
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -23,13 +23,14 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Helper\Helper;
 
 /**
  * Class ConfigurationHelper
  * @package Doctrine\DBAL\Migrations\Tools\Console\Helper
  * @internal
  */
-final class ConfigurationHelper
+class ConfigurationHelper extends Helper
 {
 
     /**
@@ -103,5 +104,13 @@ final class ConfigurationHelper
         $configuration->load($config);
 
         return $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'connection';
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -111,6 +111,6 @@ class ConfigurationHelper extends Helper
      */
     public function getName()
     {
-        return 'connection';
+        return 'configuration';
     }
 }


### PR DESCRIPTION
Added ability to set configuration via ConfigurationHelper in HelperSet.
I.e. from cli-config.php as such: 

```
$configFile = '/settings/config.yml';
$configuration = new \Doctrine\DBAL\Migrations\Configuration\YamlConfiguration($dbConnection);
$configuration->load($configFile);
$configHelper = new \Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper($dbConnection, $configuration);
$helperSet->set($configHelper, 'configuration');
```

The same idea (but for connection) can be seen here: http://davidhavl.com/devnotes/2015/07/setting-up-standalone-doctrine-migrations/