### PR TITLE
Allow 0 to be used as a version number.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -439,7 +439,7 @@ class Configuration
      */
     public function hasVersion($version)
     {
-        return isset($this->migrations[$version]);
+        return isset($this->migrations[$version]) || $version === '0';
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -99,6 +99,12 @@ class ConfigurationTest extends MigrationTestCase
         $this->assertFalse($version->isMigrated());
     }
 
+    public function testHasVersionAllowsZero()
+    {
+        $config = $this->getSqliteConfiguration();
+        $this->assertTrue($config->hasVersion('0'));
+    }
+
     public function testRegisterMigrations()
     {
         $config = $this->getSqliteConfiguration();


### PR DESCRIPTION
While using "first" as an alias will work, I expect that I can type in a version number as the parameter for the migration. This only came up with "Unknown version: 0".

I initially implemented this in `resolveVersionAlias()` as another alias for "first", but 0 really isn't an alias for a version - it is an actual version. I thought it made more sense to return true in `hasVersion()`. Let me know if you feel this implementation should be changed.