### PR TITLE
Prevent the use of 0 as migration name as it is used internally and c…

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
@@ -56,7 +56,14 @@ abstract class AbstractFinder implements MigrationFinderInterface
         foreach ($files as $file) {
             static::requireOnce($file);
             $className = basename($file, '.php');
-            $version = substr($className, 7);
+            $version = (string) substr($className, 7);
+            if ($version === '0') {
+                throw new \InvalidArgumentException(sprintf(
+                    'Cannot load a migrations with the name "%s" because it is a reserved number by doctrine migraitons' . PHP_EOL .
+                    'It\'s used to revert all migrations including the first one.',
+                    $version
+                ));
+            }
             $migrations[$version] = sprintf('%s\\%s', $namespace, $className);
         }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -29,6 +29,14 @@ class RecursiveRegexFinderTest extends MigrationTestCase
     /**
      * @expectedException InvalidArgumentException
      */
+    public function testVersionNameCausesErrorWhen0()
+    {
+        $this->finder->findMigrations(__DIR__.'/_regression/NoVersionNamed0');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testBadFilenameCausesErrorWhenFindingMigrations()
     {
         $this->finder->findMigrations(__DIR__.'/does/not/exist/at/all');


### PR DESCRIPTION
…onflict.

The documentation has already been updated.