### PR TITLE
Remove Unnecessary Docblocks from Generated Migrations

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -50,18 +50,12 @@ use Doctrine\DBAL\Schema\Schema;
  */
 class Version<version> extends AbstractMigration
 {
-    /**
-     * @param Schema $schema
-     */
     public function up(Schema $schema)
     {
         // this up() migration is auto-generated, please modify it to your needs
 <up>
     }
 
-    /**
-     * @param Schema $schema
-     */
     public function down(Schema $schema)
     {
         // this down() migration is auto-generated, please modify it to your needs


### PR DESCRIPTION
They only specified a type -- a type that was already apparent due to a typehint.