### PR TITLE
Switch the Generated Version Classes to use the Current time in UTC

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -805,13 +805,12 @@ class Configuration
     /**
      * Generate a new migration version. A version is (usually) a datetime string.
      *
-     * @param DateTimeInterface|null $now Defaults to the current time.
+     * @param DateTimeInterface|null $now Defaults to the current time in UTC
      * @return string The newly generated version
      */
     public function generateVersionNumber(\DateTimeInterface $now=null)
     {
-        // defaults to `now` in the current timezone.
-        $now = $now ?: new \DateTime();
+        $now = $now ?: new \DateTime('now', new \DateTimeZone('UTC'));
 
         return $now->format(self::VERSION_FORMAT);
     }

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -55,6 +55,11 @@ class Configuration
     const VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH = 'year_and_month';
 
     /**
+     * The date format for new version numbers
+     */
+    const VERSION_FORMAT = 'YmdHis';
+
+    /**
      * Name of this set of migrations
      *
      * @var string
@@ -795,6 +800,20 @@ class Configuration
 
         $this->migrationsAreOrganizedByYear = $migrationsAreOrganizedByYearAndMonth;
         $this->migrationsAreOrganizedByYearAndMonth = $migrationsAreOrganizedByYearAndMonth;
+    }
+
+    /**
+     * Generate a new migration version. A version is (usually) a datetime string.
+     *
+     * @param DateTimeInterface|null $now Defaults to the current time.
+     * @return string The newly generated version
+     */
+    public function generateVersionNumber(\DateTimeInterface $now=null)
+    {
+        // defaults to `now` in the current timezone.
+        $now = $now ?: new \DateTime();
+
+        return $now->format(self::VERSION_FORMAT);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -121,7 +121,8 @@ EOT
             return;
         }
 
-        $path = $this->generateMigration($configuration, $input, $up, $down);
+        $version = $configuration->generateVersionNumber();
+        $path = $this->generateMigration($configuration, $input, $version, $up, $down);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
     }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -121,8 +121,7 @@ EOT
             return;
         }
 
-        $version = date('YmdHis');
-        $path = $this->generateMigration($configuration, $input, $version, $up, $down);
+        $path = $this->generateMigration($configuration, $input, $up, $down);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
     }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -94,7 +94,8 @@ EOT
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
 
-        $path = $this->generateMigration($configuration, $input);
+        $version = $configuration->generateVersionNumber();
+        $path = $this->generateMigration($configuration, $input, $version);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
     }
@@ -104,7 +105,7 @@ EOT
         return self::$_template;
     }
 
-    protected function generateMigration(Configuration $configuration, InputInterface $input, $up = null, $down = null)
+    protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
     {
         $placeHolders = [
             '<namespace>',
@@ -114,7 +115,7 @@ EOT
         ];
         $replacements = [
             $configuration->getMigrationsNamespace(),
-            $version = $configuration->generateVersionNumber(),
+            $version,
             $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
             $down ? "        " . implode("\n        ", explode("\n", $down)) : null
         ];

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -94,8 +94,7 @@ EOT
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
 
-        $version = date('YmdHis');
-        $path = $this->generateMigration($configuration, $input, $version);
+        $path = $this->generateMigration($configuration, $input);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
     }
@@ -105,7 +104,7 @@ EOT
         return self::$_template;
     }
 
