### PR TITLE
Fix writeln call when no changes are to be done

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -116,7 +116,7 @@ EOT
         );
 
         if (! $up && ! $down) {
-            $output->writeln('No changes detected in your mapping information.', 'ERROR');
+            $output->writeln('No changes detected in your mapping information.');
 
             return;
         }


### PR DESCRIPTION
Without this fix I get:

```
  [Symfony\Component\Debug\Exception\ContextErrorException]
  Warning: A non-numeric value encountered
```

Because the OutputInterface expects options and not a string 'ERROR', I have no idea what this is supposed to do.