### PR TITLE
Keep the license file in archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 build/*                 export-ignore
 tests/*                 export-ignore
-composer.lock           export-ignore
 .coveralls              export-ignore
 .gitattributes          export-ignore
 .gitignore              export-ignore
@@ -11,4 +10,3 @@ build.properties.dev    export-ignore
 build.xml               export-ignore
 composer.json           export-ignore
 composer.lock           export-ignore
-LICENSE                 export-ignore


### PR DESCRIPTION
Shipping the code without the license would violate the license.