### PR TITLE
Fix: Avoid FQCN

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
@@ -164,13 +165,13 @@ abstract class AbstractCommand extends Command
                 if (!is_array($params)) {
                     throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
                 }
-                $this->connection = \Doctrine\DBAL\DriverManager::getConnection($params);
+                $this->connection = DriverManager::getConnection($params);
             } elseif (file_exists('migrations-db.php')) {
                 $params = include 'migrations-db.php';
                 if (!is_array($params)) {
                     throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
                 }
-                $this->connection = \Doctrine\DBAL\DriverManager::getConnection($params);
+                $this->connection = DriverManager::getConnection($params);
             } elseif ($this->getHelperSet()->has('connection')) {
                 $this->connection = $this->getHelper('connection')->getConnection();
             } elseif ($this->configuration) {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 
+use Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -86,7 +87,7 @@ EOT
             'Name'                              => $configuration->getName() ? $configuration->getName() : 'Doctrine Database Migrations',
             'Database Driver'                   => $configuration->getConnection()->getDriver()->getName(),
             'Database Name'                     => $configuration->getConnection()->getDatabase(),
-            'Configuration Source'              => $configuration instanceof \Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration ? $configuration->getFile() : 'manually configured',
+            'Configuration Source'              => $configuration instanceof AbstractFileConfiguration ? $configuration->getFile() : 'manually configured',
             'Version Table Name'                => $configuration->getMigrationsTableName(),
             'Migrations Namespace'              => $configuration->getMigrationsNamespace(),
             'Migrations Directory'              => $configuration->getMigrationsDirectory(),


### PR DESCRIPTION
This PR

* [x] avoids fully-qualified class names