### PR TITLE
Show newly generated migration

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -125,6 +125,7 @@ EOT
         $path = $this->generateMigration($configuration, $input, $version, $up, $down);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
+        $output->writeln(file_get_contents($path));
     }
 
     private function buildCodeFromSql(Configuration $configuration, array $sql, $formatted=false, $lineLength=120)


### PR DESCRIPTION
Show the newly generated diff-migration upon creation. It helps speed up programming by knowing you can directly migrate the new migration if all proposed changes are in order. No need to check your IDE.