### PR TITLE
Enhancement: Extract constants for directions in which Versions can be executed

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -681,7 +681,7 @@ class Configuration
      */
     public function getMigrationsToExecute($direction, $to)
     {
-        if ($direction === 'down') {
+        if ($direction === Version::DIRECTION_DOWN) {
             if (count($this->migrations)) {
                 $allVersions = array_reverse(array_keys($this->migrations));
                 $classes = array_reverse(array_values($this->migrations));
@@ -763,7 +763,7 @@ class Configuration
      */
     private function shouldExecuteMigration($direction, Version $version, $to, $migrated)
     {
-        if ($direction === 'down') {
+        if ($direction === Version::DIRECTION_DOWN) {
             if (!in_array($version->getVersion(), $migrated)) {
                 return false;
             }
@@ -771,7 +771,7 @@ class Configuration
             return $version->getVersion() > $to;
         }
 
-        if ($direction === 'up') {
+        if ($direction === Version::DIRECTION_UP) {
             if (in_array($version->getVersion(), $migrated)) {
                 return false;
             }

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -84,7 +84,7 @@ class Migration
             $to = $this->configuration->getLatestVersion();
         }
 
-        $direction = $from > $to ? 'down' : 'up';
+        $direction = $from > $to ? Version::DIRECTION_DOWN : Version::DIRECTION_UP;
 
         $this->outputWriter->write(sprintf("# Migrating from %s to %s\n", $from, $to));
 
@@ -129,7 +129,7 @@ class Migration
             throw MigrationException::unknownMigrationVersion($to);
         }
 
-        $direction = $from > $to ? 'down' : 'up';
+        $direction = $from > $to ? Version::DIRECTION_DOWN : Version::DIRECTION_UP;
         $migrationsToExecute = $this->configuration->getMigrationsToExecute($direction, $to);
 
         /**

--- a/lib/Doctrine/DBAL/Migrations/SqlFileWriter.php
+++ b/lib/Doctrine/DBAL/Migrations/SqlFileWriter.php
@@ -87,7 +87,7 @@ class SqlFileWriter
 
     private function getVersionUpdateQuery($version, $direction)
     {
-        if ($direction == 'down') {
+        if ($direction == Version::DIRECTION_DOWN) {
             $query = "DELETE FROM %s WHERE version = '%s';\n";
         } else {
             $query = "INSERT INTO %s (version) VALUES ('%s');\n";

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -200,7 +200,7 @@ class Version
      *
      * @return boolean $written
      */
-    public function writeSqlFile($path, $direction = 'up')
+    public function writeSqlFile($path, $direction = self::DIRECTION_UP)
     {
         $queries = $this->execute($direction, true);
 
@@ -252,7 +252,7 @@ class Version
             $fromSchema = $this->sm->createSchema();
             $this->migration->{'pre' . ucfirst($direction)}($fromSchema);
 
-            if ($direction === 'up') {
+            if ($direction === self::DIRECTION_UP) {
                 $this->outputWriter->write("\n" . sprintf('  <info>++</info> migrating <comment>%s</comment>', $this->version) . "\n");
             } else {
                 $this->outputWriter->write("\n" . sprintf('  <info>--</info> reverting <comment>%s</comment>', $this->version) . "\n");
@@ -286,7 +286,7 @@ class Version
                     ));
                 }
 
-                if ($direction === 'up') {
+                if ($direction === self::DIRECTION_UP) {
                     $this->markMigrated();
                 } else {
                     $this->markNotMigrated();
@@ -303,7 +303,7 @@ class Version
 
             $migrationEnd = microtime(true);
             $this->time = round($migrationEnd - $migrationStart, 2);
-            if ($direction === 'up') {
+            if ($direction === self::DIRECTION_UP) {
                 $this->outputWriter->write(sprintf("\n  <info>++</info> migrated (%ss)", $this->time));
             } else {
                 $this->outputWriter->write(sprintf("\n  <info>--</info> reverted (%ss)", $this->time));
@@ -325,7 +325,7 @@ class Version
 
             if ($dryRun === false) {
                 // now mark it as migrated
-                if ($direction === 'up') {
+                if ($direction === self::DIRECTION_UP) {
                     $this->markMigrated();
                 } else {
                     $this->markNotMigrated();

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -37,6 +37,9 @@ class Version
     const STATE_EXEC = 2;
     const STATE_POST = 3;
 
+    const DIRECTION_UP = 'up';
+    const DIRECTION_DOWN = 'down';
+
     /**
      * The Migrations Configuration instance for this migration
      *

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -38,6 +38,12 @@ class VersionTest extends MigrationTestCase
 
     protected $output;
 
+    public function testConstants()
+    {
+        $this->assertSame('up', Version::DIRECTION_UP);
+        $this->assertSame('down', Version::DIRECTION_DOWN);
+    }
+
     /**
      * Create simple migration
      */


### PR DESCRIPTION
This PR

* [x] asserts the values of constants for `up` and `down`
* [x] creates these constants in `Version`
* [x] makes use of these constants

:information_desk_person: Magic strings and numbers, we can avoid them, can't we?