### PR TITLE
Allow overriding of the Migration template

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -100,6 +100,11 @@ EOT
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
     }
 
+    protected function getTemplate()
+    {
+        return self::$_template;
+    }
+
     protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
     {
         $placeHolders = [
@@ -114,7 +119,7 @@ EOT
             $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
             $down ? "        " . implode("\n        ", explode("\n", $down)) : null
         ];
-        $code = str_replace($placeHolders, $replacements, self::$_template);
+        $code = str_replace($placeHolders, $replacements, $this->getTemplate());
         $code = preg_replace('/^ +$/m', '', $code);
         $migrationDirectoryHelper = new MigrationDirectoryHelper($configuration);
         $dir = $migrationDirectoryHelper->getMigrationDirectory();


### PR DESCRIPTION
Retrieving the template through a method instead of accessing the private variable directly enables the extension of the "Generate" command.

As an example: in [kreait/ezpublish-migrations-bundle](https://github.com/kreait/ezpublish-migrations-bundle), I have created a [custom Migration class](https://github.com/kreait/ezpublish-migrations-bundle/blob/master/src/Migrations/EzPublishMigration.php) and a [custom generate command](https://github.com/kreait/ezpublish-migrations-bundle/blob/master/src/Command/GenerateCommand.php), so that a Version can perform needed actions automatically and provide helper methods.

At the moment, it would be necessary to duplicate the [`generateMigration`method](https://github.com/doctrine/migrations/blob/master/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php#L103).

With the change from this PR, someone extending the `GenerateCommand` would just have to override the `getTemplate` method.
