### PR TITLE
putting the composer.json back in the archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,3 @@ tests/*                 export-ignore
 box.json                export-ignore
 build.properties.dev    export-ignore
 build.xml               export-ignore
-composer.json           export-ignore
-composer.lock           export-ignore


### PR DESCRIPTION
The composer.lock is not tracked so it's unnecessary to exclude it.
The discussion is there.
https://github.com/doctrine/migrations/commit/3a787de7c4a64460436dc2eb2e3cde8920d5fadd