### PR TITLE
Add a failing test case for an edge case with the write-sql option

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/MigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationException.php
@@ -100,4 +100,20 @@ class MigrationException extends \Exception
             )
         );
     }
+
+    /**
+     * @param string $migrationClass
+     * @return MigrationException
+     */
+    public static function migrationNotConvertibleToSql($migrationClass)
+    {
+        return new self(
+            sprintf(
+                'Migration class "%s" contains a prepared statement.
+                Unfortunately there is no cross platform way of outputing it as an sql string.
+                Do you want to write a PR for it ?',
+                $migrationClass
+            )
+        );
+    }
 }

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -204,6 +204,10 @@ class Version
     {
         $queries = $this->execute($direction, true);
 
+        if ( ! empty($this->params)) {
+            throw MigrationException::migrationNotConvertibleToSql($this->class);
+        }
+
         $this->outputWriter->write("\n# Version " . $this->version . "\n");
 
         $sqlQueries = [$this->version => $queries];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSqlWithParam.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSqlWithParam.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class VersionOutputSqlWithParam extends AbstractMigration
+{
+    public function down(Schema $schema)
+    {
+        $this->addSql('Select :param1 WHERE :param2 = :param3', [
+            'param1' => 1,
+            'param2' => 2,
+            'param3' => 3,
+        ]);
+    }
+
+    public function up(Schema $schema)
+    {
+        $this->addSql('Select :param1 WHERE :param2 = :param3', [
+            'param1' => 1,
+            'param2' => 2,
+            'param3' => 3,
+        ]);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSqlWithParam.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSqlWithParam.php
@@ -9,15 +9,11 @@ class VersionOutputSqlWithParam extends AbstractMigration
 {
     public function down(Schema $schema)
     {
-        $this->addSql('Select :param1 WHERE :param2 = :param3', [
-            'param1' => 1,
-            'param2' => 2,
-            'param3' => 3,
-        ]);
     }
 
     public function up(Schema $schema)
     {
+        $this->addSql('Select 1 WHERE 1');
         $this->addSql('Select :param1 WHERE :param2 = :param3', [
             'param1' => 1,
             'param2' => 2,

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests;
 
+use Doctrine\DBAL\Migrations\MigrationException;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSqlWithParam;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -279,7 +280,7 @@ class VersionTest extends MigrationTestCase
             VersionOutputSqlWithParam::class
         );
 
-        $this->assertContains('Select 1 WHERE 2 = 3', $version->execute('up'));
-        $this->assertContains('Select 1 WHERE 2 = 3', $version->execute('down'));
+        $this->setExpectedException(MigrationException::class, 'contains a prepared statement.');
+        $version->writeSqlFile('tralala');
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests;
 
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSqlWithParam;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Migrations\Version;
@@ -262,5 +263,23 @@ class VersionTest extends MigrationTestCase
 
         $this->assertContains('Select 1', $version->execute('up'));
         $this->assertContains('Select 1', $version->execute('down'));
+    }
+
+    public function testReturnTheSqlWithParams()
+    {
+        $this->outputWriter = $this->getOutputWriter();
+
+        $this->config = new Configuration($this->getSqliteConnection(), $this->outputWriter);
+        $this->config->setMigrationsDirectory(\sys_get_temp_dir());
+        $this->config->setMigrationsNamespace('DoctrineMigrations\\');
+
+        $version = new Version(
+            $this->config,
+            $versionName = '006',
+            VersionOutputSqlWithParam::class
+        );
+
+        $this->assertContains('Select 1 WHERE 2 = 3', $version->execute('up'));
+        $this->assertContains('Select 1 WHERE 2 = 3', $version->execute('down'));
     }
 }


### PR DESCRIPTION
Right now if addSql is used with parameters for a prepared stmt the
write-sql option will output an unusable dump.