### PR TITLE
Added hasColumn() method

### DIFF
--- a/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
@@ -11,8 +11,7 @@ use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
 use Doctrine\DBAL\Migrations\Version;
 
 /**
- * Class AbstractMigrationTest
- * @package Doctrine\DBAL\Migrations\Tests
+ * Class AbstractMigrationTest.
  *
  * @author Robbert van den Bogerd <rvdbogerd@ibuildings.nl>
  */
@@ -20,7 +19,7 @@ class AbstractMigrationTest extends MigrationTestCase
 {
     private $config;
     private $version;
-    /** @var  AbstractMigrationStub */
+    /** @var AbstractMigrationStub */
     private $migration;
     protected $outputWriter;
     protected $output;
@@ -45,15 +44,13 @@ class AbstractMigrationTest extends MigrationTestCase
     public function testWarnIfOutputMessage()
     {
         $this->migration->warnIf(true, 'Warning was thrown');
-        $this->assertContains('Warning during No State: Warning was thrown'
-            , $this->getOutputStreamContent($this->output));
+        $this->assertContains('Warning during No State: Warning was thrown', $this->getOutputStreamContent($this->output));
     }
 
     public function testWarnIfAddDefaultMessage()
     {
         $this->migration->warnIf(true);
-        $this->assertContains('Warning during No State: Unknown Reason'
-            , $this->getOutputStreamContent($this->output));
+        $this->assertContains('Warning during No State: Unknown Reason', $this->getOutputStreamContent($this->output));
     }
 
     public function testWarnIfDontOutputMessageIfFalse()
@@ -65,9 +62,7 @@ class AbstractMigrationTest extends MigrationTestCase
     public function testWriteInvokesOutputWriter()
     {
         $this->migration->exposed_Write('Message');
-        $this->assertContains('Message'
-            , $this->getOutputStreamContent($this->output));
-
+        $this->assertContains('Message', $this->getOutputStreamContent($this->output));
     }
 
     public function testAbortIfThrowsException()
@@ -120,4 +115,12 @@ class AbstractMigrationTest extends MigrationTestCase
         $this->migration->exposed_AddSql('tralala');
     }
 
+    public function testHasColumn()
+    {
+        $this->config->getConnection()->executeQuery('CREATE TABLE IF NOT EXISTS table_with_column (test INT)');
+
+        $this->assertTrue($this->migration->hasColumn('table_with_column', 'test'));
+        $this->assertFalse($this->migration->hasColumn('table_with_column', 'invalid_column'));
+        $this->assertFalse($this->migration->hasColumn('invalid_table', 'test'));
+    }
 }


### PR DESCRIPTION
Before creating a new column, it can be useful to check if this column already exists.

Doctrine migrations can be painful when you are a software editor: you don't when a user installed your software, so some migrations can be played whereas the schema of the user is good. 
We have this problem when we add new columns in our schema. 
That's why we wanted to add a check just before the `ALTER TABLE`. 

This code is very inspired by phinx from @robmorgan: [MySQL](https://github.com/robmorgan/phinx/blob/0.6.x-dev/src/Phinx/Db/Adapter/MysqlAdapter.php#L362), [SQLite](https://github.com/robmorgan/phinx/blob/0.6.x-dev/src/Phinx/Db/Adapter/SQLiteAdapter.php#L293), [Postgres](https://github.com/robmorgan/phinx/blob/0.6.x-dev/src/Phinx/Db/Adapter/PostgresAdapter.php#L346).
