### PR TITLE
Avoid uploading code coverage to Scrutinizer for HHVM and PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 5.6
   - 7.0
   - hhvm
- 
+
 matrix:
   allow_failures:
     - php: 7.0
@@ -38,5 +38,4 @@ before_install:
 
 after_script:
   - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php vendor/bin/coveralls -v ; fi
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
+  - if [[ $TRAVIS_PHP_VERSION != '7.0' ]] && [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi


### PR DESCRIPTION
PHP 7 and HHVM are not generating the code coverage data. Submitting to Scrutinizer in such case would notify it that there is no data, which would cancel the build in case it happens before another job succeeds and uploads the coverage.

this will avoid having all builds being cancelled on Scrutinizer.