### PR TITLE
Dry run added to pre and post methods

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="a2b921dd-40d5-4f2f-a8b1-3cf14d2b7b0a" name="Default" comment="">
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php" afterPath="$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php" />
+    </list>
+    <ignored path="migrations.iws" />
+    <ignored path=".idea/workspace.xml" />
+    <ignored path=".idea/dataSources.local.xml" />
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ChangesViewManager" flattened_view="true" show_ignored="false" />
+  <component name="CreatePatchCommitExecutor">
+    <option name="PATCH_PATH" value="" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="default_target" />
+  <component name="FavoritesManager">
+    <favorites_list name="migrations" />
+  </component>
+  <component name="FileEditorManager">
+    <leaf>
+      <file leaf-file-name="MigrateAddSqlPostAndPreUpAndDownTest.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="-12.384615">
+              <caret line="27" column="24" selection-start-line="27" selection-start-column="24" selection-end-line="27" selection-end-column="24" />
+              <folding>
+                <element signature="e#1299#1414#0#PHP" expanded="false" />
+                <marker date="1469545092485" expanded="true" signature="382:414" placeholder="INSERT INTO " />
+                <marker date="1469545092485" expanded="true" signature="559:591" placeholder="INSERT INTO " />
+                <marker date="1469545092485" expanded="true" signature="757:789" placeholder="INSERT INTO " />
+                <marker date="1469545092485" expanded="true" signature="956:988" placeholder="INSERT INTO " />
+                <marker date="1469545092485" expanded="true" signature="1135:1167" placeholder="INSERT INTO " />
+                <marker date="1469545092485" expanded="true" signature="1335:1367" placeholder="INSERT INTO " />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="AbstractMigration.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/lib/Doctrine/DBAL/Migrations/AbstractMigration.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="-38.923077">
+              <caret line="155" column="22" selection-start-line="155" selection-start-column="22" selection-end-line="155" selection-end-column="22" />
+              <folding>
+                <element signature="e#4501#4570#0#PHP" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="MigrationModifySchemaInPreAndPost.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="-33.615383">
+              <caret line="39" column="5" selection-start-line="39" selection-start-column="5" selection-end-line="39" selection-end-column="5" />
+              <folding>
+                <element signature="e#221#381#0#PHP" expanded="true" />
+                <element signature="e#387#496#0#PHP" expanded="true" />
+                <element signature="e#502#613#0#PHP" expanded="true" />
+                <element signature="e#619#730#0#PHP" expanded="true" />
+                <element signature="e#736#849#0#PHP" expanded="true" />
+                <element signature="e#855#938#0#PHP" expanded="true" />
+                <element signature="e#944#1080#0#PHP" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="ConfigurationTest.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="-8.491228">
+              <caret line="150" column="50" selection-start-line="150" selection-start-column="50" selection-end-line="150" selection-end-column="50" />
+              <folding>
+                <element signature="e#4807#4899#0#PHP" expanded="true" />
+                <element signature="e#4904#5680#0#PHP" expanded="true" />
+                <element signature="e#8035#8947#0#PHP" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="MigrationSkipMigration.php" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.14495799">
+              <caret line="6" column="28" selection-start-line="6" selection-start-column="6" selection-end-line="6" selection-end-column="28" />
+              <folding>
+                <element signature="e#163#260#0#PHP" expanded="true" />
+                <element signature="e#266#365#0#PHP" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="MigrateNotTouchingTheSchema.php" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="-8.846154">
+              <caret line="17" column="5" selection-start-line="17" selection-start-column="5" selection-end-line="17" selection-end-column="5" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="IdeDocumentHistory">
+    <option name="CHANGED_PATHS">
+      <list>
+        <option value="$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php" />
+        <option value="$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php" />
+        <option value="$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php" />
+        <option value="$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php" />
+      </list>
+    </option>
+  </component>
+  <component name="JsBuildToolGruntFileManager" detection-done="true" />
+  <component name="JsBuildToolPackageJson" detection-done="true" />
+  <component name="JsGulpfileManager">
+    <detection-done>true</detection-done>
+  </component>
+  <component name="PhpWorkspaceProjectConfiguration" backward_compatibility_performed="true" />
+  <component name="ProjectFrameBounds">
+    <option name="x" value="1079" />
+    <option name="y" value="387" />
+    <option name="width" value="1922" />
+    <option name="height" value="1081" />
+  </component>
+  <component name="ProjectLevelVcsManager" settingsEditedManually="false">
+    <OptionsSetting value="true" id="Add" />
+    <OptionsSetting value="true" id="Remove" />
+    <OptionsSetting value="true" id="Checkout" />
+    <OptionsSetting value="true" id="Update" />
+    <OptionsSetting value="true" id="Status" />
+    <OptionsSetting value="true" id="Edit" />
+    <ConfirmationsSetting value="0" id="Add" />
+    <ConfirmationsSetting value="0" id="Remove" />
+  </component>
+  <component name="ProjectView">
+    <navigator currentView="ProjectPane" proportions="" version="1">
+      <flattenPackages />
+      <showMembers />
+      <showModules />
+      <showLibraryContents />
+      <hideEmptyPackages />
+      <abbreviatePackageNames />
+      <autoscrollToSource />
+      <autoscrollFromSource />
+      <sortByType />
+      <manualOrder />
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="ProjectPane">
+        <subPane>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="migrations" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="migrations" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="migrations" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+          <PATH>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="migrations" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.ProjectViewProjectNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="migrations" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+            <PATH_ELEMENT>
+              <option name="myItemId" value="vendor" />
+              <option name="myItemType" value="com.intellij.ide.projectView.impl.nodes.PsiDirectoryNode" />
+            </PATH_ELEMENT>
+          </PATH>
+        </subPane>
+      </pane>
+      <pane id="Scratches" />
+      <pane id="Scope" />
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="options.lastSelected" value="SQL Dialects" />
+    <property name="options.splitter.main.proportions" value="0.3" />
+    <property name="options.splitter.details.proportions" value="0.2" />
+    <property name="settings.editor.selected.configurable" value="configurable.group.language" />
+    <property name="settings.editor.splitter.proportion" value="0.2" />
+    <property name="WebServerToolWindowFactoryState" value="true" />
+    <property name="SearchEverywhereHistoryKey" value="MigrationSkipMigration&#9;null&#9;null&#10;testVersionsTryToGetLoadedIfNotAlreadyLoadedWhenAccessingMethodThatNeedThemEvenIfSomeMigrationsAreAlreadyMigrated&#9;null&#9;null&#10;MigrateAddSqlPostAndPreUpAndDownTest&#9;null&#9;null" />
+  </component>
+  <component name="ShelveChangesManager" show_recycled="false" />
+  <component name="SvnConfiguration">
+    <configuration />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="a2b921dd-40d5-4f2f-a8b1-3cf14d2b7b0a" name="Default" comment="" />
+      <created>1469544775370</created>
+      <option name="number" value="Default" />
+      <updated>1469544775370</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="1079" y="387" width="1922" height="1081" extended-state="6" />
+    <editor active="true" />
+    <layout>
+      <window_info id="Remote Host" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
+      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="true" content_ui="tabs" />
+      <window_info id="Database" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Find" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32935324" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="false" content_ui="tabs" />
+      <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="-1" side_tool="true" content_ui="tabs" />
+      <window_info id="Cvs" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="4" side_tool="false" content_ui="tabs" />
+      <window_info id="Hierarchy" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="2" side_tool="false" content_ui="combo" />
+      <window_info id="Message" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Commander" active="false" anchor="right" auto_hide="false" internal_type="SLIDING" type="SLIDING" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="0" side_tool="false" content_ui="tabs" />
+      <window_info id="Inspection" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="5" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
+    </layout>
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager />
+    <watches-manager />
+  </component>
+  <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-8.846154">
+          <caret line="17" column="5" selection-start-line="17" selection-start-column="5" selection-end-line="17" selection-end-column="5" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-12.384615">
+          <caret line="27" column="24" selection-start-line="27" selection-start-column="24" selection-end-line="27" selection-end-column="24" />
+          <folding>
+            <element signature="e#1299#1414#0#PHP" expanded="false" />
+            <marker date="1469545092485" expanded="true" signature="382:414" placeholder="INSERT INTO " />
+            <marker date="1469545092485" expanded="true" signature="559:591" placeholder="INSERT INTO " />
+            <marker date="1469545092485" expanded="true" signature="757:789" placeholder="INSERT INTO " />
+            <marker date="1469545092485" expanded="true" signature="956:988" placeholder="INSERT INTO " />
+            <marker date="1469545092485" expanded="true" signature="1135:1167" placeholder="INSERT INTO " />
+            <marker date="1469545092485" expanded="true" signature="1335:1367" placeholder="INSERT INTO " />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/lib/Doctrine/DBAL/Migrations/AbstractMigration.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-38.923077">
+          <caret line="155" column="22" selection-start-line="155" selection-start-column="22" selection-end-line="155" selection-end-column="22" />
+          <folding>
+            <element signature="e#4501#4570#0#PHP" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-33.615383">
+          <caret line="39" column="5" selection-start-line="39" selection-start-column="5" selection-end-line="39" selection-end-column="5" />
+          <folding>
+            <element signature="e#221#381#0#PHP" expanded="true" />
+            <element signature="e#387#496#0#PHP" expanded="true" />
+            <element signature="e#502#613#0#PHP" expanded="true" />
+            <element signature="e#619#730#0#PHP" expanded="true" />
+            <element signature="e#736#849#0#PHP" expanded="true" />
+            <element signature="e#855#938#0#PHP" expanded="true" />
+            <element signature="e#944#1080#0#PHP" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-8.491228">
+          <caret line="150" column="50" selection-start-line="150" selection-start-column="50" selection-end-line="150" selection-end-column="50" />
+          <folding>
+            <element signature="e#4807#4899#0#PHP" expanded="true" />
+            <element signature="e#4904#5680#0#PHP" expanded="true" />
+            <element signature="e#8035#8947#0#PHP" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.14495799">
+          <caret line="6" column="28" selection-start-line="6" selection-start-column="6" selection-end-line="6" selection-end-column="28" />
+          <folding>
+            <element signature="e#163#260#0#PHP" expanded="true" />
+            <element signature="e#266#365#0#PHP" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+  </component>
+</project>

