### PR TITLE
Fix: Case-insensitive method calls and types

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php
@@ -59,7 +59,7 @@ abstract class AbstractFileConfiguration extends Configuration
         'migrations' => 'loadMigrations',
     ];
 
-    protected function setConfiguration(Array $config)
+    protected function setConfiguration(array $config)
     {
         foreach($config as $configurationKey => $configurationValue) {
             if (!isset($this->configurationProperties[$configurationKey])) {

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -322,7 +322,7 @@ class Version
         } catch (SkipMigrationException $e) {
             if ($transaction) {
                 //only rollback transaction if in transactional mode
-                $this->connection->rollback();
+                $this->connection->rollBack();
             }
 
             if ($dryRun === false) {
@@ -348,7 +348,7 @@ class Version
 
             if ($transaction) {
                 //only rollback transaction if in transactional mode
-                $this->connection->rollback();
+                $this->connection->rollBack();
             }
 
             $this->state = self::STATE_NONE;

--- a/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -70,7 +70,7 @@ class OrmSchemaProviderTest extends MigrationTestCase
     public function notEntityManagers()
     {
         return array(
-            array(new \stdclass),
+            array(new \stdClass),
             array(false),
             array(1),
             array('oops'),

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
@@ -90,7 +90,7 @@ class MigrationStatusTest extends MigrationTestCase
         );
 
         $textOutput = $commandTester->getDisplay();
-        $this->assertRegexp('/\s+>> ' . $label . ':\s+' . preg_quote($output) . '/m', $textOutput);
+        $this->assertRegExp('/\s+>> ' . $label . ':\s+' . preg_quote($output) . '/m', $textOutput);
     }
 
     /**
@@ -146,6 +146,6 @@ class MigrationStatusTest extends MigrationTestCase
         );
 
         $textOutput = $commandTester->getDisplay();
-        $this->assertRegexp('/\s+>> New Migrations:\s+1/m', $textOutput);
+        $this->assertRegExp('/\s+>> New Migrations:\s+1/m', $textOutput);
     }
 }


### PR DESCRIPTION
This PR

* [x] fixes case-insensitive method calls and references to types