### PR TITLE
Fix: Use class keyword

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -20,7 +20,11 @@
 namespace Doctrine\DBAL\Migrations\Tools\Console\Helper;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Configuration\ArrayConfiguration;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Configuration\JsonConfiguration;
+use Doctrine\DBAL\Migrations\Configuration\XmlConfiguration;
+use Doctrine\DBAL\Migrations\Configuration\YamlConfiguration;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Helper\Helper;
@@ -99,11 +103,11 @@ class ConfigurationHelper extends Helper
     private function loadConfig($config, OutputWriter $outputWriter)
     {
         $map = array(
-            'xml'   => '\XmlConfiguration',
-            'yaml'  => '\YamlConfiguration',
-            'yml'   => '\YamlConfiguration',
-            'php'   => '\ArrayConfiguration',
-            'json'  => '\JsonConfiguration'
+            'xml'   => XmlConfiguration::class,
+            'yaml'  => YamlConfiguration::class,
+            'yml'   => YamlConfiguration::class,
+            'php'   => ArrayConfiguration::class,
+            'json'  => JsonConfiguration::class,
         );
 
         $info = pathinfo($config);
@@ -112,8 +116,7 @@ class ConfigurationHelper extends Helper
             throw new \InvalidArgumentException('Given config file type is not supported');
         }
 
-        $class         = 'Doctrine\DBAL\Migrations\Configuration';
-        $class        .= $map[$info['extension']];
+        $class         = $map[$info['extension']];
         $configuration = new $class($this->connection, $outputWriter);
         $configuration->load($config);
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
@@ -2,8 +2,12 @@
 
 namespace Doctrine\DBAL\Migrations\Tests;
 
+use Doctrine\DBAL\Migrations\AbortMigrationException;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\IrreversibleMigrationException;
+use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Migrations\Tests\Stub\AbstractMigrationStub;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
 use Doctrine\DBAL\Migrations\Version;
 
 /**
@@ -29,7 +33,7 @@ class AbstractMigrationTest extends MigrationTestCase
         $this->config->setMigrationsDirectory(\sys_get_temp_dir());
         $this->config->setMigrationsNamespace('DoctrineMigrations\\');
 
-        $this->version = new Version($this->config, 'Dummy', 'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy');
+        $this->version = new Version($this->config, 'Dummy', VersionDummy::class);
         $this->migration = new AbstractMigrationStub($this->version);
     }
 
@@ -68,7 +72,7 @@ class AbstractMigrationTest extends MigrationTestCase
 
     public function testAbortIfThrowsException()
     {
-        $this->setExpectedException('Doctrine\DBAL\Migrations\AbortMigrationException', 'Something failed');
+        $this->setExpectedException(AbortMigrationException::class, 'Something failed');
         $this->migration->abortIf(true, 'Something failed');
     }
 
@@ -79,13 +83,13 @@ class AbstractMigrationTest extends MigrationTestCase
 
     public function testAbortIfThrowsExceptionEvenWithoutMessage()
     {
-        $this->setExpectedException('Doctrine\DBAL\Migrations\AbortMigrationException', 'Unknown Reason');
+        $this->setExpectedException(AbortMigrationException::class, 'Unknown Reason');
         $this->migration->abortIf(true);
     }
 
     public function testSkipIfThrowsException()
     {
-        $this->setExpectedException('Doctrine\DBAL\Migrations\SkipMigrationException', 'Something skipped');
+        $this->setExpectedException(SkipMigrationException::class, 'Something skipped');
         $this->migration->skipIf(true, 'Something skipped');
     }
 
@@ -96,13 +100,13 @@ class AbstractMigrationTest extends MigrationTestCase
 
     public function testThrowIrreversibleMigrationException()
     {
-        $this->setExpectedException('Doctrine\DBAL\Migrations\IrreversibleMigrationException', 'Irreversible migration');
+        $this->setExpectedException(IrreversibleMigrationException::class, 'Irreversible migration');
         $this->migration->exposed_ThrowIrreversibleMigrationException('Irreversible migration');
     }
 
     public function testThrowIrreversibleMigrationExceptionWithoutMessage()
     {
-        $this->setExpectedException('Doctrine\DBAL\Migrations\IrreversibleMigrationException', 'This migration is irreversible and cannot be reverted.');
+        $this->setExpectedException(IrreversibleMigrationException::class, 'This migration is irreversible and cannot be reverted.');
         $this->migration->exposed_ThrowIrreversibleMigrationException();
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -2,8 +2,10 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Configuration;
 
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Finder\GlobFinder;
 use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
+use Doctrine\DBAL\Migrations\MigrationException;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 
@@ -61,7 +63,7 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
 
     public function testSetMigrationFinder()
     {
-        $migrationFinderProphecy = $this->prophesize('Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface');
+        $migrationFinderProphecy = $this->prophesize(MigrationFinderInterface::class);
         /** @var $migrationFinder MigrationFinderInterface */
         $migrationFinder = $migrationFinderProphecy->reveal();
 
