### PR TITLE
typo

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -269,7 +269,7 @@ class Configuration
     }
 
     /**
-     * set the implementation of the migration finder.
+     * Set the implementation of the migration finder.
      *
      * @param   $finder The new migration finder
      * @return  void


### PR DESCRIPTION
Tests fail due to missing xdebug in hhvm. Not related to the PR.