--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -149,19 +149,19 @@ abstract class AbstractMigration
         }
     }
 
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema, $isDryRun = false)
     {
     }
 
-    public function postUp(Schema $schema)
+    public function postUp(Schema $schema, $isDryRun = false)
     {
     }
 
-    public function preDown(Schema $schema)
+    public function preDown(Schema $schema, $isDryRun = false)
     {
     }
 
-    public function postDown(Schema $schema)
+    public function postDown(Schema $schema, $isDryRun = false)
     {
     }
 

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -276,7 +276,7 @@ class Version
             $this->state = self::STATE_PRE;
             $fromSchema = $this->schemaProvider->createFromSchema();
 
-            $this->migration->{'pre' . ucfirst($direction)}($fromSchema);
+            $this->migration->{'pre' . ucfirst($direction)}($fromSchema, $dryRun);
 
             if ($direction === self::DIRECTION_UP) {
                 $this->outputWriter->write("\n" . sprintf('  <info>++</info> migrating <comment>%s</comment>', $this->version) . "\n");
@@ -294,7 +294,7 @@ class Version
             $this->executeRegisteredSql($dryRun, $timeAllQueries);
 
             $this->state = self::STATE_POST;
-            $this->migration->{'post' . ucfirst($direction)}($toSchema);
+            $this->migration->{'post' . ucfirst($direction)}($toSchema, $dryRun);
 
             if (! $dryRun) {
                 if ($direction === self::DIRECTION_UP) {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php
@@ -9,7 +9,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
 {
     const TABLE_NAME = 'test_add_sql_post_up_table';
 
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema, $dryRun = false)
     {
         $this->addSql(
             sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
@@ -25,7 +25,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
         );
     }
 
-    public function postUp(Schema $schema)
+    public function postUp(Schema $schema, $dryRun = false)
     {
         $this->addSql(
             sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
@@ -33,7 +33,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
         );
     }
 
-    public function preDown(Schema $schema)
+    public function preDown(Schema $schema, $dryRun = false)
     {
         $this->addSql(
             sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
@@ -49,7 +49,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
         );
     }
 
-    public function postDown(Schema $schema)
+    public function postDown(Schema $schema, $dryRun = false)
     {
         $this->addSql(
             sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Schema\Schema;
 
 class MigrateNotTouchingTheSchema extends AbstractMigration
 {
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema, $dryRun = false)
     {
 
     }
@@ -17,12 +17,12 @@ class MigrateNotTouchingTheSchema extends AbstractMigration
         $this->addSql("SELECT 1");
     }
 
-    public function postUp(Schema $schema)
+    public function postUp(Schema $schema, $dryRun = false)
     {
 
     }
 
-    public function preDown(Schema $schema)
+    public function preDown(Schema $schema, $dryRun = false)
     {
 
     }
@@ -32,7 +32,7 @@ class MigrateNotTouchingTheSchema extends AbstractMigration
         $this->addSql("SELECT 1");
     }
 
-    public function postDown(Schema $schema)
+    public function postDown(Schema $schema, $dryRun = false)
     {
 
     }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php
@@ -14,22 +14,22 @@ class MigrationModifySchemaInPreAndPost extends AbstractMigration
         $table->addColumn('id', 'integer');
     }
 
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema, $isDryRun = false)
     {
         $this->addTable($schema, 'bar');
     }
 
-    public function preDown(Schema $schema)
+    public function preDown(Schema $schema, $isDryRun = false)
     {
         $this->addTable($schema, 'bar');
     }
 
-    public function postUp(Schema $schema)
+    public function postUp(Schema $schema, $isDryRun = false)
     {
         $this->addTable($schema, 'bar2');
     }
 
-    public function postDown(Schema $schema)
+    public function postDown(Schema $schema, $isDryRun = false)
     {
         $this->addTable($schema, 'bar2');
     }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php
@@ -7,12 +7,12 @@ use Doctrine\DBAL\Schema\Schema;
 class MigrationSkipMigration extends MigrationMigrateUp
 {
 
-    public function preUp(Schema $schema)
+    public function preUp(Schema $schema, $isDryRun = false)
     {
         $this->skipIf(true);
     }
 
-    public function preDown(Schema $schema)
+    public function preDown(Schema $schema, $isDryRun = false)
     {
         $this->skipIf(true);
     }


### PR DESCRIPTION
When adding a column, we can't use `$this->addSql()` in postUp because this is not executed anymore. So we use `$this->connection->executeSql()`. This works fine if you execute the migration directly the database. But if you are dry-running to check if all is well, i dont want my postUp to execute any statements.