### PR TITLE
support addSql() calls in postUp/postDown methods

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -264,11 +264,11 @@ class Version
             $this->migration->$direction($toSchema);
             $this->addSql($fromSchema->getMigrateToSql($toSchema, $this->platform));
 
-            $this->executeRegisteredSql();
+            $this->executeRegisteredSql($dryRun, $timeAllQueries);
 
             $this->state = self::STATE_POST;
             $this->migration->{'post' . ucfirst($direction)}($toSchema);
-            $this->executeRegisteredSql();
+            $this->executeRegisteredSql($dryRun, $timeAllQueries);
 
             if (! $dryRun) {
                 if ($direction === self::DIRECTION_UP) {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -178,6 +178,29 @@ class FunctionalTest extends MigrationTestCase
         $this->assertFalse($schema->hasTable('test_add_sql_table'));
     }
 
+    public function testAddSqlInPostUp()
+    {
+        $this->config->registerMigration(1, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlPostUpTest');
+        $tableName = \Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlPostUpTest::TABLE_NAME;
+
+        $migration = new \Doctrine\DBAL\Migrations\Migration($this->config);
+        $migration->migrate(1);
+
+        $migrations = $this->config->getMigrations();
+        $this->assertTrue($migrations[1]->isMigrated());
+
+        $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
+        $this->assertTrue($schema->hasTable($tableName));
+        $check = $this->config->getConnection()->fetchAll("select * from $tableName");
+        $this->assertNotEmpty($check);
+        $this->assertEquals('test', $check[0]['test']);
+
+        $migration->migrate(0);
+        $this->assertFalse($migrations[1]->isMigrated());
+        $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
+        $this->assertFalse($schema->hasTable($tableName));
+    }
+
     public function testVersionInDatabaseWithoutRegisteredMigrationStillMigrates()
     {
         $this->config->registerMigration(1, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlTest');

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostUpTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostUpTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub\Functional;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+
+class MigrateAddSqlPostUpTest extends AbstractMigration
+{
+    const TABLE_NAME = 'test_add_sql_post_up_table';
+
+    public function up(Schema $schema)
+    {
+        $table = $schema->createTable(self::TABLE_NAME);
+        $table->addColumn('test', Type::STRING, ['length' => 64]);
+    }
+
+    public function postUp(Schema $schema)
+    {
+        $this->addSql(
+            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            ['test']
+        );
+    }
+
+    public function down(Schema $schema)
+    {
+        $schema->dropTable(self::TABLE_NAME);
+    }
+}


### PR DESCRIPTION
In migration version classes It's possible to call `$this->addSql()` method (will be proxied to `Doctrine\DBAL\Migrations\Version::addSql` in preUp/preDown and `up`/`down` methods. But calling this method in `postUp`/`postDown` will have no effect right now since all the SQL commands queued to be executed are executed before the `postUp`/`postDown` methods.

This branch allows calling `addSql` in `postUp`/`postDown` by extracting the logic of executing the SQL queue from the `execute` method body into a private method, and call it both `up`/`down` as well as `postUp`/`postDown`.
