### PR TITLE
Fix issue of false warning for no queries after migrations

### DIFF
--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionEmptyPostUpAndPostDown.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionEmptyPostUpAndPostDown.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Class VersionEmptyPostUpAndPostDown
+ */
+class VersionEmptyPostUpAndPostDown extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE TABLE test (test INT)");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("DROP TABLE test");
+    }
+
+    public function postUp(Schema $schema)
+    {
+    }
+
+    public function postDown(Schema $schema)
+    {
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionWithPostUpAndEmptyPostDown.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionWithPostUpAndEmptyPostDown.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Class VersionWithPostUpAndEmptyPostDown
+ */
+class VersionWithPostUpAndEmptyPostDown extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE TABLE test (test INT)");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("DROP TABLE test");
+    }
+
+    public function postUp(Schema $schema)
+    {
+        $this->addSql("INSERT INTO test VALUES (1)");
+    }
+
+    public function postDown(Schema $schema)
+    {
+    }
+}


### PR DESCRIPTION
Migrations shows a warning if not actual SQL statement is run after
migrations. After merging "add-sql" branch
(Ydbbcee1906524f4667c9db06ee9afef476fa0)
an issue is introduced for the warning kept showing.

This is because the logic of executing registered SQL statements was
moved to a private function which is called once after the
migration and once after post migration method. This logic
(`executeRegisteredSql` mehtod) used to show the warning for no SQL
statements, and when called after post migration methods it is
quite possible to show the warnings, since they might not register
any SQL statements at all.

Fixed this issue by removing showing the warning from the
`executeRegisteredSql` method to the caller (`execute` method).

Also the previous behavior of `execute` method was to return the list of
SQL statements registered, but "add-sql" branch affected this, since
we cleared out the `sql` property of the `Version` class after executing
them. Fixed this issue by keeping a local copy of the SQL statements
and return that list instead.