### PR TITLE
Fixing an issue in the order at which some configuration key are loaded

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php
@@ -50,10 +50,10 @@ abstract class AbstractFileConfiguration extends Configuration
      * @var array of possible configuration properties in migrations configuration.
      */
     private $configurationProperties = [
-        'name' => 'setName',
-        'table_name' => 'setMigrationsTableName',
         'migrations_namespace' => 'setMigrationsNamespace',
+        'table_name' => 'setMigrationsTableName',
         'organize_migrations' => 'setMigrationOrganisation',
+        'name' => 'setName','name' => 'setName',
         'migrations_directory' => 'loadMigrationsFromDirectory',
         'migrations' => 'loadMigrations',
     ];
@@ -65,7 +65,11 @@ abstract class AbstractFileConfiguration extends Configuration
                 $msg = sprintf('Migrations configuration key "%s" does not exists.', $configurationKey);
                 throw MigrationException::configurationNotValid($msg);
             }
-            $this->{$this->configurationProperties[$configurationKey]}($configurationValue);
+        }
+        foreach($this->configurationProperties as $configurationKey => $configurationSetter) {
+            if (isset($config[$configurationKey])) {
+                $this->{$configurationSetter}($config[$configurationKey]);
+            }
         }
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -137,4 +137,20 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
         $this->loadConfiguration('migrations_list');
         $this->loadConfiguration('migrations_list2');
     }
+
+    /**
+     * @dataProvider getConfigWithKeysInVariousOrder
+     */
+    public function testThatTheOrderOfConfigKeysDoesNotMatter($file)
+    {
+        $this->loadConfiguration($file);
+    }
+
+    public function getConfigWithKeysInVariousOrder()
+    {
+        return [
+            ['order_1'],
+            ['order_2'],
+        ];
+    }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.json
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.json
@@ -1,0 +1,8 @@
+{
+  "name"                : "Doctrine Sandbox Migrations",
+  "migrations_namespace": "DoctrineMigrationsTest",
+  "table_name"          : "doctrine_migration_versions_test",
+  "migrations_directory": ".",
+  "migrations"          : []
+}
+

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.php
@@ -1,0 +1,8 @@
+<?php
+return array(
+'name'                 => 'Doctrine Sandbox Migrations',
+'migrations_namespace' => 'DoctrineMigrationsTest',
+'table_name'           => 'doctrine_migration_versions_test',
+'migrations_directory' => '.',
+'migrations'           => array()
+);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <name>Doctrine Sandbox Migrations</name>
+    <migrations-namespace>DoctrineMigrationsTest</migrations-namespace>
+    <table name="doctrine_migration_versions_test" />
+    <migrations-directory>.</migrations-directory>
+
+</doctrine-migrations>

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.yml
@@ -1,0 +1,6 @@
+---
+name: Doctrine Sandbox Migrations
+migrations_namespace: DoctrineMigrationsTest
+table_name: doctrine_migration_versions_test
+migrations_directory: .
+migrations:

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.json
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.json
@@ -1,0 +1,8 @@
+{
+  "name"                : "Doctrine Sandbox Migrations",
+  "migrations_directory": ".",
+  "migrations_namespace": "DoctrineMigrationsTest",
+  "table_name"          : "doctrine_migration_versions_test",
+  "migrations"          : []
+}
+

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.php
@@ -1,0 +1,8 @@
+<?php
+return array(
+    'name'                 => 'Doctrine Sandbox Migrations',
+    'migrations_directory' => '.',
+    'migrations_namespace' => 'DoctrineMigrationsTest',
+    'table_name'           => 'doctrine_migration_versions_test',
+    'migrations'           => array()
+);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.xml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <name>Doctrine Sandbox Migrations</name>
+    <migrations-directory>.</migrations-directory>
+    <migrations-namespace>DoctrineMigrationsTest</migrations-namespace>
+    <table name="doctrine_migration_versions_test" />
+
+</doctrine-migrations>

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.yml
@@ -1,0 +1,6 @@
+---
+name: Doctrine Sandbox Migrations
+migrations_directory: .
+migrations_namespace: DoctrineMigrationsTest
+table_name: doctrine_migration_versions_test
+migrations:


### PR DESCRIPTION
There is validation that check that the namespace and folder name are
set. Namely the validate method in the configuration class.

Because of that check we need to make sure that the namespace is set
before any migration are loaded, as the check happen there.