### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -17,10 +17,10 @@
  * <http://www.doctrine-project.org>.
  */
 
-$autoloadFiles = array(
+$autoloadFiles = [
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php'
-);
+];
 
 $autoloader = false;
 foreach ($autoloadFiles as $autoloadFile) {
@@ -38,7 +38,7 @@ if (!$autoloader) {
 }
 
 // Support for using the Doctrine ORM convention of providing a `cli-config.php` file.
-$directories = array(getcwd(), getcwd() . DIRECTORY_SEPARATOR . 'config');
+$directories = [getcwd(), getcwd() . DIRECTORY_SEPARATOR . 'config'];
 
 $configFile = null;
 foreach ($directories as $directory) {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
@@ -36,7 +36,7 @@ class ConsoleRunner
      *
      * @return void
      */
-    public static function run(HelperSet $helperSet, $commands = array())
+    public static function run(HelperSet $helperSet, $commands = [])
     {
         $cli = self::createApplication($helperSet, $commands);
         $cli->run();
@@ -51,7 +51,7 @@ class ConsoleRunner
      *
      * @return \Symfony\Component\Console\Application
      */
-    public static function createApplication(HelperSet $helperSet, $commands = array())
+    public static function createApplication(HelperSet $helperSet, $commands = [])
     {
         $cli = new Application('Doctrine Migrations', MigrationsVersion::VERSION());
         $cli->setCatchExceptions(true);
@@ -69,14 +69,14 @@ class ConsoleRunner
      */
     public static function addCommands(Application $cli)
     {
-        $cli->addCommands(array(
+        $cli->addCommands([
             new Command\ExecuteCommand(),
             new Command\GenerateCommand(),
             new Command\LatestCommand(),
             new Command\MigrateCommand(),
             new Command\StatusCommand(),
             new Command\VersionCommand(),
-        ));
+        ]);
 
         if ($cli->getHelperSet()->has('em')) {
             $cli->add(new Command\DiffCommand());

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -102,13 +102,13 @@ class ConfigurationHelper extends Helper
 
     private function loadConfig($config, OutputWriter $outputWriter)
     {
-        $map = array(
+        $map = [
             'xml'   => XmlConfiguration::class,
             'yaml'  => YamlConfiguration::class,
             'yml'   => YamlConfiguration::class,
             'php'   => ArrayConfiguration::class,
             'json'  => JsonConfiguration::class,
-        );
+        ];
 
         $info = pathinfo($config);
         // check we can support this file type

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.php
@@ -1,9 +1,9 @@
 <?php
-return array(
+return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'migrations_namespace' => 'DoctrineMigrationsTest',
 'table_name'           => 'doctrine_migration_versions_test',
 'column_name'          => 'doctrine_migration_column_test',
 'migrations_directory' => '.',
-'migrations'           => array()
-);
+'migrations'           => []
+];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_invalid.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_invalid.php
@@ -1,4 +1,4 @@
 <?php
-return array(
+return [
 'OptionThatDoesNotExists' => 'Doctrine Sandbox Migrations',
-);
+];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list.php
@@ -1,5 +1,5 @@
 <?php
-return array(
+return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations'           => [
@@ -16,4 +16,4 @@ return array(
         "version" => "Version3Test",
     ]
 ]
-);
+];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list2.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list2.php
@@ -1,5 +1,5 @@
 <?php
-return array(
+return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations'           => [
@@ -19,4 +19,4 @@ return array(
             "version" => "Version3Test",
         ]
 ]
-);
+];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.php
@@ -1,8 +1,8 @@
 <?php
-return array(
+return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'migrations_namespace' => 'DoctrineMigrationsTest',
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations_directory' => '.',
-'migrations'           => array()
-);
+'migrations'           => []
+];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.php
@@ -1,8 +1,8 @@
 <?php
-return array(
+return [
     'name'                 => 'Doctrine Sandbox Migrations',
     'migrations_directory' => '.',
     'migrations_namespace' => 'DoctrineMigrationsTest',
     'table_name'           => 'doctrine_migration_versions_test',
-    'migrations'           => array()
-);
+    'migrations'           => []
+];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -69,13 +69,13 @@ class OrmSchemaProviderTest extends MigrationTestCase
 
     public function notEntityManagers()
     {
-        return array(
-            array(new \stdClass),
-            array(false),
-            array(1),
-            array('oops'),
-            array(1.0),
-        );
+        return [
+            [new \stdClass],
+            [false],
+            [1],
+            ['oops'],
+            [1.0],
+        ];
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files/config.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files/config.php
@@ -1,7 +1,7 @@
 <?php
-return array(
+return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'migrations_namespace' => 'DoctrineMigrationsTest',
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations_directory' => 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files'
-);
+];


### PR DESCRIPTION
This PR

* [x] uses short array syntax

:information_desk_person: Fixed running

```
$ composer global require fabpot/php-cs-fixer
$ php-cs-fixer fix  --using-cache=0 --rules=short_array_syntax bin
$ php-cs-fixer fix  --using-cache=0 --rules=short_array_syntax lib
$ php-cs-fixer fix  --using-cache=0 --rules=short_array_syntax tests
```