### PR TITLE
Fix: ExecuteCommand

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -454,6 +454,10 @@ class Configuration
      */
     public function getVersion($version)
     {
+        if (empty($this->migrations)) {
+            $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
+        }
+
         if (!isset($this->migrations[$version])) {
             throw MigrationException::unknownMigrationVersion($version);
         }

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\MigrationException;
-use Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions\Version1Test;
 
 class ConfigurationTest extends MigrationTestCase
 {
@@ -193,7 +192,7 @@ class ConfigurationTest extends MigrationTestCase
     }
 
     /**
-     * @dataProvider getVersionProvider
+     * @dataProvider autoloadVersionProvider
      *
      * @param $version
      */
@@ -243,7 +242,7 @@ class ConfigurationTest extends MigrationTestCase
     /**
      * @return array
      */
-    public function getVersionProvider()
+    public function autoloadVersionProvider()
     {
         return [
             ['1Test'],

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -3,6 +3,8 @@
 namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\MigrationException;
+use Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions\Version1Test;
 
 class ConfigurationTest extends MigrationTestCase
 {
@@ -191,6 +193,31 @@ class ConfigurationTest extends MigrationTestCase
     }
 
     /**
+     * @dataProvider getVersionProvider
+     *
+     * @param $version
+     */
+    public function testGetVersion($version)
+    {
+        $config = $this->getSqliteConfiguration();
+        $config->setMigrationsNamespace('Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions');
+        $config->setMigrationsDirectory(__DIR__ . '/Stub/Configuration/AutoloadVersions');
+
+        $result = $config->getVersion($version);
+
+        $this->assertNotNull($result);
+    }
+
+    public function testGetVersionNotFound()
+    {
+        $this->setExpectedException(MigrationException::class);
+
+        $config = $this->getSqliteConfiguration();
+
+        $config->getVersion('foo');
+    }
+
+    /**
      * @dataProvider versionProvider
      */
     public function testGetDatetime($version, $return)
@@ -210,6 +237,20 @@ class ConfigurationTest extends MigrationTestCase
             ['20130101123545Version', '2013-01-01 12:35:45'],
             ['20150202042811', '2015-02-02 04:28:11'],
             ['20150202162811', '2015-02-02 16:28:11']
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getVersionProvider()
+    {
+        return [
+            ['1Test'],
+            ['2Test'],
+            ['3Test'],
+            ['4Test'],
+            ['5Test'],
         ];
     }
 }


### PR DESCRIPTION
* Fix `\Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand` unable to find Migration Version by registering Migration Versions on call to `\Doctrine\DBAL\Migrations\Configuration\Configuration#getVersion()`
* Adds missing check for empty migrations array in `\Doctrine\DBAL\Migrations\Configuration\Configuration#getVersion()`
* Commit https://github.com/doctrine/migrations/commit/916bee27bae598fbaf90bc21117fb6b2f76bba1c previously added checks for registered migrations (Pull Request https://github.com/doctrine/migrations/pull/421)
* Added tests for `\Doctrine\DBAL\Migrations\Configuration\Configuration#getVersion()` 

> Fix issue with some method call order when the migrations were not loaded
>
> Previously you needed to make sure manually that registerMigrations was
called before to make any call to a method that was using the migrations
loaded.
>
> This might cause performance issue in some edge case but it's unlikely.
Unfortunately in the current desgin I don't see any other solution.
