### PR TITLE
Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/phpunit.xml
 vendor/
 composer.lock
 box.phar
+phpunit.xml

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
-use Doctrine\DBAL\Schema\Schema;
 
 class ConfigurationTest extends MigrationTestCase
 {
@@ -32,7 +31,7 @@ class ConfigurationTest extends MigrationTestCase
         $config->setMigrationsNamespace("DoctrineMigrations\\");
 
         $this->setExpectedException(
-            "Doctrine\DBAL\Migrations\MigrationException",
+            "Doctrine\\DBAL\\Migrations\\MigrationException",
             "Migrations directory must be configured in order to use Doctrine migrations."
         );
         $config->validate();
@@ -212,44 +211,5 @@ class ConfigurationTest extends MigrationTestCase
             ['20150202042811', '2015-02-02 04:28:11'],
             ['20150202162811', '2015-02-02 16:28:11']
         ];
-    }
-}
-
-class ConfigMigration extends \Doctrine\DBAL\Migrations\AbstractMigration
-{
-    public function down(Schema $schema)
-    {
-
-    }
-
-    public function up(Schema $schema)
-    {
-
-    }
-}
-
-class Config2Migration extends \Doctrine\DBAL\Migrations\AbstractMigration
-{
-    public function down(Schema $schema)
-    {
-
-    }
-
-    public function up(Schema $schema)
-    {
-
-    }
-}
-
-class Config3Migration extends \Doctrine\DBAL\Migrations\AbstractMigration
-{
-    public function down(Schema $schema)
-    {
-
-    }
-
-    public function up(Schema $schema)
-    {
-
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTestCase.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTestCase.php
@@ -26,6 +26,11 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 abstract class MigrationTestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var OutputWriter
+     */
+    private $outputWriter;
+
     public function getSqliteConnection()
     {
         $params = ['driver' => 'pdo_sqlite', 'memory' => true];


### PR DESCRIPTION
- few fixes of unused code
- phpunit.xml added to .gitignore (existence of `phpunit.xml.dist` would make no sense without it) - allows local phpunit configuration, that doesn't require coverage and is much much faster to run => faster and more pleasant development