### PR TITLE
Enhancement: Allow to set OutputWriter

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -204,6 +204,16 @@ class Configuration
     }
 
     /**
+     * Sets the output writer.
+     *
+     * @param OutputWriter $outputWriter
+     */
+    public function setOutputWriter(OutputWriter $outputWriter)
+    {
+        $this->outputWriter = $outputWriter;
+    }
+
+    /**
      * Returns the OutputWriter instance
      *
      * @return OutputWriter $outputWriter  The OutputWriter instance

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -20,6 +20,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($outputWriter, $configuration->getOutputWriter());
     }
 
+    public function testOutputWriterIsCreatedIfNotInjected()
+    {
+        $configuration = new Configuration($this->getConnectionMock());
+
+        $this->assertInstanceOf('Doctrine\DBAL\Migrations\OutputWriter', $configuration->getOutputWriter());
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Connection
      */

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Configuration;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\OutputWriter;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructorSetsOutputWriter()
+    {
+        $outputWriter = $this->getOutputWriterMock();
+
+        $configuration = new Configuration(
+            $this->getConnectionMock(),
+            $outputWriter
+        );
+
+        $this->assertSame($outputWriter, $configuration->getOutputWriter());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Connection
+     */
+    private function getConnectionMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|OutputWriter
+     */
+    private function getOutputWriterMock()
+    {
+        return $this->getMockBuilder('Doctrine\DBAL\Migrations\OutputWriter')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -27,6 +27,16 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Doctrine\DBAL\Migrations\OutputWriter', $configuration->getOutputWriter());
     }
 
+    public function testOutputWriterCanBeSet()
+    {
+        $outputWriter = $this->getOutputWriterMock();
+
+        $configuration = new Configuration($this->getConnectionMock());
+        $configuration->setOutputWriter($outputWriter);
+
+        $this->assertSame($outputWriter, $configuration->getOutputWriter());
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Connection
      */


### PR DESCRIPTION
This PR

* [x] asserts that an instance of `OutputWriter` can be injected via constructor
* [x] asserts that an instance of `OutputWriter` is created otherwise
* [x] asserts that an instance of `OutputWriter` can be injected via mutator

### Use Case

When fetching a migration configuration from a container, you don't have an `OutputWriter` yet, you don't even have an `Output` yet (you may not even need it). So, wiring up both `OutputWriter` and `Output` in the container seems like overkill.

Being able to set the `OutputWriter`, however, when you need it, would be nice.