### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
@@ -25,7 +25,7 @@ class AbstractMigrationTest extends MigrationTestCase
     protected $outputWriter;
     protected $output;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->outputWriter = $this->getOutputWriter();
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -28,7 +28,7 @@ class FunctionalTest extends MigrationTestCase
      */
     private $connection;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->connection = $this->getSqliteConnection();
         $this->config = new Configuration($this->connection);

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -34,7 +34,7 @@ class MigrationTest extends MigrationTestCase
     /** @var Configuration */
     private $config;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->config = new Configuration($this->getSqliteConnection());
         $this->config->setMigrationsDirectory(__DIR__ . DIRECTORY_SEPARATOR . 'Stub/migration-empty-folder');

--- a/tests/Doctrine/DBAL/Migrations/Tests/SqlFileWriterTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/SqlFileWriterTest.php
@@ -32,7 +32,7 @@ class SqlFileWriterTest extends MigrationTestCase
     /** @var \Mockery\Mock */
     protected $ow;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->ow = m::mock(OutputWriter::class);
     }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
@@ -16,7 +16,7 @@ class MigrationVersionTest extends MigrationTestCase
     /** @var Configuration */
     private $configuration;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->command = $this
             ->getMockBuilder(VersionCommand::class)

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
@@ -41,7 +41,7 @@ class ConfigurationHelperTest extends MigrationTestCase
      */
     private $input;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->configuration = $this->getSqliteConfiguration();
 


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` in tests to `protected`

:information_desk_person: This is the visibility as declared by the parent - there's no need to increase it.