### PR TITLE
Allow setting version column name

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -483,7 +483,7 @@ class Configuration
         $this->createMigrationTable();
 
         $version = $this->connection->fetchColumn(
-            "SELECT version FROM " . $this->migrationsTableName . " WHERE version = ?",
+            "SELECT " . $this->migrationsColumnName . " FROM " . $this->migrationsTableName . " WHERE " . $this->migrationsColumnName . " = ?",
             [$version->getVersion()]
         );
 
@@ -499,7 +499,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        $ret = $this->connection->fetchAll("SELECT version FROM " . $this->migrationsTableName);
+        $ret = $this->connection->fetchAll("SELECT " . $this->migrationsColumnName . " FROM " . $this->migrationsTableName);
         $versions = [];
         foreach ($ret as $version) {
             $versions[] = current($version);
@@ -541,8 +541,8 @@ class Configuration
             $where = " WHERE version IN (" . implode(', ', $migratedVersions) . ")";
         }
 
-        $sql = sprintf("SELECT version FROM %s%s ORDER BY version DESC",
-            $this->migrationsTableName, $where
+        $sql = sprintf("SELECT %s FROM %s%s ORDER BY %s DESC",
+            $this->migrationsColumnName, $this->migrationsTableName, $where, $this->migrationsColumnName
         );
 
         $sql = $this->connection->getDatabasePlatform()->modifyLimitQuery($sql, 1);
@@ -640,7 +640,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        $result = $this->connection->fetchColumn("SELECT COUNT(version) FROM " . $this->migrationsTableName);
+        $result = $this->connection->fetchColumn("SELECT COUNT(" . $this->migrationsColumnName . ") FROM " . $this->migrationsTableName);
 
         return $result !== false ? $result : 0;
     }
@@ -683,10 +683,10 @@ class Configuration
 
         if (!$this->connection->getSchemaManager()->tablesExist([$this->migrationsTableName])) {
             $columns = [
-                'version' => new Column('version', Type::getType('string'), ['length' => 255]),
+                $this->migrationsColumnName => new Column($this->migrationsColumnName, Type::getType('string'), ['length' => 255]),
             ];
             $table = new Table($this->migrationsTableName, $columns);
-            $table->setPrimaryKey(['version']);
+            $table->setPrimaryKey([$this->migrationsColumnName]);
             $this->connection->getSchemaManager()->createTable($table);
 
             $this->migrationTableCreated = true;

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -538,7 +538,7 @@ class Configuration
             foreach ($this->migrations as $migration) {
                 $migratedVersions[] = sprintf("'%s'", $migration->getVersion());
             }
-            $where = " WHERE version IN (" . implode(', ', $migratedVersions) . ")";
+            $where = " WHERE " . $this->migrationsColumnName . " IN (" . implode(', ', $migratedVersions) . ")";
         }
 
         $sql = sprintf("SELECT %s FROM %s%s ORDER BY %s DESC",

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -98,6 +98,13 @@ class Configuration
     private $migrationsTableName = 'doctrine_migration_versions';
 
     /**
+     * The migration column name to track versions in
+     *
+     * @var string
+     */
+    private $migrationsColumnName = 'version';
+
+    /**
      * The path to a directory where new migration classes will be written
      *
      * @var string
@@ -282,6 +289,26 @@ class Configuration
     public function getMigrationsTableName()
     {
         return $this->migrationsTableName;
+    }
+
+    /**
+     * Set the migration column name
+     *
+     * @param string $columnName The migration column name
+     */
+    public function setMigrationsColumnName($columnName)
+    {
+        $this->migrationsColumnName = $columnName;
+    }
+
+    /**
+     * Returns the migration column name
+     *
+     * @return string $migrationsColumnName The migration column name
+     */
+    public function getMigrationsColumnName()
+    {
+        return $this->migrationsColumnName;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -89,6 +89,7 @@ EOT
             'Database Name'                     => $configuration->getConnection()->getDatabase(),
             'Configuration Source'              => $configuration instanceof AbstractFileConfiguration ? $configuration->getFile() : 'manually configured',
             'Version Table Name'                => $configuration->getMigrationsTableName(),
+            'Version Column Name'                => $configuration->getMigrationsColumnName(),
             'Migrations Namespace'              => $configuration->getMigrationsNamespace(),
             'Migrations Directory'              => $configuration->getMigrationsDirectory(),
             'Previous Version'                  => $formattedVersions['prev'],

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -152,7 +152,7 @@ class Version
         $this->configuration->createMigrationTable();
         $this->connection->insert(
             $this->configuration->getMigrationsTableName(),
-            ['version' => $this->version]
+            [$this->configuration->getMigrationsColumnName() => $this->version]
         );
     }
 
@@ -161,7 +161,7 @@ class Version
         $this->configuration->createMigrationTable();
         $this->connection->delete(
             $this->configuration->getMigrationsTableName(),
-            ['version' => $this->version]
+            [$this->configuration->getMigrationsColumnName() => $this->version]
         );
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -72,4 +72,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
     }
+
+    public function testGetSetMigrationsColumnName()
+    {
+        $configuration = new Configuration($this->getConnectionMock());
+
+        $this->assertSame('version', $configuration->getMigrationsColumnName());
+
+        $configuration->setMigrationsColumnName('foobar');
+        $this->assertSame('foobar', $configuration->getMigrationsColumnName());
+    }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -24,6 +24,8 @@ class FunctionalTest extends MigrationTestCase
         $this->config = new Configuration($this->connection);
         $this->config->setMigrationsNamespace('Doctrine\DBAL\Migrations\Tests\Functional');
         $this->config->setMigrationsDirectory('.');
+        $this->config->setMigrationsTableName('test_migrations_table');
+        $this->config->setMigrationsColumnName('current_version');
     }
 
     public function testMigrateUp()
@@ -219,6 +221,8 @@ class FunctionalTest extends MigrationTestCase
         $config->setMigrationsDirectory('.');
         $config->registerMigration(1, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlTest');
         $config->registerMigration(2, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationMigrateUp');
+        $config->setMigrationsTableName('test_migrations_table');
+        $config->setMigrationsColumnName('current_version');
 
         $migration = new \Doctrine\DBAL\Migrations\Migration($config);
         $migration->migrate();
@@ -249,6 +253,8 @@ class FunctionalTest extends MigrationTestCase
         $config->registerMigration(1, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlTest');
         $config->registerMigration(2, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationMigrateUp');
         $config->registerMigration(3, 'Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationMigrateFurther');
+        $config->setMigrationsTableName('test_migrations_table');
+        $config->setMigrationsColumnName('current_version');
 
         $this->assertEquals(1, count($config->getMigrationsToExecute('up', 3)));
         $migrations = $config->getMigrationsToExecute('up', 3);


### PR DESCRIPTION
This, in theory, would solve [DMIG-48](http://www.doctrine-project.org/jira/browse/DMIG-48), as it allows usage of column names other than `version`.