### PR TITLE
Add a way to avoid reading the existing schema before each migration

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/SqlMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/SqlMigration.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+*/
+
+namespace Doctrine\DBAL\Migrations;
+
+/**
+ * Marker interface implemented by migrations which provide SQL queries rather than using the Schema
+ *
+ * When the migration implements this interface, the runner will pass an empty Schema object to the migration
+ * instead of reading the current state of the database, and it will forbid making changes on the Schema itself.
+ * This improves performance when the migration does not rely on the schema
+ */
+interface SqlMigration
+{
+}

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -109,7 +109,7 @@ EOT
         }
 
         $version = date('YmdHis');
-        $path = $this->generateMigration($configuration, $input, $version, $up, $down);
+        $path = $this->generateMigration($configuration, $input, $version, $up, $down, true);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
     }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -42,12 +42,13 @@ class GenerateCommand extends AbstractCommand
 namespace <namespace>;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\SqlMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version<version> extends AbstractMigration
+class Version<version> extends AbstractMigration<interfaces>
 {
     /**
      * @param Schema $schema
@@ -99,19 +100,21 @@ EOT
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
     }
 
-    protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
+    protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null, $isSqlMigration = false)
     {
         $placeHolders = [
             '<namespace>',
             '<version>',
             '<up>',
             '<down>',
+            '<interfaces>',
         ];
         $replacements = [
             $configuration->getMigrationsNamespace(),
             $version,
             $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
-            $down ? "        " . implode("\n        ", explode("\n", $down)) : null
+            $down ? "        " . implode("\n        ", explode("\n", $down)) : null,
+            $isSqlMigration ? ' implements SqlMigration' : null,
         ];
         $code = str_replace($placeHolders, $replacements, self::$_template);
         $code = preg_replace('/^ +$/m', '', $code);

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Migrations;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Class which wraps a migration version and allows execution of the
@@ -242,11 +243,17 @@ class Version
             $this->connection->beginTransaction();
         }
 
+        $isSqlMigration = $this->migration instanceof SqlMigration;
+
         try {
             $migrationStart = microtime(true);
 
             $this->state = self::STATE_PRE;
-            $fromSchema = $this->sm->createSchema();
+            if ($isSqlMigration) {
+                $fromSchema = new Schema();
+            } else {
+                $fromSchema = $this->sm->createSchema();
+            }
             $this->migration->{'pre' . ucfirst($direction)}($fromSchema);
 
             if ($direction === 'up') {
@@ -259,7 +266,17 @@ class Version
 
             $toSchema = clone $fromSchema;
             $this->migration->$direction($toSchema);
-            $this->addSql($fromSchema->getMigrateToSql($toSchema, $this->platform));
+
+            if ($isSqlMigration) {
+                $tables = $toSchema->getTables();
+                $sequences = $toSchema->getSequences();
+
+                if (! empty($tables) || ! empty($sequences)) {
+                    throw new \LogicException('Migrations implementing SqlMigration are not allowed to perform changes on the Schema object but should add SQL queries directly.');
+                }
+            } else {
+                $this->addSql($fromSchema->getMigrateToSql($toSchema, $this->platform));
+            }
 
             if (! $dryRun) {
                 if (!empty($this->sql)) {


### PR DESCRIPTION
Most migrations don't actually perform changes on the Schema object but rather add SQL queries directly in the migration, because it is much more powerful (it is the only way to migrate data for instance, as this must generally happen in the middle of schema changes) and because the
diff commands generates migrations this way.
For such migrations, the Schema object will never be altered, but the migration tool will still need to read it at the beginning of each migration to pass it to the Migration (which does not care about it). To
improve performance, migrations can now implement an optional marker interface. In such cases, the migration will receive an empty Schema object and will not be allowed to perform changes on it. This avoids the need to read the database schema all the time for nothing.

To prove the performance improvement, look at these Blackfire profiles. They are profiling the execution of ``app/console doctrine:migrations:migrate -n`` on my work project. The project currently has 55 migrations going from an empty database to the current schema (for as much as it matters, this is running on the PostgreSQL platform, but similar results would be visible with other platforms).

- before the change (running with the librart at 1c7d88ae519361761fad42c03707ca8e8e37cd53): https://blackfire.io/profiles/c5b7813b-305d-4b8f-b1fa-ea63ad013adc/graph
- after the change of this PR (and implementing the marker interface on all 55 migration classes): https://blackfire.io/profiles/ab773a44-1e02-4873-9939-8021c6c253de/graph
- comparison between them: https://blackfire.io/profiles/compare/efe08c00-7a85-4ddc-a7b3-f62f8a08426d/graph

note how we are spending 72% of the time loading schemas from the DB and 22% of the time comparing them to find no changes. These nodes account for 94% of the runtime for something we don't need at all.

TODOs:

- [x] change the DiffCommand to implement the marker interface by default as these migrations don't rely on the Schema object (the GenerateCommand will not add it IMO as we don't know how the code in them will look like)
- [ ] Settle on the name of the interface in case someone has a better name
- [ ] Write some tests for this behavior
- [ ] Write some doc about this feature