### PR TITLE
Fix issue with some method when the migrations were not loaded

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -382,6 +382,8 @@ class Configuration
      */
     public function registerMigrationsFromDirectory($path)
     {
+        $this->validate();
+
         return $this->registerMigrations($this->findMigrations($path));
     }
 
@@ -468,6 +470,10 @@ class Configuration
      */
     public function hasVersion($version)
     {
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         return isset($this->migrations[$version]);
     }
 
@@ -516,6 +522,11 @@ class Configuration
     public function getAvailableVersions()
     {
         $availableVersions = [];
+
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         foreach ($this->migrations as $migration) {
             $availableVersions[] = $migration->getVersion();
         }
@@ -531,6 +542,10 @@ class Configuration
     public function getCurrentVersion()
     {
         $this->createMigrationTable();
+
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
 
         $where = null;
         if (!empty($this->migrations)) {
@@ -582,6 +597,10 @@ class Configuration
      */
     public function getRelativeVersion($version, $delta)
     {
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         $versions = array_keys($this->migrations);
         array_unshift($versions, 0);
         $offset = array_search($version, $versions);
@@ -652,6 +671,10 @@ class Configuration
      */
     public function getNumberOfAvailableMigrations()
     {
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         return count($this->migrations);
     }
 
@@ -662,6 +685,10 @@ class Configuration
      */
     public function getLatestVersion()
     {
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         $versions = array_keys($this->migrations);
         $latest = end($versions);
 
@@ -710,6 +737,10 @@ class Configuration
      */
     public function getMigrationsToExecute($direction, $to)
     {
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         if ($direction === Version::DIRECTION_DOWN) {
             if (count($this->migrations)) {
                 $allVersions = array_reverse(array_keys($this->migrations));

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -35,7 +35,7 @@ class MigrationTest extends MigrationTestCase
     public function setUp()
     {
         $this->config = new Configuration($this->getSqliteConnection());
-        $this->config->setMigrationsDirectory(\sys_get_temp_dir());
+        $this->config->setMigrationsDirectory(__DIR__ . DIRECTORY_SEPARATOR . 'Stub/migration-empty-folder');
         $this->config->setMigrationsNamespace('DoctrineMigrations\\');
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTestCase.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTestCase.php
@@ -48,7 +48,7 @@ abstract class MigrationTestCase extends \PHPUnit_Framework_TestCase
     public function getSqliteConfiguration()
     {
         $config = new Configuration($this->getSqliteConnection());
-        $config->setMigrationsDirectory(\sys_get_temp_dir());
+        $config->setMigrationsDirectory(__DIR__ . '/Stub/migration-empty-folder');
         $config->setMigrationsNamespace('DoctrineMigrations');
 
         return $config;

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
@@ -7,6 +7,15 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class MigrationStatusTest extends MigrationTestCase
 {
+
+    private $migrationDirectory;
+
+    public function __construct()
+    {
+        parent::__construct(null, [], null);
+        $this->migrationDirectory = __DIR__ . '/../../../Stub/migration-empty-folder';
+    }
+
     /**
      * Tests the display of the previous/current/next/latest versions.
      */
@@ -46,7 +55,7 @@ class MigrationStatusTest extends MigrationTestCase
 
         $configuration = $this->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
             ->setConstructorArgs([$this->getSqliteConnection()])
-            ->setMethods(['resolveVersionAlias', 'getDateTime'])
+            ->setMethods(['resolveVersionAlias', 'getDateTime', 'getAvailableVersions'])
             ->getMock();
 
         $configuration
@@ -61,8 +70,13 @@ class MigrationStatusTest extends MigrationTestCase
             ->method('getDateTime')
             ->will($this->returnValue('FORMATTED'));
 
+        $configuration
+            ->expects($this->any())
+            ->method('getAvailableVersions')
+            ->will($this->returnValue([]));
+
         $configuration->setMigrationsNamespace('DoctrineMigrations');
-        $configuration->setMigrationsDirectory(sys_get_temp_dir());
+        $configuration->setMigrationsDirectory($this->migrationDirectory);
 
         $command
             ->expects($this->once())
@@ -118,7 +132,7 @@ class MigrationStatusTest extends MigrationTestCase
             ->will($this->returnValue(1239));
 
         $configuration->setMigrationsNamespace('DoctrineMigrations');
-        $configuration->setMigrationsDirectory(sys_get_temp_dir());
+        $configuration->setMigrationsDirectory($this->migrationDirectory);
 
         $command
             ->expects($this->once())


### PR DESCRIPTION
Previously you needed to make sure manually that registerMigrations was
called before to make any call to a method that was using the migrations
loaded.

This might cause performance issue in some edge case but it's unlikely.
Unfortunately in the current desgin I don't see any other solution.