### PR TITLE
Add delta in migrate command

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -664,7 +664,7 @@ class Configuration
                     }
 
                     if ($symbol == "+" || $symbol == "-") {
-                        return $this->getRelativeVersion($this->getCurrentVersion(), intValue($symbol.$number));
+                        return $this->getRelativeVersion($this->getCurrentVersion(), (int)($symbol.$number));
                     }
                 }
                 return null;

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -655,6 +655,18 @@ class Configuration
             case 'latest':
                 return $this->getLatestVersion();
             default:
+                if (substr($alias, 0, 7) == 'current') {
+                    $symbol = substr($alias, 7, 1);
+                    $number = (int) substr($alias, 8);
+
+                    if ($number <= 0) {
+                        return null;
+                    }
+
+                    if ($symbol == "+" || $symbol == "-") {
+                        return $this->getRelativeVersion($this->getCurrentVersion(), intValue($symbol.$number));
+                    }
+                }
                 return null;
         }
     }

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -622,6 +622,27 @@ class Configuration
     }
 
     /**
+     * Returns the version with the specified to the current version.
+     *
+     * @return string|null A version string, or null if the specified delta is
+     *                     not within the list of available versions.
+     */
+    public function getDeltaVersion($delta) {
+        $symbol = substr($delta, 0, 1);
+        $number = (int) substr($delta, 1);
+
+        if ($number <= 0) {
+            return null;
+        }
+
+        if ($symbol == "+" || $symbol == "-") {
+            return $this->getRelativeVersion($this->getCurrentVersion(), (int) $delta);
+        }
+
+        return null;
+    }
+
+    /**
      * Returns the version number from an alias.
      *
      * Supported aliases are:
@@ -656,16 +677,7 @@ class Configuration
                 return $this->getLatestVersion();
             default:
                 if (substr($alias, 0, 7) == 'current') {
-                    $symbol = substr($alias, 7, 1);
-                    $number = (int) substr($alias, 8);
-
-                    if ($number <= 0) {
-                        return null;
-                    }
-
-                    if ($symbol == "+" || $symbol == "-") {
-                        return $this->getRelativeVersion($this->getCurrentVersion(), (int)($symbol.$number));
-                    }
+                    return $this->getDeltaVersion(substr($alias, 7));
                 }
                 return null;
         }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -59,6 +59,10 @@ You can specify the version you wish to migrate to using an alias:
 
     <info>%command.full_name% prev</info>
 
+You can specify the version you wish to migrate to using an number against the current version:
+
+    <info>%command.full_name% current+3</info>
+
 You can also execute the migration as a <comment>--dry-run</comment>:
 
     <info>%command.full_name% YYYYMMDDHHMMSS --dry-run</info>
@@ -189,6 +193,10 @@ EOT
             }
             if ($versionAlias == 'next') {
                 $output->writeln('<error>Already at latest version.</error>');
+                return false;
+            }
+            if (substr($version, 0, 7) == 'current') {
+                $output->writeln('<error>The delta couldn\'t be reached.</error>');
                 return false;
             }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -58,6 +58,7 @@ You can optionally manually specify the version you wish to migrate to:
 You can specify the version you wish to migrate to using an alias:
 
     <info>%command.full_name% prev</info>
+    <info>These alias are defined : first, lastest, prev, current and next</info>
 
 You can specify the version you wish to migrate to using an number against the current version:
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -196,7 +196,7 @@ EOT
                 $output->writeln('<error>Already at latest version.</error>');
                 return false;
             }
-            if (substr($version, 0, 7) == 'current') {
+            if (substr($versionAlias, 0, 7) == 'current') {
                 $output->writeln('<error>The delta couldn\'t be reached.</error>');
                 return false;
             }

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -240,6 +240,46 @@ class ConfigurationTest extends MigrationTestCase
         $this->assertSame('1236', $config->getLatestVersion(), "latest version 1236");
     }
 
+    public function testDeltaVersion()
+    {
+        $config = $this->getSqliteConfiguration();
+        $config->registerMigrations([
+            1234 => Version1Test::class,
+            1235 => Version2Test::class,
+            1236 => Version3Test::class,
+        ]);
+
+        $this->assertNull($config->getDeltaVersion('-1'), "no current-1 version");
+        $this->assertSame('1234', $config->getDeltaVersion('+1'), "current+1 is 1234");
+        $this->assertSame('1235', $config->getDeltaVersion('+2'), "current+2 is 1235");
+        $this->assertSame('1236', $config->getDeltaVersion('+3'), "current+3 is 1236");
+        $this->assertNull($config->getDeltaVersion('+4'), "no current+4 version");
+
+        $config->getVersion(1234)->markMigrated();
+
+        $this->assertNull($config->getDeltaVersion('-2'), "no current-2 version");
+        $this->assertSame('0', $config->getDeltaVersion('-1'), "current-1 is 0");
+        $this->assertSame('1235', $config->getDeltaVersion('+1'), "current+1 is 1235");
+        $this->assertSame('1236', $config->getDeltaVersion('+2'), "current+2 is 1236");
+        $this->assertNull($config->getDeltaVersion('+3'), "no current+3");
+
+        $config->getVersion(1235)->markMigrated();
+
+        $this->assertNull($config->getDeltaVersion('-3'), "no current-3 version");
+        $this->assertSame('0', $config->getDeltaVersion('-2'), "current-2 is 0");
+        $this->assertSame('1234', $config->getDeltaVersion('-1'), "current-1 is 1234");
+        $this->assertSame('1236', $config->getDeltaVersion('+1'), "current+1 is 1236");
+        $this->assertNull($config->getDeltaVersion('+2'), "no current+2");
+
+        $config->getVersion(1236)->markMigrated();
+
+        $this->assertNull($config->getDeltaVersion('-4'), "no current-4 version");
+        $this->assertSame('0', $config->getDeltaVersion('-3'), "current-3 is 0");
+        $this->assertSame('1234', $config->getDeltaVersion('-2'), "current-2 is 1234");
+        $this->assertSame('1235', $config->getDeltaVersion('-1'), "current-1 is 1235");
+        $this->assertNull($config->getDeltaVersion('+1'), "no current+1");
+    }
+
     public function testGetAvailableVersions()
     {
         $config = $this->getSqliteConfiguration();


### PR DESCRIPTION
Hi all,

I needed to come back 3 migrations earlier and I don't found a rapid way to do it (without execute `migrations:migrate prev` 3 times). So I added a new dynamic alias like `git checkout HEAD~3`, for my case the command will be `migrations:migrate current-3`. You can go forward with `+` and backward with `-`.

Hope this can be help someone else :)