@@ -69,7 +71,7 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
         $config->setMigrationsFinder($migrationFinder);
 
         $migrationFinderPropertyReflected = new \ReflectionProperty(
-            'Doctrine\DBAL\Migrations\Configuration\Configuration',
+            Configuration::class,
             'migrationFinder'
         );
         $migrationFinderPropertyReflected->setAccessible(true);
@@ -79,7 +81,7 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
     public function testThrowExceptionIfAlreadyLoaded()
     {
         $config = $this->loadConfiguration();
-        $this->setExpectedException('Doctrine\DBAL\Migrations\MigrationException');
+        $this->setExpectedException(MigrationException::class);
         $config->load($config->getFile());
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -28,7 +28,7 @@ class ConfigurationTest extends MigrationTestCase
     {
         $configuration = new Configuration($this->getConnectionMock());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\OutputWriter', $configuration->getOutputWriter());
+        $this->assertInstanceOf(OutputWriter::class, $configuration->getOutputWriter());
     }
 
     public function testOutputWriterCanBeSet()
@@ -50,7 +50,7 @@ class ConfigurationTest extends MigrationTestCase
         $configuration->setMigrationsDirectory($migrationsDir);
 
         $this->setExpectedException(
-            'Doctrine\DBAL\Migrations\MigrationException',
+            MigrationException::class,
             'Migration class "Migrations\Version123" was not found. Is it placed in "Migrations" namespace?'
         );
         $configuration->registerMigrationsFromDirectory($migrationsDir);
@@ -61,7 +61,7 @@ class ConfigurationTest extends MigrationTestCase
      */
     private function getConnectionMock()
     {
-        return $this->getMockBuilder('Doctrine\DBAL\Connection')
+        return $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;
@@ -71,7 +71,7 @@ class ConfigurationTest extends MigrationTestCase
      */
     private function getOutputWriterMock()
     {
-        return $this->getMockBuilder('Doctrine\DBAL\Migrations\OutputWriter')
+        return $this->getMockBuilder(OutputWriter::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -4,6 +4,10 @@ namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\MigrationException;
+use Doctrine\DBAL\Migrations\Tests\Stub\Version1Test;
+use Doctrine\DBAL\Migrations\Tests\Stub\Version2Test;
+use Doctrine\DBAL\Migrations\Tests\Stub\Version3Test;
+use Doctrine\DBAL\Migrations\Version;
 
 class ConfigurationTest extends MigrationTestCase
 {
@@ -79,7 +83,7 @@ class ConfigurationTest extends MigrationTestCase
         $config = $this->getSqliteConfiguration();
 
         $this->setExpectedException(
-            'Doctrine\DBAL\Migrations\MigrationException',
+            MigrationException::class,
             'Could not find migration version 1234'
         );
         $config->getVersion(1234);
@@ -88,13 +92,13 @@ class ConfigurationTest extends MigrationTestCase
     public function testRegisterMigration()
     {
         $config = $this->getSqliteConfiguration();
-        $config->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $config->registerMigration(1234, Version1Test::class);
 
         $this->assertEquals(1, count($config->getMigrations()), "One Migration registered.");
         $this->assertTrue($config->hasVersion(1234));
 
         $version = $config->getVersion(1234);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Version', $version);
+        $this->assertInstanceOf(Version::class, $version);
         $this->assertEquals(1234, $version->getVersion());
         $this->assertFalse($version->isMigrated());
     }
@@ -103,39 +107,39 @@ class ConfigurationTest extends MigrationTestCase
     {
         $config = $this->getSqliteConfiguration();
         $config->registerMigrations([
-            1234 => 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test',
-            1235 => 'Doctrine\DBAL\Migrations\Tests\Stub\Version2Test',
+            1234 => Version1Test::class,
+            1235 => Version2Test::class,
         ]);
 
         $this->assertEquals(2, count($config->getMigrations()), "Two Migration registered.");
 
         $version = $config->getVersion(1234);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Version', $version);
+        $this->assertInstanceOf(Version::class, $version);
 
         $version = $config->getVersion(1235);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Version', $version);
+        $this->assertInstanceOf(Version::class, $version);
     }
 
     public function testRegisterDuplicateVersion()
     {
         $config = $this->getSqliteConfiguration();
 
-        $config->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $config->registerMigration(1234, Version1Test::class);
 
         $this->setExpectedException(
-            'Doctrine\DBAL\Migrations\MigrationException',
+            MigrationException::class,
             'Migration version 1234 already registered with class Doctrine\DBAL\Migrations\Version'
         );
-        $config->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $config->registerMigration(1234, Version1Test::class);
     }
 
     public function testPreviousCurrentNextLatestVersion()
     {
         $config = $this->getSqliteConfiguration();
         $config->registerMigrations([
-            1234 => 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test',
-            1235 => 'Doctrine\DBAL\Migrations\Tests\Stub\Version2Test',
-            1236 => 'Doctrine\DBAL\Migrations\Tests\Stub\Version3Test',
+            1234 => Version1Test::class,
+            1235 => Version2Test::class,
+            1236 => Version3Test::class,
         ]);
 
         $this->assertSame(null, $config->getPrevVersion(), "no prev version");
@@ -177,7 +181,7 @@ class ConfigurationTest extends MigrationTestCase
     {
         $config = $this->getSqliteConfiguration();
 
-        $config->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $config->registerMigration(1234, Version1Test::class);
         $this->assertEquals([1234], $config->getAvailableVersions());
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -21,6 +21,8 @@ namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Migration;
+use Doctrine\DBAL\Migrations\MigrationException;
+use Doctrine\DBAL\Migrations\OutputWriter;
 use \Mockery as m;
 
 /**
@@ -44,7 +46,7 @@ class MigrationTest extends MigrationTestCase
         $migration = new Migration($this->config);
 
         $this->setExpectedException(
-            'Doctrine\DBAL\Migrations\MigrationException',
+            MigrationException::class,
             'Could not find migration version 1234'
         );
         $migration->migrate('1234');
@@ -76,7 +78,7 @@ class MigrationTest extends MigrationTestCase
      */
     public function testGetSql($to)
     {
-        $migrationMock = m::mock('Doctrine\DBAL\Migrations\Migration');
+        $migrationMock = m::mock(Migration::class);
         $migrationMock->makePartial();
         $expected = 'something';
         $migrationMock->shouldReceive('migrate')->with($to, true)->andReturn($expected);
@@ -109,10 +111,10 @@ class MigrationTest extends MigrationTestCase
         $sqlWriter = m::instanceMock('overload:Doctrine\DBAL\Migrations\SqlFileWriter');
         $sqlWriter->shouldReceive('write')->with(m::type('array'), m::anyOf('up', 'down'))->andReturn($expectedReturn);
 
-        $outputWriter = m::mock('Doctrine\DBAL\Migrations\OutputWriter');
+        $outputWriter = m::mock(OutputWriter::class);
         $outputWriter->shouldReceive('write');
 
-        $config = m::mock('Doctrine\DBAL\Migrations\Configuration\Configuration')
+        $config = m::mock(Configuration::class)
             ->makePartial();
         $config->shouldReceive('getCurrentVersion')->andReturn($from);
         $config->shouldReceive('getOutputWriter')->andReturn($outputWriter);

--- a/tests/Doctrine/DBAL/Migrations/Tests/SqlFileWriterTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/SqlFileWriterTest.php
@@ -19,6 +19,9 @@
 
 namespace Doctrine\DBAL\Migrations\Tests;
 
+use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Exception\InvalidArgumentException;
+use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\SqlFileWriter;
 use Doctrine\DBAL\Migrations\Version;
 use \Mockery as m;
@@ -31,43 +34,43 @@ class SqlFileWriterTest extends MigrationTestCase
 
     public function setUp()
     {
-        $this->ow = m::mock('Doctrine\DBAL\Migrations\OutputWriter');
+        $this->ow = m::mock(OutputWriter::class);
     }
 
     public function testGoodConstructor()
     {
         $instance = new SqlFileWriter('version', 'test', '/tmp', $this->ow);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\SqlFileWriter', $instance);
+        $this->assertInstanceOf(SqlFileWriter::class, $instance);
     }
 
     public function testConstructorEmptyColumnName()
     {
         $expectedException = class_exists('Doctrine\DBAL\Exception\InvalidArgumentException') ?
-            'Doctrine\DBAL\Exception\InvalidArgumentException' :
-            'Doctrine\DBAL\DBALException';
+            InvalidArgumentException::class :
+            DBALException::class;
         $this->setExpectedException($expectedException);
         $instance = new SqlFileWriter('', 'test', '/tmp', $this->ow);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\SqlFileWriter', $instance);
+        $this->assertInstanceOf(SqlFileWriter::class, $instance);
     }
 
     public function testConstructorEmptyTableName()
     {
         $expectedException = class_exists('Doctrine\DBAL\Exception\InvalidArgumentException') ?
-            'Doctrine\DBAL\Exception\InvalidArgumentException' :
-            'Doctrine\DBAL\DBALException';
+            InvalidArgumentException::class :
+            DBALException::class;
         $this->setExpectedException($expectedException);
         $instance = new SqlFileWriter('version', '', '/tmp', $this->ow);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\SqlFileWriter', $instance);
+        $this->assertInstanceOf(SqlFileWriter::class, $instance);
     }
 
     public function testConstructorEmptyDestPath()
     {
         $expectedException = class_exists('Doctrine\DBAL\Exception\InvalidArgumentException') ?
-            'Doctrine\DBAL\Exception\InvalidArgumentException' :
-            'Doctrine\DBAL\DBALException';
+            InvalidArgumentException::class :
+            DBALException::class;
         $this->setExpectedException($expectedException);
         $instance = new SqlFileWriter('test', '', $this->ow);
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\SqlFileWriter', $instance);
+        $this->assertInstanceOf(SqlFileWriter::class, $instance);
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -2,12 +2,17 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Configuration\YamlConfiguration;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\Output;
 
 class AbstractCommandTest extends MigrationTestCase
 {
@@ -21,17 +26,17 @@ class AbstractCommandTest extends MigrationTestCase
      * @param bool $noConnection
      * @param mixed $helperSet
      *
-     * @return \Doctrine\DBAL\Migrations\Configuration\Configuration
+     * @return Configuration
      */
     public function invokeMigrationConfigurationGetter($input, $configuration = null, $noConnection = false, $helperSet = null)
     {
-        $class = new \ReflectionClass('Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand');
+        $class = new \ReflectionClass(AbstractCommand::class);
         $method = $class->getMethod('getMigrationConfiguration');
         $method->setAccessible(true);
 
-        /** @var \Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand $command */
+        /** @var AbstractCommand $command */
         $command = $this->getMockForAbstractClass(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand',
+            AbstractCommand::class,
             ['command']
         );
 
@@ -51,7 +56,7 @@ class AbstractCommandTest extends MigrationTestCase
             $command->setMigrationConfiguration($configuration);
         }
 
-        $output = $this->getMockBuilder('Symfony\Component\Console\Output\Output')
+        $output = $this->getMockBuilder(Output::class)
             ->setMethods(['doWrite', 'writeln'])
             ->getMock();
 
@@ -67,7 +72,7 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testInjectedMigrationConfigurationIsBeingReturned()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -78,7 +83,7 @@ class AbstractCommandTest extends MigrationTestCase
             ->will($this->returnValue(null));
 
         $configuration = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -90,7 +95,7 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testMigrationConfigurationReturnsConnectionFromHelperSet()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -102,7 +107,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $actualConfiguration);
+        $this->assertInstanceOf(Configuration::class, $actualConfiguration);
         $this->assertEquals($this->getSqliteConnection(), $actualConfiguration->getConnection());
     }
 
@@ -111,7 +116,7 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testMigrationConfigurationReturnsConnectionFromInputOption()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -124,7 +129,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $actualConfiguration);
+        $this->assertInstanceOf(Configuration::class, $actualConfiguration);
         $this->assertEquals($this->getSqliteConnection(), $actualConfiguration->getConnection());
     }
 
@@ -133,7 +138,7 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testMigrationConfigurationReturnsConfigurationFileOption()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -146,7 +151,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\YamlConfiguration', $actualConfiguration);
+        $this->assertInstanceOf(YamlConfiguration::class, $actualConfiguration);
         $this->assertEquals('name', $actualConfiguration->getName());
         $this->assertEquals('migrations_table_name', $actualConfiguration->getMigrationsTableName());
         $this->assertEquals('migrations_namespace', $actualConfiguration->getMigrationsNamespace());
@@ -157,14 +162,14 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testMigrationConfigurationReturnsConnectionFromConfigurationIfNothingElseIsProvided()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->getMock();
 
-        $configuration = new \Doctrine\DBAL\Migrations\Configuration\Configuration($this->getSqliteConnection());
+        $configuration = new Configuration($this->getSqliteConnection());
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input, $configuration, true);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $actualConfiguration);
+        $this->assertInstanceOf(Configuration::class, $actualConfiguration);
         $this->assertEquals($this->getSqliteConnection(), $actualConfiguration->getConnection());
         $this->assertEquals('doctrine_migration_versions', $actualConfiguration->getMigrationsTableName());
         $this->assertEquals(null, $actualConfiguration->getMigrationsNamespace());
@@ -177,13 +182,13 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testMigrationConfigurationReturnsErrorWhenNoConnectionIsProvided()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->getMock();
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input, null, true);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $actualConfiguration);
+        $this->assertInstanceOf(Configuration::class, $actualConfiguration);
         $this->assertEquals($this->getSqliteConnection(), $actualConfiguration->getConnection());
         $this->assertEquals('doctrine_migration_versions', $actualConfiguration->getMigrationsTableName());
         $this->assertEquals(null, $actualConfiguration->getMigrationsNamespace());
@@ -191,7 +196,7 @@ class AbstractCommandTest extends MigrationTestCase
 
     public function testMigrationsConfigurationFromCommandLineOverridesInjectedConfiguration()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -203,13 +208,13 @@ class AbstractCommandTest extends MigrationTestCase
             ]));
 
         $configuration = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input, $configuration);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\YamlConfiguration', $actualConfiguration);
