### PR TITLE
Fix: Type-hint against OutputInterface

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -118,7 +118,7 @@ EOT
         }
     }
 
-    private function showVersions($migrations, Configuration $configuration, $output)
+    private function showVersions($migrations, Configuration $configuration, OutputInterface $output)
     {
         $migratedVersions = $configuration->getMigratedVersions();
 


### PR DESCRIPTION
This PR

* [x] type-hints against `OutputInterface` as the private method `showVersions()` is always invoked with an instance of `OutputInterface`