### PR TITLE
Made composer.json compatible with SF 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=5.4.0",
         "doctrine/dbal": "~2.2",
-        "symfony/yaml": "~2.3",
-        "symfony/console": "~2.3"
+        "symfony/yaml": "~2.3|~3.0",
+        "symfony/console": "~2.3|~3.0"
     },
     "require-dev": {
         "doctrine/orm": "2.*",


### PR DESCRIPTION
Hi there, 

It seems that the DoctrineMigrationsBundle is ]already made compatible](https://github.com/doctrine/DoctrineMigrationsBundle/blob/master/composer.json#L24) with SF 3.0 but you can't install it because this underlaying package still requires only ~2.3. This is a fix for that. Cheers!