### PR TITLE
Improve the Travis configuration by persisting the composer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
   - 5.6
   - 7.0
   - hhvm
- 
+
 matrix:
   allow_failures:
     - php: 7.0
@@ -17,14 +17,18 @@ matrix:
     - php: 5.4
       env: deps=low
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 env:
   global:
     - deps=no
     - secure: "TaQTGgMHcaejJfKyuHeT7YAc6ysT+xT6j6SEvSKfjIPkroJE/ZXDRdMevTIlkmPz7InLWmWksZ8mfb3ZlFtOYF9H5N88XTuSMCf3Ce+FY8yQNAxLimtpN5qXQ3jLuDLhsG2eI8r/9bIK6Amx9g4GRVeDOvCwJ3lfiaipMRPNKZY="
 
 install:
-  - if [ "$deps" = "no" ]; then composer $flag install; fi;
-  - if [ "$deps" = "low" ]; then composer $flag --prefer-lowest --prefer-stable update; fi;
+  - if [ "$deps" = "no" ]; then composer install; fi;
+  - if [ "$deps" = "low" ]; then composer --prefer-lowest --prefer-stable update; fi;
 
 script:
   - mkdir -p build/logs
@@ -34,7 +38,6 @@ before_install:
   - composer self-update
   - composer config --quiet github-oauth.github.com $GITHUB_TOKEN
   - if [[ ! $GITHUB_TOKEN ]]; then echo "no github token"; fi
-  - if [[ ! $GITHUB_TOKEN ]]; then flag=--prefer-source; fi
 
 after_script:
   - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php vendor/bin/coveralls -v ; fi


### PR DESCRIPTION
This keeps using dists when the github token is not available, relying on the fact that dists will already be cached in most cases (because of builds for the master branch) and so would still be usable, and that Composer will fallback to source install automatically in case the dist downloading fails.