### PR TITLE
Clean the autogenerated ZIP archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,7 @@
 build/*                 export-ignore
-tests/*                 export-ignore
-.coveralls              export-ignore
-.gitattributes          export-ignore
-.gitignore              export-ignore
-.scrutinizer.yml        export-ignore
-.travis.yml             export-ignore
+/tests                  export-ignore
+/.*                     export-ignore
 box.json                export-ignore
 build.properties.dev    export-ignore
 build.xml               export-ignore
+/phpunit.xml.dist       export-ignore


### PR DESCRIPTION
In the autogenerated ZIP archive I have some files that are uneeded in production:

- `/tests/`
- `/.coveralls.yml`
- `/phpunit.xml.dist`

Let's remove them