### PR TITLE
Don't Prompt the User for Confirmation on the `migrations:migrate` Command When There is Nothing to Do

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -156,7 +156,7 @@ class Migration
          * to signify that there is nothing left to do.
          */
         if ($from === $to && empty($migrationsToExecute) && !empty($migrations)) {
-            return [];
+            return $this->noMigrations();
         }
 
         $output = $dryRun ? 'Executing dry run of migration' : 'Migrating';
@@ -168,6 +168,8 @@ class Migration
          */
         if (empty($migrationsToExecute) && !$this->noMigrationException) {
             throw MigrationException::noMigrationsToExecute();
+        } elseif (empty($migrationsToExecute)) {
+            return $this->noMigrations();
         }
 
         $sql = [];
@@ -184,5 +186,11 @@ class Migration
         $this->outputWriter->write(sprintf("  <info>++</info> %s sql queries", count($sql, true) - count($sql)));
 
         return $sql;
+    }
+
+    private function noMigrations()
+    {
+        $this->outputWriter->write('<comment>No migrations to execute.</comment>');
+        return [];
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -119,7 +119,9 @@ class Migration
      * @param boolean $dryRun         Whether or not to make this a dry run and not execute anything.
      * @param boolean $timeAllQueries Measuring or not the execution time of each SQL query.
      * @param callable|null $confirm A callback to confirm whether the migrations should be executed.
+     *
      * @return array|false An array of migration sql statements or false if the confirm callback denied execution
+     *
      * @throws MigrationException
      */
     public function migrate($to = null, $dryRun = false, $timeAllQueries = false, callable $confirm = null)

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -120,7 +120,7 @@ class Migration
      * @param boolean $timeAllQueries Measuring or not the execution time of each SQL query.
      * @param callable|null $confirm A callback to confirm whether the migrations should be executed.
      *
-     * @return array|false An array of migration sql statements or false if the confirm callback denied execution
+     * @return array An array of migration sql statements. This will be empty if the the $confirm callback declines to execute the migration
      *
      * @throws MigrationException
      */
@@ -161,7 +161,7 @@ class Migration
         }
 
         if (!$dryRun && false === $this->migrationsCanExecute($confirm)) {
-            return false;
+            return [];
         }
 
         $output = $dryRun ? 'Executing dry run of migration' : 'Migrating';

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -83,7 +83,7 @@ EOT
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
-        $migration = new Migration($configuration);
+        $migration = $this->createMigration($configuration);
 
         $this->outputHeader($configuration, $output);
 
@@ -146,6 +146,17 @@ EOT
                 $output->writeln('<comment>No migrations to execute.</comment>');
             }
         }
+    }
+
+    /**
+     * Create a new migration instance to execute the migrations.
+     *
+     * @param $configuration The configuration with which the migrations will be executed
+     * @return Migration a new migration instance
+     */
+    protected function createMigration(Configuration $configuration)
+    {
+        return new Migration($configuration);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -124,27 +124,28 @@ EOT
         if ($path = $input->getOption('write-sql')) {
             $path = is_bool($path) ? getcwd() : $path;
             $migration->writeSqlFile($path, $version);
-        } else {
-            $dryRun = (boolean) $input->getOption('dry-run');
+            return 0;
+        }
 
-            // warn the user if no dry run and interaction is on
-            if (! $dryRun) {
-                $question = 'WARNING! You are about to execute a database migration'
-                    . ' that could result in schema changes and data lost.'
-                    . ' Are you sure you wish to continue? (y/n)';
-                if (! $this->canExecute($question, $input, $output)) {
-                    $output->writeln('<error>Migration cancelled!</error>');
+        $dryRun = (boolean) $input->getOption('dry-run');
 
-                    return 1;
-                }
+        // warn the user if no dry run and interaction is on
+        if (! $dryRun) {
+            $question = 'WARNING! You are about to execute a database migration'
+                . ' that could result in schema changes and data lost.'
+                . ' Are you sure you wish to continue? (y/n)';
+            if (! $this->canExecute($question, $input, $output)) {
+                $output->writeln('<error>Migration cancelled!</error>');
+
+                return 1;
             }
+        }
 
-            $migration->setNoMigrationException($input->getOption('allow-no-migration'));
-            $sql = $migration->migrate($version, $dryRun, $timeAllqueries);
+        $migration->setNoMigrationException($input->getOption('allow-no-migration'));
+        $sql = $migration->migrate($version, $dryRun, $timeAllqueries);
 
-            if (empty($sql)) {
-                $output->writeln('<comment>No migrations to execute.</comment>');
-            }
+        if (empty($sql)) {
+            $output->writeln('<comment>No migrations to execute.</comment>');
         }
     }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -129,20 +129,18 @@ EOT
 
         $dryRun = (boolean) $input->getOption('dry-run');
 
-        // warn the user if no dry run and interaction is on
-        if (! $dryRun) {
+        $migration->setNoMigrationException($input->getOption('allow-no-migration'));
+        $result = $migration->migrate($version, $dryRun, $timeAllqueries, function () use ($input, $output) {
             $question = 'WARNING! You are about to execute a database migration'
                 . ' that could result in schema changes and data lost.'
                 . ' Are you sure you wish to continue? (y/n)';
-            if (! $this->canExecute($question, $input, $output)) {
-                $output->writeln('<error>Migration cancelled!</error>');
+            return $this->canExecute($question, $input, $output);
+        });
 
-                return 1;
-            }
+        if (false === $result) {
+            $output->writeln('<error>Migration cancelled!</error>');
+            return 1;
         }
-
-        $migration->setNoMigrationException($input->getOption('allow-no-migration'));
-        $migration->migrate($version, $dryRun, $timeAllqueries);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -142,11 +142,7 @@ EOT
         }
 
         $migration->setNoMigrationException($input->getOption('allow-no-migration'));
-        $sql = $migration->migrate($version, $dryRun, $timeAllqueries);
-
-        if (empty($sql)) {
-            $output->writeln('<comment>No migrations to execute.</comment>');
-        }
+        $migration->migrate($version, $dryRun, $timeAllqueries);
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -235,7 +235,7 @@ class MigrationTest extends MigrationTestCase
             return false;
         });
 
