### PR TITLE
add migrations:up-to-date command

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Command to show if your schema is up-to-date.
+ */
+class UpToDateCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('migrations:up-to-date')
+            ->setDescription('Tells you if your schema is up-to-date.')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command tells you if your schema is up-to-date:
+
+    <info>%command.full_name%</info>
+EOT
+        );
+
+        parent::configure();
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $configuration = $this->getMigrationConfiguration($input, $output);
+        
+        $migrations = count($configuration->getMigrations());
+        $migratedVersions = count($configuration->getMigratedVersions());
+        $availableMigrations = $migrations - $migratedVersions;
+        
+        if ($availableMigrations === 0) {
+            $output->writeln('<comment>Up-to-date! No migrations to execute.</comment>');
+            return 0;
+        }
+        
+        $output->writeln(sprintf(
+            '<comment>Out-of-date! %u migration%s available to execute.</comment>',
+            $availableMigrations,
+            $availableMigrations > 1 ? 's are' : ' is'
+        ));
+        return 1;
+    }
+}

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
@@ -76,6 +76,7 @@ class ConsoleRunner
             new Command\MigrateCommand(),
             new Command\StatusCommand(),
             new Command\VersionCommand(),
+            new Command\UpToDateCommand(),
         ]);
 
         if ($cli->getHelperSet()->has('em')) {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
+
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\UpToDateCommand;
+use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
+use Doctrine\DBAL\Migrations\Version;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @covers \Doctrine\DBAL\Migrations\Tools\Console\Command\UpToDateCommand
+ */
+class UpToDateCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject|OutputInterface */
+    private $commandOutput;
+    
+    /** @var \PHPUnit_Framework_MockObject_MockObject|Configuration */
+    private $configuration;
+    
+    /** @var \PHPUnit_Framework_MockObject_MockObject|ConfigurationHelper */
+    private $configurationHelper;
+    
+    /** @var UpToDateCommand */
+    private $sut;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        $this->configuration = $this->getMockBuilder(Configuration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->configurationHelper = $this->getMockBuilder(ConfigurationHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $this->commandOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
+        
+        $this->sut = new UpToDateCommand();
+        $this->sut->setHelperSet(new HelperSet(array(
+            'configuration' => $this->configurationHelper,
+        )));
+    }
+
+    /**
+     * @dataProvider dataIsUpToDate
+     * @param Version[] $migrations
+     * @param string[] $migratedVersions
+     * @param int $exitCode
+     */
+    public function testIsUpToDate($migrations, $migratedVersions, $exitCode)
+    {
+        // Set up mocks based on data provider.
+        $this->configurationHelper->method('getMigrationConfig')->willReturn($this->configuration);
+        $this->configuration->method('getMigrations')->willReturn($migrations);
+        $this->configuration->method('getMigratedVersions')->willReturn($migratedVersions);
+        
+        // Command should always tell the user something.
+        $this->commandOutput->expects(self::atLeastOnce())->method('writeln');
+        
+        $actual = $this->sut->execute(new ArrayInput([]), $this->commandOutput);
+
+        // Assert.
+        self::assertSame($exitCode, $actual);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function dataIsUpToDate()
+    {
+        return [
+            'up-to-date' => [
+                [
+                    $this->createVersion('20160614015627'),
+                ],
+                [
+                    '20160614015627',
+                ],
+                0
+            ],
+            'empty-migration-set' => [
+                [
+                    
+                ],
+                [
+                    
+                ],
+                0
+            ],
+            'one-migration-available' => [
+                [
+                    $this->createVersion('20150614015627'),
+                ],
+                [
+                    
+                ],
+                1
+            ],
+            'many-migrations-available' => [
+                [
+                    $this->createVersion('20110614015627'),
+                    $this->createVersion('20120614015627'),
+                    $this->createVersion('20130614015627'),
+                    $this->createVersion('20140614015627'),
+                ],
+                [
+                    '20110614015627',
+                ],
+                1
+            ],
+        ];
+    }
+
+    /**
+     * @param string $migration
+     * @return Version
+     */
+    private function createVersion($migration)
+    {
+        $version = $this->getMockBuilder(Version::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $version->method('getVersion')->willReturn($migration);
+        
+        return $version;
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Doctrine\DBAL\Migrations\Tools\Console\ConsoleRunner;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+
+/**
+ * @covers \Doctrine\DBAL\Migrations\Tools\Console\ConsoleRunner
+ */
+class ConsoleRunnerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var  PHPUnit_Framework_MockObject_MockObject|EntityManagerHelper */
+    private $entityManagerHelper;
+    
+    /** @var Application */
+    private $application;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        
+        $this->application = new Application();
+        $this->entityManagerHelper = $this->getMockBuilder(EntityManagerHelper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testHasExecuteCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:execute'));
+    }
+
+    public function testHasGenerateCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:generate'));
+    }
+
+    public function testHasLatestCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:latest'));
+    }
+
+    public function testHasMigrateCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:migrate'));
+    }
+
+    public function testHasStatusCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:status'));
+    }
+
+    public function testHasVersionCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:version'));
+    }
+
+    public function testHasUpToDateCommand()
+    {
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:up-to-date'));
+    }
+
+    public function testHasDiffCommand()
+    {
+        $this->application->setHelperSet(new HelperSet(array(
+            'em' => $this->entityManagerHelper,
+        )));
+        
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertTrue($this->application->has('migrations:diff'));
+    }
+
+    public function testNotHasDiffCommand()
+    {
+        $this->application->setHelperSet(new HelperSet(array(
+            
+        )));
+
+        ConsoleRunner::addCommands($this->application);
+        
+        self::assertFalse($this->application->has('migrations:diff'));
+    }
+    
+    public function testCreateApplication()
+    {
+        $actual = ConsoleRunner::createApplication(new HelperSet());
+        
+        self::assertInstanceOf(Application::class, $actual);
+    }
+}


### PR DESCRIPTION
add up-to-date command, which simply tells the user whether or not there are migrations to run. returns a non-zero exit code if there are migrations available, which can be used more easily in diagnostic checks and build/deploy processes, without the need to parse output.