-    protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
+    protected function generateMigration(Configuration $configuration, InputInterface $input, $up = null, $down = null)
     {
         $placeHolders = [
             '<namespace>',
@@ -115,7 +114,7 @@ EOT
         ];
         $replacements = [
             $configuration->getMigrationsNamespace(),
-            $version,
+            $version = $configuration->generateVersionNumber(),
             $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
             $down ? "        " . implode("\n        ", explode("\n", $down)) : null
         ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -145,6 +145,31 @@ class ConfigurationTest extends MigrationTestCase
         $this->assertEquals($expectedResult, $result);
     }
 
+    public function testGenerateVersionNumberFormatsTheDatePassedIn()
+    {
+        $configuration = new Configuration($this->getSqliteConnection());
+        $now = new \DateTime('2016-07-05 01:00:00');
+
+        $version = $configuration->generateVersionNumber($now);
+
+        $this->assertEquals('20160705010000', $version);
+    }
+
+    /**
+     * We don't actually test the "time" part of this, since that would fail
+     * intermittently. Instead we just verify that we get a series of numbers
+     * back. We're really just testing the `?: new \DateTime()` bit of
+     * generateVersionNumber
+     */
+    public function testGenerateVersionNumberWithoutNowUsesTheCurrentTime()
+    {
+        $configuration = new Configuration($this->getSqliteConnection());
+
+        $version = $configuration->generateVersionNumber();
+
+        $this->assertRegExp('/^\d{14}$/', $version);
+    }
+
     public function methodsThatNeedsVersionsLoadedWithAlreadyMigratedMigrations()
     {
         return [

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -156,18 +156,19 @@ class ConfigurationTest extends MigrationTestCase
     }
 
     /**
-     * We don't actually test the "time" part of this, since that would fail
-     * intermittently. Instead we just verify that we get a series of numbers
-     * back. We're really just testing the `?: new \DateTime()` bit of
-     * generateVersionNumber
+     * We don't actually test the full "time" part of this, since that would fail
+     * intermittently. Instead we just verify that we get a version number back
+     * that has the current date, hour, and minute. We're really just testing
+     * the `?: new \DateTime(...)` bit of generateVersionNumber
      */
     public function testGenerateVersionNumberWithoutNowUsesTheCurrentTime()
     {
         $configuration = new Configuration($this->getSqliteConnection());
 
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
         $version = $configuration->generateVersionNumber();
 
-        $this->assertRegExp('/^\d{14}$/', $version);
+        $this->assertRegExp(sprintf('/^%s\d{2}$/', $now->format('YmdHi')), $version);
     }
 
     public function methodsThatNeedsVersionsLoadedWithAlreadyMigratedMigrations()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/CommandTestCase.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/CommandTestCase.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+
+abstract class CommandTestCase extends MigrationTestCase
+{
+    protected $commmand, $app, $config, $connection;
+
+    protected function setUp()
+    {
+        $this->connection = $this->createConnection();
+        $this->config = $this->getMockBuilder(Configuration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->config->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($this->connection);
+        $this->command = $this->createCommand();
+        $this->command->setMigrationConfiguration($this->config);
+        $this->app = new Application();
+        $this->app->add($this->command);
+    }
+
+    abstract protected function createCommand();
+
+    protected function createConnection()
+    {
+        return $this->getSqliteConnection();
+    }
+
+    protected function createCommandTester()
+    {
+        return new CommandTester($this->app->find($this->command->getName()));
+    }
+
+    protected function executeCommand(array $args, array $options=[])
+    {
+        $tester = $this->createCommandTester();
+        $statusCode = $tester->execute(array_replace([
+            'command' => $this->command->getName(),
+        ], $args), $options);
+
+        return [$tester, $statusCode];
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
+
+use org\bovigo\vfs\vfsStream;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Migrations\Provider\SchemaProviderInterface;
+use Doctrine\DBAL\Migrations\Provider\StubSchemaProvider;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand;
+
+class DiffCommandTest extends CommandTestCase
+{
+    const VERSION = '20160705000000';
+
+    private $root, $migrationFile;
+
+    public function testCommandCreatesNewMigrationsFileWithAVersionFromConfiguration()
+    {
+        $this->config->expects($this->once())
+            ->method('generateVersionNumber')
+            ->willReturn(self::VERSION);
+
+        list($tester, $statusCode) = $this->executeCommand([]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertContains($this->migrationFile, $tester->getDisplay());
+        $this->assertTrue($this->root->hasChild($this->migrationFile));
+        $content = $this->root->getChild($this->migrationFile)->getContent();
+        $this->assertContains('class Version'.self::VERSION, $content);
+        $this->assertContains('CREATE TABLE example', $content);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->migrationFile = sprintf('Version%s.php', self::VERSION);
+        $this->root = vfsStream::setup('migrations');
+        $this->config->expects($this->any())
+            ->method('getMigrationsDirectory')
+            ->willReturn(vfsStream::url('migrations'));
+    }
+
+    protected function createCommand()
+    {
+        $schema = new Schema();
+        $t = $schema->createTable('example');
+        $t->addColumn('id', 'integer', ['autoincrement' => true]);
+        $t->setPrimaryKey(['id']);
+
+        return new DiffCommand(new StubSchemaProvider($schema));
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
+
+use org\bovigo\vfs\vfsStream;
+use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
+
+class GenerateCommandTest extends CommandTestCase
+{
+    const VERSION = '20160705000000';
+
+    private $root, $migrationFile;
+
+    public function testCommandCreatesNewMigrationsFileWithAVersionFromConfiguration()
+    {
+        $this->config->expects($this->once())
+            ->method('generateVersionNumber')
+            ->willReturn(self::VERSION);
+
+        list($tester, $statusCode) = $this->executeCommand([]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertContains($this->migrationFile, $tester->getDisplay());
+        $this->assertTrue($this->root->hasChild($this->migrationFile));
+        $this->assertContains('class Version'.self::VERSION, $this->root->getChild($this->migrationFile)->getContent());
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->migrationFile = sprintf('Version%s.php', self::VERSION);
+        $this->root = vfsStream::setup('migrations');
+        $this->config->expects($this->any())
+            ->method('getMigrationsDirectory')
+            ->willReturn(vfsStream::url('migrations'));
+    }
+
+    protected function createCommand()
+    {
+        return new GenerateCommand();
+    }
+}


### PR DESCRIPTION
Rather than the current time in whatever PHP's default time zone happens to be set to.

Closes #330 

Couple big things here:
1. new tests for the generate and diff commands. Both just ensure that the expected files are created
2. I refactored the version number generation into the configuration (explained below)

I moved the version number generation into `Configuration::generateVersionNumber` for a few reasons. The first is that this change is *probably* a BC break. If someone upgraded a minor version, there's a chance that they may generate a new migration with a version number before their latest version. Not good.

Moving the version number generation into `Configuration` means we could preserve BC by adding a configuration option for a timezone (which defaults to UTC). Also means additional configuration could be presented around version numbers if desired (probably not a great idea, but it's there).

Second reason is that it makes the system as a whole more testable and centralizes the version number generation in once place (was in both the diff and generate commands before).

If this is too much for such a small change feel free to close @mikeSimonson.