-        $this->assertFalse($result);
+        $this->assertSame([], $result);
         $this->assertTrue($called, 'should have called the confirmation callback');
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DialogSupport.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DialogSupport.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Helper\DialogHelper;
+
+trait DialogSupport
+{
+    protected $questions, $isDialogHelper;
+
+    protected function configureDialogs(Application $app)
+    {
+        if (class_exists(QuestionHelper::class)) {
+            $this->isDialogHelper = false;
+            $this->questions = $this->getMock(QuestionHelper::class);
+        } else {
+            $this->isDialogHelper = true;
+            $this->questions = $this->getMock(DialogHelper::class);
+        }
+        $app->getHelperSet()->set($this->questions, $this->isDialogHelper ? 'dialog' : 'question');
+    }
+
+    protected function willAskConfirmationAndReturn($bool)
+    {
+        $this->questions->expects($this->once())
+            ->method($this->isDialogHelper ? 'askConfirmation' : 'ask')
+            ->willReturn($bool);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -10,9 +10,11 @@ use Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand;
 
 class ExecuteCommandTest extends CommandTestCase
 {
+    use DialogSupport;
+
     const VERSION = '20160705000000';
 
-    private $version, $questions, $isDialogHelper;
+    private $version;
 
     public function testWriteSqlCommandOutputsSqlFileToTheCurrentWorkingDirectory()
     {
@@ -94,14 +96,7 @@ class ExecuteCommandTest extends CommandTestCase
             ->with(self::VERSION)
             ->willReturn($this->version);
 
-        if (class_exists(QuestionHelper::class)) {
-            $this->isDialogHelper = false;
-            $this->questions = $this->getMock(QuestionHelper::class);
-        } else {
-            $this->isDialogHelper = true;
-            $this->questions = $this->getMock(DialogHelper::class);
-        }
-        $this->app->getHelperSet()->set($this->questions, $this->isDialogHelper ? 'dialog' : 'question');
+        $this->configureDialogs($this->app);
     }
 
     protected function createCommand()
@@ -120,12 +115,5 @@ class ExecuteCommandTest extends CommandTestCase
         return $this->getMockBuilder($cls)
             ->disableOriginalConstructor()
             ->getMock();
-    }
-
-    private function willAskConfirmationAndReturn($bool)
-    {
-        $this->questions->expects($this->once())
-            ->method($this->isDialogHelper ? 'askConfirmation' : 'ask')
-            ->willReturn($bool);
     }
 }


### PR DESCRIPTION
Possibly closes #306

Couple big things here:
- Better tests for the `MigrateCommand` so I could feel more comfortable changing it
- Moved the "No migrations ..." message into `Migration::migrate`.
- Reworked `Migration::migrate` to take an optional fourth argument for "confirm" the migrations can execute. This is similar to how `OuputWriter` abstracts away the Symfony console output in `Migration`. The default behavior is to always "confirm" the migrations if no `$confirm` callback is given (same as it is currently).

Not sure if adding another argument is okay, but it seemed to make the most sense. Even if none of the changes are okay, I do think the tests for the `MigrateCommand` are useful. Let me know!
