### PR TITLE
Add a Set of Events to Migrations

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\DBAL\Migrations\Configuration;
 
+use Doctrine\Common\EventArgs;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Migrations\Finder\MigrationDeepFinderInterface;
@@ -772,6 +773,17 @@ class Configuration
         }
 
         return $versions;
+    }
+
+    /**
+     * Use the connection's event manager to emit an event.
+     *
+     * @param string $eventName The event to emit.
+     * @param $args The event args instance to emit.
+     */
+    public function dispatchEvent($eventName, EventArgs $args=null)
+    {
+        $this->connection->getEventManager()->dispatchEvent($eventName, $args);
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Event/MigrationsEventArgs.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/MigrationsEventArgs.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+
+class MigrationsEventArgs extends EventArgs
+{
+    /**
+     * @var Configuration
+     */
+    private $config;
+
+    /**
+     * The direction of the migration.
+     *
+     * @var string (up|down)
+     */
+    private $direction;
+
+    /**
+     * Whether or not the migrations are executing in dry run mode.
+     *
+     * @var bool
+     */
+    private $dryRun;
+
+    public function __construct(Configuration $config, $direction, $dryRun)
+    {
+        $this->config = $config;
+        $this->direction = $direction;
+        $this->dryRun = (bool) $dryRun;
+    }
+
+    public function getConfiguration()
+    {
+        return $this->config;
+    }
+
+    public function getDirection()
+    {
+        return $this->direction;
+    }
+
+    public function isDryRun()
+    {
+        return $this->dryRun;
+    }
+}

--- a/lib/Doctrine/DBAL/Migrations/Event/MigrationsVersionEventArgs.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/MigrationsVersionEventArgs.php
@@ -17,20 +17,28 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\DBAL\Migrations;
+namespace Doctrine\DBAL\Migrations\Event;
 
-final class Events
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Version;
+
+class MigrationsVersionEventArgs extends MigrationsEventArgs
 {
     /**
-     * Private constructor. This class cannot be instantiated.
+     * The version the event pertains to.
+     *
+     * @var Version
      */
-    private function __construct()
+    private $version;
+
+    public function __construct(Version $version, Configuration $config, $direction, $dryRun)
     {
+        parent::__construct($config, $direction, $dryRun);
+        $this->version = $version;
     }
 
-    const onMigrationsMigrating = 'onMigrationsMigrating';
-    const onMigrationsMigrated = 'onMigrationsMigrated';
-    const onMigrationsVersionExecuting = 'onMigrationsVersionExecuting';
-    const onMigrationsVersionExecuted = 'onMigrationsVersionExecuted';
-    const onMigrationsVersionSkipped = 'onMigrationsVersionSkipped';
+    public function getVersion()
+    {
+        return $this->version;
+    }
 }

--- a/lib/Doctrine/DBAL/Migrations/Events.php
+++ b/lib/Doctrine/DBAL/Migrations/Events.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations;
+
+final class Events
+{
+    /**
+     * Private constructor. This class cannot be instantiated.
+     */
+    private function __construct()
+    {
+    }
+
+    const onMigrationsMigrating = 'onMigrationsMigrating';
+    const onMigrationsMigrated = 'onMigrationsMigrated';
+}

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -20,6 +20,7 @@
 namespace Doctrine\DBAL\Migrations;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
 
 /**
  * Class for running migrations to the current version or a manually specified version.
@@ -177,6 +178,11 @@ class Migration
             return $this->noMigrations();
         }
 
+        $this->configuration->dispatchEvent(
+            Events::onMigrationsMigrating,
+            new MigrationsEventArgs($this->configuration, $direction, $dryRun)
+        );
+
         $sql = [];
         $time = 0;
         foreach ($migrationsToExecute as $version) {
@@ -184,6 +190,11 @@ class Migration
             $sql[$version->getVersion()] = $versionSql;
             $time += $version->getTime();
         }
+
+        $this->configuration->dispatchEvent(
+            Events::onMigrationsMigrated,
+            new MigrationsEventArgs($this->configuration, $direction, $dryRun)
+        );
 
         $this->outputWriter->write("\n  <comment>------------------------</comment>\n");
         $this->outputWriter->write(sprintf("  <info>++</info> finished in %ss", $time));

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -3,7 +3,10 @@
 namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Events;
+use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
 use Doctrine\DBAL\Migrations\MigrationException;
+use Doctrine\DBAL\Migrations\Tests\Stub\EventVerificationListener;
 use Doctrine\DBAL\Migrations\Tests\Stub\Version1Test;
 use Doctrine\DBAL\Migrations\Tests\Stub\Version2Test;
 use Doctrine\DBAL\Migrations\Tests\Stub\Version3Test;
@@ -256,6 +259,22 @@ class ConfigurationTest extends MigrationTestCase
         $config = $this->getSqliteConfiguration();
 
         $this->assertEquals($return, $config->formatVersion($version));
+    }
+
+    public function testDispatchEventProxiesToConnectionsEventManager()
+    {
+        $config = $this->getSqliteConfiguration();
+        $config->getConnection()
+            ->getEventManager()
+            ->addEventSubscriber($listener = new EventVerificationListener());
+
+        $config->dispatchEvent(
+            Events::onMigrationsMigrating,
+            $ea = new MigrationsEventArgs($config, 'up', false)
+        );
+
+        $this->assertArrayHasKey(Events::onMigrationsMigrating, $listener->events);
+        $this->assertSame($ea, $listener->events[Events::onMigrationsMigrating][0]);
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -2,9 +2,11 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Functional;
 
+use Doctrine\DBAL\Migrations\Events;
 use Doctrine\DBAL\Migrations\Migration;
 use Doctrine\DBAL\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+use Doctrine\DBAL\Migrations\Tests\Stub\EventVerificationListener;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlPostAndPreUpAndDownTest;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateAddSqlTest;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateNotTouchingTheSchema;
@@ -374,6 +376,25 @@ class FunctionalTest extends MigrationTestCase
         $methods = get_class_methods(Schema::class);
         foreach($methods as $method) {
             $schema->expects($this->never())->method($method);
+        }
+    }
+
+    public function testMigrateDispatchesTheExpectedEvents()
+    {
+        $this->config->registerMigration(1, MigrationMigrateUp::class);
+        $this->config->getConnection()->getEventManager()->addEventSubscriber(
+            $listener = new EventVerificationListener()
+        );
+
+        $migration = new Migration($this->config);
+        $migration->migrate();
+
+        $this->assertCount(2, $listener->events);
+        foreach ([
+            Events::onMigrationsMigrating,
+            Events::onMigrationsMigrated,
+        ] as $eventName) {
+            $this->assertArrayHasKey($eventName, $listener->events);
         }
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/EventVerificationListener.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/EventVerificationListener.php
@@ -15,16 +15,34 @@ final class EventVerificationListener implements EventSubscriber
         return [
             Events::onMigrationsMigrating,
             Events::onMigrationsMigrated,
+            Events::onMigrationsVersionExecuting,
+            Events::onMigrationsVersionExecuted,
+            Events::onMigrationsVersionSkipped,
         ];
     }
 
     public function onMigrationsMigrating(EventArgs $args)
     {
-        $this->events[Events::onMigrationsMigrating][] = $args;
+        $this->events[__FUNCTION__][] = $args;
     }
 
     public function onMigrationsMigrated(EventArgs $args)
     {
-        $this->events[Events::onMigrationsMigrated][] = $args;
+        $this->events[__FUNCTION__][] = $args;
+    }
+
+    public function onMigrationsVersionExecuting(EventArgs $args)
+    {
+        $this->events[__FUNCTION__][] = $args;
+    }
+
+    public function onMigrationsVersionExecuted(EventArgs $args)
+    {
+        $this->events[__FUNCTION__][] = $args;
+    }
+
+    public function onMigrationsVersionSkipped(EventArgs $args)
+    {
+        $this->events[__FUNCTION__][] = $args;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/EventVerificationListener.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/EventVerificationListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Migrations\Events;
+
+final class EventVerificationListener implements EventSubscriber
+{
+    public $events = [];
+
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::onMigrationsMigrating,
+            Events::onMigrationsMigrated,
+        ];
+    }
+
+    public function onMigrationsMigrating(EventArgs $args)
+    {
+        $this->events[Events::onMigrationsMigrating][] = $args;
+    }
+
+    public function onMigrationsMigrated(EventArgs $args)
+    {
+        $this->events[Events::onMigrationsMigrated][] = $args;
+    }
+}


### PR DESCRIPTION
Per the discussion in #505 and #468

There are five events:

- `onMigrationsMigrating` - fired when the `Migrations::migrate` method is about to start executing versions.
- `onMigrationsMigrated` - fired when the `Migrations::migrate` method finishes executing all its versions.
- `onMigrationsVersionExecuting` - Fired immediately before a version does anything
- `onMigrationsVersionExecuted` - Fired when a version finishes its execution
- `onMigrationsVersionSkipped` - Fired when a version is skipped

Not sure on the naming. I figured more unique names would be better (hence the `onMigrations` prefix).

Maybe needs an event when a version fails?