+        $this->assertInstanceOf(YamlConfiguration::class, $actualConfiguration);
         $this->assertEquals('name', $actualConfiguration->getName());
         $this->assertEquals('migrations_table_name', $actualConfiguration->getMigrationsTableName());
         $this->assertEquals('migrations_namespace', $actualConfiguration->getMigrationsNamespace());
@@ -221,7 +226,7 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testInjectedConfigurationIsPreferedOverConfigFileIsCurrentWorkingDirectory()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -233,7 +238,7 @@ class AbstractCommandTest extends MigrationTestCase
             ]));
 
         $configuration = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -248,12 +253,12 @@ class AbstractCommandTest extends MigrationTestCase
      */
     public function testMigrationsConfigurationFromConfighelperInHelperset()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->getMock();
 
         $configuration = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -268,13 +273,13 @@ class AbstractCommandTest extends MigrationTestCase
 
     public function invokeAbstractCommandConfirmation($input, $helper, $response="y", $question="There is no question?")
     {
-        $class = new \ReflectionClass('Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand');
+        $class = new \ReflectionClass(AbstractCommand::class);
         $method = $class->getMethod('askConfirmation');
         $method->setAccessible(true);
 
-        /** @var \Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand $command */
+        /** @var AbstractCommand $command */
         $command = $this->getMockForAbstractClass(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand',
+            AbstractCommand::class,
             ['command']
         );
 
@@ -291,7 +296,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $command->setHelperSet($helperSet);
 
-        $output = $this->getMockBuilder('Symfony\Component\Console\Output\Output')
+        $output = $this->getMockBuilder(Output::class)
             ->setMethods(['doWrite', 'writeln'])
             ->getMock();
 
@@ -303,7 +308,7 @@ class AbstractCommandTest extends MigrationTestCase
 
     public function testAskConfirmation()
     {
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -2,21 +2,23 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\ArrayInput;
 
 class MigrateCommandTest extends MigrationTestCase
 {
 
     public function testGetVersionNameFromAlias()
     {
-        $class = new \ReflectionClass('Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand');
+        $class = new \ReflectionClass(MigrateCommand::class);
         $method = $class->getMethod('getVersionNameFromAlias');
         $method->setAccessible(true);
 
-        $configuration = $this->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+        $configuration = $this->getMockBuilder(Configuration::class)
             ->setConstructorArgs([$this->getSqliteConnection()])
             ->setMethods(['resolveVersionAlias'])
             ->getMock();
@@ -55,7 +57,7 @@ class MigrateCommandTest extends MigrationTestCase
             );
         }
 
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['isInteractive'])
             ->getMock();
@@ -66,13 +68,13 @@ class MigrateCommandTest extends MigrationTestCase
 
         $output = $this->getOutputStream();
 
-        $class = new \ReflectionClass('Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand');
+        $class = new \ReflectionClass(MigrateCommand::class);
         $method = $class->getMethod('canExecute');
         $method->setAccessible(true);
 
         /** @var \Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand $command */
         $command = $this->getMock(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand',
+            MigrateCommand::class,
             ['getHelperSet']
         );
 
@@ -96,7 +98,7 @@ class MigrateCommandTest extends MigrationTestCase
         $this->assertEquals(false, $method->invokeArgs($command, ['test', $input, $output]));
 
         //should return true if non interactive
-        $input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['isInteractive'])
             ->getMock();

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
@@ -2,7 +2,9 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class MigrationStatusTest extends MigrationTestCase
@@ -44,7 +46,7 @@ class MigrationStatusTest extends MigrationTestCase
     protected function assertVersion($alias, $version, $label, $output)
     {
         $command = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand')
+            ->getMockBuilder(StatusCommand::class)
             ->setConstructorArgs(['migrations:status'])
             ->setMethods(
                 [
@@ -53,7 +55,7 @@ class MigrationStatusTest extends MigrationTestCase
             )
             ->getMock();
 
-        $configuration = $this->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+        $configuration = $this->getMockBuilder(Configuration::class)
             ->setConstructorArgs([$this->getSqliteConnection()])
             ->setMethods(['resolveVersionAlias', 'getDateTime', 'getAvailableVersions'])
             ->getMock();
@@ -102,7 +104,7 @@ class MigrationStatusTest extends MigrationTestCase
     public function testIfAmountNewMigrationsIsCorrectWithUnavailableMigrations()
     {
         $command = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand')
+            ->getMockBuilder(StatusCommand::class)
             ->setConstructorArgs(['migrations:status'])
             ->setMethods(
                 [
@@ -111,7 +113,7 @@ class MigrationStatusTest extends MigrationTestCase
             )
             ->getMock();
 
-        $configuration = $this->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+        $configuration = $this->getMockBuilder(Configuration::class)
             ->setConstructorArgs([$this->getSqliteConnection()])
             ->setMethods(['getMigratedVersions', 'getAvailableVersions', 'getCurrentVersion'])
             ->getMock();

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+use Doctrine\DBAL\Migrations\Tests\Stub\Version1Test;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
 use InvalidArgumentException;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -17,7 +19,7 @@ class MigrationVersionTest extends MigrationTestCase
     public function setUp()
     {
         $this->command = $this
-            ->getMockBuilder('Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand')
+            ->getMockBuilder(VersionCommand::class)
             ->setConstructorArgs(['migrations:version'])
             ->setMethods(['getMigrationConfiguration'])
             ->getMock();
@@ -38,11 +40,11 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testAddRangeOption()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1235, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1239, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1240, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
+        $this->configuration->registerMigration(1234, Version1Test::class);
+        $this->configuration->registerMigration(1235, Version1Test::class);
+        $this->configuration->registerMigration(1239, Version1Test::class);
+        $this->configuration->registerMigration(1240, Version1Test::class);
 
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(
@@ -150,11 +152,11 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testDeleteRangeOption()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1235, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1239, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1240, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
+        $this->configuration->registerMigration(1234, Version1Test::class);
+        $this->configuration->registerMigration(1235, Version1Test::class);
+        $this->configuration->registerMigration(1239, Version1Test::class);
+        $this->configuration->registerMigration(1240, Version1Test::class);
 
         $this->configuration->getVersion('1233')->markMigrated();
         $this->configuration->getVersion('1234')->markMigrated();
@@ -186,11 +188,11 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testAddAllOption()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1235, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1239, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1240, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
+        $this->configuration->registerMigration(1234, Version1Test::class);
+        $this->configuration->registerMigration(1235, Version1Test::class);
+        $this->configuration->registerMigration(1239, Version1Test::class);
+        $this->configuration->registerMigration(1240, Version1Test::class);
 
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(
@@ -215,11 +217,11 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testDeleteAllOption()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1235, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1239, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1240, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
+        $this->configuration->registerMigration(1234, Version1Test::class);
+        $this->configuration->registerMigration(1235, Version1Test::class);
+        $this->configuration->registerMigration(1239, Version1Test::class);
+        $this->configuration->registerMigration(1240, Version1Test::class);
 
         $this->configuration->getVersion('1233')->markMigrated();
         $this->configuration->getVersion('1234')->markMigrated();
@@ -247,9 +249,9 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testAddOption()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1235, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
+        $this->configuration->registerMigration(1234, Version1Test::class);
+        $this->configuration->registerMigration(1235, Version1Test::class);
 
         $this->configuration->getVersion('1233')->markMigrated();
 
@@ -274,9 +276,9 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testDeleteOption()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1234, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
-        $this->configuration->registerMigration(1235, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
+        $this->configuration->registerMigration(1234, Version1Test::class);
+        $this->configuration->registerMigration(1235, Version1Test::class);
 
         $this->configuration->getVersion('1234')->markMigrated();
 
@@ -304,7 +306,7 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testAddOptionIfVersionAlreadyMigrated()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
         $this->configuration->getVersion('1233')->markMigrated();
 
         $commandTester = new CommandTester($this->command);
@@ -327,7 +329,7 @@ class MigrationVersionTest extends MigrationTestCase
      */
     public function testDeleteOptionIfVersionNotMigrated()
     {
-        $this->configuration->registerMigration(1233, 'Doctrine\DBAL\Migrations\Tests\Stub\Version1Test');
+        $this->configuration->registerMigration(1233, Version1Test::class);
 
         $commandTester = new CommandTester($this->command);
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
@@ -2,10 +2,13 @@
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Helper;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Configuration\ArrayConfiguration;
+use Doctrine\DBAL\Migrations\Configuration\JsonConfiguration;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
 use Doctrine\ORM\Configuration;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use InvalidArgumentException;
@@ -44,7 +47,7 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $this->connection = $this->getSqliteConnection();
 
-        $this->input = $this->getMockBuilder('Symfony\Component\Console\Input\ArrayInput')
+        $this->input = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -54,7 +57,7 @@ class ConfigurationHelperTest extends MigrationTestCase
     {
         $configurationHelper = new ConfigurationHelper($this->connection, $this->configuration);
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper', $configurationHelper);
+        $this->assertInstanceOf(ConfigurationHelper::class, $configurationHelper);
     }
 
     //used in other tests to see if xml or yaml or yml config files are loaded.
@@ -118,7 +121,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $configurationHelper = new ConfigurationHelper($this->getSqliteConnection());
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\ArrayConfiguration', $migrationConfig);
+        $this->assertInstanceOf(ArrayConfiguration::class, $migrationConfig);
         $this->assertSame('DoctrineMigrationsTest', $migrationConfig->getMigrationsNamespace());
     }
 
@@ -131,7 +134,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $configurationHelper = new ConfigurationHelper($this->getSqliteConnection());
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\JsonConfiguration', $migrationConfig);
+        $this->assertInstanceOf(JsonConfiguration::class, $migrationConfig);
         $this->assertSame('DoctrineMigrationsTest', $migrationConfig->getMigrationsNamespace());
     }
 
@@ -163,7 +166,7 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $migrationConfig);
+        $this->assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
 
         $this->assertStringMatchesFormat("Loading configuration from the integration code of your framework (setter).", trim($this->getOutputStreamContent($this->output)));
     }
@@ -179,7 +182,7 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $migrationConfig);
+        $this->assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
         $this->assertStringMatchesFormat("Loading configuration from command option: %a", $this->getOutputStreamContent($this->output));
     }
 
@@ -194,7 +197,7 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Configuration\Configuration', $migrationConfig);
+        $this->assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
         $this->assertStringMatchesFormat("", $this->getOutputStreamContent($this->output));
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/MigrationDirectoryHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/MigrationDirectoryHelperTest.php
@@ -12,7 +12,7 @@ class MigrationDirectoryHelperTest extends MigrationTestCase
     {
         $mirationDirectoryHelper = new MigrationDirectoryHelper($this->getSqliteConfiguration());
 
-        $this->assertInstanceOf('Doctrine\DBAL\Migrations\Tools\Console\Helper\MigrationDirectoryHelper', $mirationDirectoryHelper);
+        $this->assertInstanceOf(MigrationDirectoryHelper::class, $mirationDirectoryHelper);
     }
 
     public function testMigrationDirectoryHelperReturnConfiguredDir() {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/MigrationsVersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/MigrationsVersionTest.php
@@ -5,7 +5,7 @@ use Doctrine\DBAL\Migrations\MigrationsVersion;
 
 class MigrationsVersionTest extends \PHPUnit_Framework_TestCase {
 
-    private $MigrationVersionClass = 'Doctrine\DBAL\Migrations\MigrationsVersion';
+    private $MigrationVersionClass = MigrationsVersion::class;
 
     public function testVersionNumber()
     {

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -20,6 +20,11 @@
 namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\MigrationException;
+use Doctrine\DBAL\Migrations\OutputWriter;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyDescription;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyException;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSql;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSqlWithParam;
 use Doctrine\DBAL\Migrations\Version;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
@@ -50,7 +55,7 @@ class VersionTest extends MigrationTestCase
     public function testCreateVersion()
     {
         $version = new Version(new Configuration($this->getSqliteConnection()), $versionName = '003',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy');
+            VersionDummy::class);
         $this->assertEquals($versionName, $version->getVersion());
     }
 
@@ -62,7 +67,7 @@ class VersionTest extends MigrationTestCase
         $versionName = '003';
         $versionDescription = 'My super migration';
         $version = new Version(new Configuration($this->getSqliteConnection()), $versionName,
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyDescription');
+            VersionDummyDescription::class);
         $this->assertEquals($versionName, $version->getVersion());
         $this->assertEquals($versionDescription, $version->getMigration()->getDescription());
     }
@@ -72,17 +77,17 @@ class VersionTest extends MigrationTestCase
      */
     public function testOutputQueryTimeAllQueries()
     {
-        $outputWriterMock = $this->getMock('Doctrine\DBAL\Migrations\OutputWriter');
+        $outputWriterMock = $this->getMock(OutputWriter::class);
         $outputWriterMock->expects($this->once())->method('write');
         $configuration = new Configuration($this->getSqliteConnection(), $outputWriterMock);
-        $reflectionVersion = new \ReflectionClass('Doctrine\DBAL\Migrations\Version');
+        $reflectionVersion = new \ReflectionClass(Version::class);
         $method = $reflectionVersion->getMethod('outputQueryTime');
         $method->setAccessible(true);
 
         $version = new Version(
             $configuration,
             $versionName = '003',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy'
+            VersionDummy::class
         );
         $this->assertNull($method->invoke($version, 0, true));
     }
@@ -92,17 +97,17 @@ class VersionTest extends MigrationTestCase
      */
     public function testOutputQueryTimeNotAllQueries()
     {
-        $outputWriterMock = $this->getMock('Doctrine\DBAL\Migrations\OutputWriter');
+        $outputWriterMock = $this->getMock(OutputWriter::class);
         $outputWriterMock->expects($this->exactly(0))->method('write');
         $configuration = new Configuration($this->getSqliteConnection(), $outputWriterMock);
-        $reflectionVersion = new \ReflectionClass('Doctrine\DBAL\Migrations\Version');
+        $reflectionVersion = new \ReflectionClass(Version::class);
         $method = $reflectionVersion->getMethod('outputQueryTime');
         $method->setAccessible(true);
 
         $version = new Version(
             $configuration,
             $versionName = '003',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy'
+            VersionDummy::class
         );
         $this->assertNull($method->invoke($version, 0, false));
     }
@@ -117,9 +122,9 @@ class VersionTest extends MigrationTestCase
         $version = new Version(
             $configuration,
             $versionName = '003',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy'
+            VersionDummy::class
         );
-        $reflectionVersion = new \ReflectionClass('Doctrine\DBAL\Migrations\Version');
+        $reflectionVersion = new \ReflectionClass(Version::class);
         $stateProperty = $reflectionVersion->getProperty('state');
         $stateProperty->setAccessible(true);
         $stateProperty->setValue($version, $state);
@@ -150,7 +155,7 @@ class VersionTest extends MigrationTestCase
         $version = new Version(
             $configuration,
             $versionName = '003',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy'
+            VersionDummy::class
         );
         $this->assertNull($version->addSql('SELECT * FROM foo'));
         $this->assertNull($version->addSql(['SELECT * FROM foo']));
@@ -169,12 +174,12 @@ class VersionTest extends MigrationTestCase
     {
         $version = 1;
 
-        $outputWriter = m::mock('Doctrine\DBAL\Migrations\OutputWriter');
+        $outputWriter = m::mock(OutputWriter::class);
         $outputWriter->shouldReceive('write');
 
         $connection = $this->getSqliteConnection();
 
-        $config = m::mock('Doctrine\DBAL\Migrations\Configuration\Configuration')
+        $config = m::mock(Configuration::class)
             ->makePartial();
         $config->shouldReceive('getOutputWriter')->andReturn($outputWriter);
         $config->shouldReceive('getConnection')->andReturn($connection);
@@ -210,7 +215,7 @@ class VersionTest extends MigrationTestCase
         $version = new Version(
             $this->config,
             $versionName = '003',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy'
+            VersionDummy::class
         );
 
         $version->execute('up');
@@ -230,7 +235,7 @@ class VersionTest extends MigrationTestCase
         $version = new Version(
             $this->config,
             $versionName = '004',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyException'
+            VersionDummyException::class
         );
 
         try {
@@ -253,7 +258,7 @@ class VersionTest extends MigrationTestCase
         $version = new Version(
             $this->config,
             $versionName = '005',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSql'
+            VersionOutputSql::class
         );
 
         $this->assertContains('Select 1', $version->execute('up'));
@@ -295,7 +300,7 @@ class VersionTest extends MigrationTestCase
         $version = new Version(
             $configuration,
             $versionName = '005',
-            'Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSql'
+            VersionOutputSql::class
         );
         $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations';
 


### PR DESCRIPTION
This PR

* [x] makes use of the `class` keyword instead of referring to class names using string literals

Follows #393.

:information_desk_person: Let me know if you prefer to get rid of FQCNs within this PR as well, otherwise I will follow up!