### PR TITLE
Fix: Version should probably be 1.0.0

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/MigrationsVersion.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationsVersion.php
@@ -21,7 +21,7 @@ namespace Doctrine\DBAL\Migrations;
 
 class MigrationsVersion
 {
-    private static $version = 'v1.0.0-alpha3';
+    private static $version = 'v1.0.0';
 
     public static function VERSION() {
         $gitversion = '@git-version@';


### PR DESCRIPTION
This PR

* [x] fixes a thing where the version should be `v1.0.0` instead of `v1.0.0-alpha3`

:information_desk_person: I heard we're stable now, aren't we`