### PR TITLE
Introduce AutoCommitListener

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.5|^7.0",
-        "doctrine/dbal": "~2.2",
+        "doctrine/dbal": "~2.5",
         "symfony/yaml": "~2.3|~3.0",
         "symfony/console": "~2.3|~3.0",
         "ocramius/proxy-manager": "^1.0|^2.0"

--- a/lib/Doctrine/DBAL/Migrations/Event/Listeners/AutoCommitListener.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/Listeners/AutoCommitListener.php
@@ -20,30 +20,17 @@
 namespace Doctrine\DBAL\Migrations\Event\Listeners;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\DBAL\Version;
 use Doctrine\DBAL\Migrations\Events;
 use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
 
-
 /**
  * Listens for `onMigrationsMigrated` and, if the conneciton is has autocommit
- * makes sure to do the final commit to make sure changes stick around.
+ * makes sure to do the final commit to ensure changes stick around.
  *
  * @since 1.6
  */
 final class AutoCommitListener implements EventSubscriber
 {
-    public function __construct()
-    {
-        if (Version::compare('2.5') > 0) {
-            throw new \LogicException(sprintf(
-                'Autocommit was introduced in DBAL 2.5, version %s detected. You cannot use %s',
-                Version::VERSION,
-                __CLASS__
-            ));
-        }
-    }
-
     public function onMigrationsMigrated(MigrationsEventArgs $args)
     {
         $conn = $args->getConnection();

--- a/lib/Doctrine/DBAL/Migrations/Event/Listeners/AutoCommitListener.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/Listeners/AutoCommitListener.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\DBAL\Migrations\Event\Listeners;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Version;
+use Doctrine\DBAL\Migrations\Events;
+use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
+
+
+/**
+ * Listens for `onMigrationsMigrated` and, if the conneciton is has autocommit
+ * makes sure to do the final commit to make sure changes stick around.
+ *
+ * @since 1.6
+ */
+final class AutoCommitListener implements EventSubscriber
+{
+    public function __construct()
+    {
+        if (Version::compare('2.5') > 0) {
+            throw new \LogicException(sprintf(
+                'Autocommit was introduced in DBAL 2.5, version %s detected. You cannot use %s',
+                Version::VERSION,
+                __CLASS__
+            ));
+        }
+    }
+
+    public function onMigrationsMigrated(MigrationsEventArgs $args)
+    {
+        $conn = $args->getConnection();
+        if (!$args->isDryRun() && !$conn->isAutoCommit()) {
+            $conn->commit();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return [Events::onMigrationsMigrated];
+    }
+}

--- a/lib/Doctrine/DBAL/Migrations/Event/MigrationsEventArgs.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/MigrationsEventArgs.php
@@ -55,6 +55,11 @@ class MigrationsEventArgs extends EventArgs
         return $this->config;
     }
 
+    public function getConnection()
+    {
+        return $this->config->getConnection();
+    }
+
     public function getDirection()
     {
         return $this->direction;

--- a/tests/Doctrine/DBAL/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Event\Listeners;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
+use Doctrine\DBAL\Migrations\Event\Listeners\AutoCommitListener;
+use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+
+class AutoCommitListenerTest extends MigrationTestCase
+{
+    private $conn, $listener;
+
+    public function testListenerDoesNothingDuringADryRun()
+    {
+        $this->willNotCommit();
+
+        $this->listener->onMigrationsMigrated($this->createArgs(true));
+    }
+
+    public function testListenerDoesNothingWhenConnecitonAutoCommitIsOn()
+    {
+        $this->willNotCommit();
+        $this->conn->expects($this->once())
+            ->method('isAutoCommit')
+            ->willReturn(true);
+
+        $this->listener->onMigrationsMigrated($this->createArgs(false));
+    }
+
+    public function testListenerDoesFinalCommitWhenAutoCommitIsOff()
+    {
+        $this->conn->expects($this->once())
+            ->method('isAutoCommit')
+            ->willReturn(false);
+        $this->conn->expects($this->once())
+            ->method('commit');
+
+        $this->listener->onMigrationsMigrated($this->createArgs(false));
+    }
+
+    protected function setUp()
+    {
+        $this->conn = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        try {
+            $this->listener = new AutoCommitListener();
+        } catch (\LogicException $e) {
+            $this->markTestSkipped('DBAL 2.5 required for auto commit tests');
+        }
+    }
+
+    private function willNotCommit()
+    {
+        $this->conn->expects(self::never())
+            ->method('commit');
+    }
+
+    private function createArgs($isDryRun)
+    {
+        return new MigrationsEventArgs(new Configuration($this->conn), 'up', $isDryRun);
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
@@ -45,11 +45,7 @@ class AutoCommitListenerTest extends MigrationTestCase
         $this->conn = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        try {
-            $this->listener = new AutoCommitListener();
-        } catch (\LogicException $e) {
-            $this->markTestSkipped('DBAL 2.5 required for auto commit tests');
-        }
+        $this->listener = new AutoCommitListener();
     }
 
     private function willNotCommit()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -429,11 +429,7 @@ class FunctionalTest extends MigrationTestCase
      */
     public function testMigrateWithConnectionWithAutoCommitOffStillPersistsChanges()
     {
-        try {
-            $listener = new AutoCommitListener();
-        } catch (\LogicException $e) {
-            $this->markTestSkipped('Need DBAL 2.5 to do auto commit tests');
-        }
+        $listener = new AutoCommitListener();
         list($conn, $config) = self::fileConnectionAndConfig();
         $config->registerMigration(1, MigrateWithDataModification::class);
         $migration = new Migration($config);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/_files/db/.gitignore
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/_files/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateWithDataModification.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateWithDataModification.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Doctrine\DBAL\Migrations\Tests\Stub\Functional;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class MigrateWithDataModification extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('INSERT INTO test_data_migration (test) VALUES (1), (2), (3)');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('DELETE FROM test_data_migration');
+    }
+
+    public function isTransactional()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Provided for folks who are using auto commit. By adding this listener to
their connection's event manager a finally `commit` call will be made
when migrations are complete.

Should close #496

See the discussion #505 for the rational here.