### PR TITLE
Select a compression algorythm for the phar package

### DIFF
--- a/box.json
+++ b/box.json
@@ -4,6 +4,7 @@
         "Herrera\\Box\\Compactor\\Composer",
         "Herrera\\Box\\Compactor\\Json"
     ],
+    "compression": "GZ",
     "main": "bin/doctrine-migrations.php",
     "output": "build/doctrine-migrations.phar",
     "finder": [


### PR DESCRIPTION
It's more than 3 times smaller than the previous one and about 10% smaller than the bz2 version.