### PR TITLE
RecursiveDirectoryIterator don't obtain some order of the file list.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
@@ -53,6 +53,9 @@ abstract class AbstractFinder implements MigrationFinderInterface
     protected function loadMigrations($files, $namespace)
     {
         $migrations = [];
+
+        uasort($files, $this->getFileSortCallback());
+
         foreach ($files as $file) {
             static::requireOnce($file);
             $className = basename($file, '.php');
@@ -68,5 +71,16 @@ abstract class AbstractFinder implements MigrationFinderInterface
         }
 
         return $migrations;
+    }
+
+    /**
+     * Return callable for files basename uasort
+     *
+     * @return callable
+     */
+    protected function getFileSortCallback(){
+        return function ($a, $b) {
+            return (basename($a) < basename($b)) ? -1 : 1;
+        };
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -71,6 +71,8 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
         foreach ($iteratorFilesMatch as $file) {
             $files[] = $file[0];
         }
+        
+        sort($files);
 
         return $files;
     }

--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -72,8 +72,6 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
             $files[] = $file[0];
         }
         
-        sort($files);
-
         return $files;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -68,6 +68,11 @@ class RecursiveRegexFinderTest extends MigrationTestCase
             $this->assertArrayHasKey($version, $migrations);
             $this->assertEquals($namespace, $migrations[$version]);
         }
+        $migrationsForTestSort = (array)$migrations;
+
+        asort($migrationsForTestSort);
+
+        $this->assertTrue($migrationsForTestSort === $migrations,"Finder have to return sorted list of the files.");
         $this->assertArrayNotHasKey('InvalidVersion20150502000002', $migrations);
         $this->assertArrayNotHasKey('Version20150502000002', $migrations);
         $this->assertArrayNotHasKey('20150502000002', $migrations);


### PR DESCRIPTION
RecursiveDirectoryIterator shouldn't return a sorted list and haven't to do it be direct. But migration script logic requires sorted list of the Version*.php files for correct working.