### PR TITLE
Add ConsoleRunner similar to that in DBAL and ORM

### DIFF
--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -78,27 +78,12 @@ if(class_exists('\Symfony\Component\Console\Helper\QuestionHelper')) {
 }
 
 
-$cli = new \Symfony\Component\Console\Application('Doctrine Migrations', \Doctrine\DBAL\Migrations\MigrationsVersion::VERSION());
-$cli->setCatchExceptions(true);
-$cli->setHelperSet($helperSet);
-$cli->addCommands(array(
-    // Migrations Commands
-    new \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand(),
-    new \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand(),
-    new \Doctrine\DBAL\Migrations\Tools\Console\Command\LatestCommand(),
-    new \Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand(),
-    new \Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand(),
-    new \Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand()
-));
-if ($helperSet->has('em')) {
-    $cli->add(new \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand());
-}
-
 $input = file_exists('migrations-input.php')
        ? include 'migrations-input.php' : null;
 
 $output = file_exists('migrations-output.php')
         ? include 'migrations-output.php' : null;
 
+$cli = \Doctrine\DBAL\Migrations\Tools\Console\ConsoleRunner::createApplication($helperSet);
 $cli->run($input, $output);
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Tools\Console;
+
+use Doctrine\DBAL\Migrations\Tools\Console\Command;
+use Doctrine\DBAL\Migrations\MigrationsVersion;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+
+/**
+ * Handles running the Console Tools inside Symfony Console context.
+ */
+class ConsoleRunner
+{
+    /**
+     * Runs console with the given helperset.
+     *
+     * @param \Symfony\Component\Console\Helper\HelperSet  $helperSet
+     * @param \Symfony\Component\Console\Command\Command[] $commands
+     *
+     * @return void
+     */
+    public static function run(HelperSet $helperSet, $commands = array())
+    {
+        $cli = self::createApplication($helperSet, $commands);
+        $cli->run();
+    }
+
+    /**
+     * Creates a console application with the given helperset and
+     * optional commands.
+     *
+     * @param \Symfony\Component\Console\Helper\HelperSet $helperSet
+     * @param array $commands
+     *
+     * @return \Symfony\Component\Console\Application
+     */
+    public static function createApplication(HelperSet $helperSet, $commands = array())
+    {
+        $cli = new Application('Doctrine Migrations', MigrationsVersion::VERSION());
+        $cli->setCatchExceptions(true);
+        $cli->setHelperSet($helperSet);
+        self::addCommands($cli);
+        $cli->addCommands($commands);
+
+        return $cli;
+    }
+
+    /**
+     * @param Application $cli
+     *
+     * @return void
+     */
+    public static function addCommands(Application $cli)
+    {
+        $cli->addCommands(array(
+            new Command\ExecuteCommand(),
+            new Command\GenerateCommand(),
+            new Command\LatestCommand(),
+            new Command\MigrateCommand(),
+            new Command\StatusCommand(),
+            new Command\VersionCommand(),
+        ));
+
+        if ($cli->getHelperSet()->has('em')) {
+            $cli->add(new Command\DiffCommand());
+        }
+    }
+}


### PR DESCRIPTION
To make it easier to add the migration commands to existing console applications, this patch adds ConsoleRunner similar to that in DBAL and ORM.