### PR TITLE
Handle Connections with Auto Commit Off

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 
 /**
@@ -44,6 +45,11 @@ class Migration
     private $configuration;
 
     /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
      * @var boolean
      */
     private $noMigrationException;
@@ -57,6 +63,7 @@ class Migration
     {
         $this->configuration = $configuration;
         $this->outputWriter = $configuration->getOutputWriter();
+        $this->connection = $configuration->getConnection();
         $this->noMigrationException = false;
     }
 
@@ -183,6 +190,10 @@ class Migration
             $versionSql = $version->execute($direction, $dryRun, $timeAllQueries);
             $sql[$version->getVersion()] = $versionSql;
             $time += $version->getTime();
+        }
+
+        if (!$dryRun && !$this->connection->isAutoCommit()) {
+            $this->connection->commit();
         }
 
         $this->outputWriter->write("\n  <comment>------------------------</comment>\n");

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/_files/db/.gitignore
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/_files/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateWithDataModification.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateWithDataModification.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub\Functional;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class MigrateWithDataModification extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('INSERT INTO test_data_migration (test) VALUES (1), (2), (3)');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('DELETE FROM test_data_migration');
+    }
+
+    public function isTransactional()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Possibly fixes #496 

This adds a test to verify that the issue is indeed the case and has a possible fix: adding a final `Connection::commit` call in `Migration::migrate` if auto commit is off. `Migration` being the actual application object, this seems like the right place for that final commit. Not really sure on that.

Also seems like the total time for the migrations should include the time of that final commit?