### PR TITLE
Switch unexisting <warning> tag to <comment>

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -112,7 +112,7 @@ abstract class AbstractMigration
         if ($condition) {
             $message = $message?: 'Unknown Reason';
             $this->outputWriter->write(sprintf(
-                '    <warning>Warning during %s: %s</warning>',
+                '    <comment>Warning during %s: %s</comment>',
                 $this->version->getExecutionState(),
                 $message
             ));

--- a/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
@@ -41,14 +41,14 @@ class AbstractMigrationTest extends MigrationTestCase
     public function testWarnIfOutputMessage()
     {
         $this->migration->warnIf(true, 'Warning was thrown');
-        $this->assertContains('<warning>Warning during No State: Warning was thrown</warning>'
+        $this->assertContains('Warning during No State: Warning was thrown'
             , $this->getOutputStreamContent($this->output));
     }
 
     public function testWarnIfAddDefaultMessage()
     {
         $this->migration->warnIf(true);
-        $this->assertContains('<warning>Warning during No State: Unknown Reason</warning>'
+        $this->assertContains('Warning during No State: Unknown Reason'
             , $this->getOutputStreamContent($this->output));
     }
 


### PR DESCRIPTION
It's outputting the tag as such, switching to <comment> turns it to yellow.