### PR TITLE
Add Parameters to the Output of Dry Run Migrations

### DIFF
--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunNamedParams.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunNamedParams.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class VersionDryRunNamedParams extends AbstractMigration
+{
+    public function down(Schema $schema)
+    {
+    }
+
+    public function up(Schema $schema)
+    {
+        $this->addSql('INSERT INTO test VALUES (:one, :two)', [
+            'one' => 'one',
+            'two' => 'two',
+        ]);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunQuestionMarkParams.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunQuestionMarkParams.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class VersionDryRunQuestionMarkParams extends AbstractMigration
+{
+    public function down(Schema $schema)
+    {
+    }
+
+    public function up(Schema $schema)
+    {
+        $this->addSql('INSERT INTO test VALUES (?, ?)', ['one', 'two']);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunTypes.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunTypes.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class VersionDryRunTypes extends AbstractMigration
+{
+    private $value;
+    private $type;
+
+    public function setParam($value, $type)
+    {
+        $this->value = $value;
+        $this->type = $type;
+    }
+
+    public function down(Schema $schema)
+    {
+    }
+
+    public function up(Schema $schema)
+    {
+        $this->addSql('INSERT INTO test VALUES (?)', [$this->value], [$this->type]);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunWithoutParams.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunWithoutParams.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class VersionDryRunWithoutParams extends AbstractMigration
+{
+    public function down(Schema $schema)
+    {
+    }
+
+    public function up(Schema $schema)
+    {
+        $this->addSql('SELECT 1 WHERE 1');
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -46,6 +46,7 @@ use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyDescription;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyException;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunNamedParams;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunTypes;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunQuestionMarkParams;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunWithoutParams;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSql;
@@ -438,5 +439,37 @@ class VersionTest extends MigrationTestCase
         $this->assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
         $this->assertContains('INSERT INTO test VALUES (:one, :two)', $messages[1]);
         $this->assertContains('with parameters (:one => one, :two => two)', $messages[1]);
+    }
+
+    public static function dryRunTypes()
+    {
+        return [
+            'datetime' => [new \DateTime('2016-07-05 01:00:00'), 'datetime', '2016-07-05 01:00:00'],
+            'array' => [['one' => 'two'], 'array', serialize(['one' => 'two'])],
+        ];
+    }
+
+    /**
+     * @dataProvider dryRunTypes
+     */
+    public function testDryRunWithParametersOfComplexTypesCorrectFormatsParameters($value, $type, $output)
+    {
+        $messages = [];
+        $ow = new OutputWriter(function ($msg) use (&$messages) {
+            $messages[] = trim($msg);
+        });
+        $config = new Configuration($this->getSqliteConnection(), $ow);
+        $version = new Version(
+            $config,
+            '006',
+            VersionDryRunTypes::class
+        );
+        $version->getMigration()->setParam($value, $type);
+
+        $version->execute(Version::DIRECTION_UP, true);
+
+        $this->assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
+        $this->assertContains('INSERT INTO test VALUES (?)', $messages[1]);
+        $this->assertContains(sprintf('with parameters (%s)', $output), $messages[1]);
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -45,6 +45,9 @@ use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyDescription;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummyException;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunNamedParams;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunQuestionMarkParams;
+use Doctrine\DBAL\Migrations\Tests\Stub\VersionDryRunWithoutParams;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSql;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSqlWithParam;
 use Doctrine\DBAL\Migrations\Version;
@@ -376,5 +379,64 @@ class VersionTest extends MigrationTestCase
         $sqlMigrationFile = current($sqlFilesDir->getChildren());
         $this->assertInstanceOf(vfsStreamFile::class, $sqlMigrationFile);
         $this->assertNotRegExp('/^\s*#/m', $sqlMigrationFile->getContent());
-    }    
+    }
+
+    public function testDryRunCausesSqlToBeOutputViaTheOutputWriter()
+    {
+        $messages = [];
+        $ow = new OutputWriter(function ($msg) use (&$messages) {
+            $messages[] = trim($msg);
+        });
+        $config = new Configuration($this->getSqliteConnection(), $ow);
+        $version = new Version(
+            $config,
+            '006',
+            VersionDryRunWithoutParams::class
+        );
+
+        $version->execute(Version::DIRECTION_UP, true);
+
+        $this->assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
+        $this->assertContains('SELECT 1 WHERE 1', $messages[1]);
+    }
+
+    public function testDryRunWithQuestionMarkedParamsOutputsParamsWithSqlStatement()
+    {
+        $messages = [];
+        $ow = new OutputWriter(function ($msg) use (&$messages) {
+            $messages[] = trim($msg);
+        });
+        $config = new Configuration($this->getSqliteConnection(), $ow);
+        $version = new Version(
+            $config,
+            '006',
+            VersionDryRunQuestionMarkParams::class
+        );
+
+        $version->execute(Version::DIRECTION_UP, true);
+
+        $this->assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
+        $this->assertContains('INSERT INTO test VALUES (?, ?)', $messages[1]);
+        $this->assertContains('with parameters (one, two)', $messages[1]);
+    }
+
+    public function testDryRunWithNamedParametersOutputsParamsAndNamesWithSqlStatement()
+    {
+        $messages = [];
+        $ow = new OutputWriter(function ($msg) use (&$messages) {
+            $messages[] = trim($msg);
+        });
+        $config = new Configuration($this->getSqliteConnection(), $ow);
+        $version = new Version(
+            $config,
+            '006',
+            VersionDryRunNamedParams::class
+        );
+
+        $version->execute(Version::DIRECTION_UP, true);
+
+        $this->assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
+        $this->assertContains('INSERT INTO test VALUES (:one, :two)', $messages[1]);
+        $this->assertContains('with parameters (:one => one, :two => two)', $messages[1]);
+    }
 }


### PR DESCRIPTION
Closes #186 

Right now this looks like...

```
    -> INSERT INTO whatever VALUES (?, ?) with parameters (one, two)
```

with numeric indices in the param array. If there are string indices, those names are included in the output (under the assumption that they match placeholders in the SQL).

```
    -> INSERT INTO whatever VALUES (:one, :two) with parameters (:one => one, :two => two)
```

The DBAL type classes are used to convert the values to something suitable for output (specifically [Type::convertToDatabaseValue](https://github.com/doctrine/dbal/blob/97f423a42c100c0ea9a8ff78f17a9ed020b8b6bf/lib/Doctrine/DBAL/Types/Type.php#L110).

SQL statements without any params look the same as they do currently.

This is probably a good enough first pass at this, but it's not going to protect users from doing something wonky like...

```php
$this->addSql('INSERT INTO whatever VALUES (?)', [new \stdClass]);
```

and causing it the dryrun fail (granted the migration itself would fail anyway).

In other words: there's not a lot of validation. But that's not necessarily a bad thing. Types aren't validated to make sure they exist before fetching them with `Type::getType(...)`, but that's something thay may help a user catch bugs.