### PR TITLE
Fix: Move Expected Exception

### DIFF
--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -209,9 +209,9 @@ class ConfigurationTest extends MigrationTestCase
 
     public function testGetVersionNotFound()
     {
-        $this->setExpectedException(MigrationException::class);
-
         $config = $this->getSqliteConfiguration();
+        
+        $this->setExpectedException(MigrationException::class);
 
         $config->getVersion('foo');
     }


### PR DESCRIPTION
* Moves `expectException()` call in Unit Test after the call to `getSqlConfiguration` to ensure exception is thrown from call to `getVersion` as intended.