### PR TITLE
Fixed doctrine:migrations:execute command help message when using

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -64,7 +64,7 @@ You can output the would be executed SQL statements to a file with <comment>--wr
 
 Or you can also execute the migration without a warning message which you need to interact with:
 
-    <info>%command.full_name% --no-interaction</info>
+    <info>%command.full_name% YYYYMMDDHHMMSS --no-interaction</info>
 EOT
         );
 


### PR DESCRIPTION
This is a really quick fix but when using `doctrine:migrations:execute` command, the version number is required but is not displayed in the command help message when using `--no-interaction` option.

I fix that because a new person I'm teaching Symfony just told me that the command suggested in the help of the command don't work... ;)

Thank you!