### PR TITLE
ProxyManager ~2.0 is also compatible with migrations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "doctrine/dbal": "~2.2",
         "symfony/yaml": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",
-        "ocramius/proxy-manager": "^1.0"
+        "ocramius/proxy-manager": "^1.0|^2.0"
     },
     "require-dev": {
         "doctrine/orm": "2.*",


### PR DESCRIPTION
Note: can't seem to be able to install it with the dev dependencies unless I remove `"doctrine/coding-standard": "dev-master"`, which relies on an old PHP_CodeSniffer version. Other than that, runs fine.