### PR TITLE
Support PDO::PARAM_* & Connection::PARAM_* in SQL Output

### DIFF
--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -40,6 +40,7 @@ if (!function_exists(__NAMESPACE__ . '\realpath')) {
 
 namespace Doctrine\DBAL\Migrations\Tests;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Migrations\MigrationException;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
@@ -446,6 +447,10 @@ class VersionTest extends MigrationTestCase
         return [
             'datetime' => [new \DateTime('2016-07-05 01:00:00'), 'datetime', '2016-07-05 01:00:00'],
             'array' => [['one' => 'two'], 'array', serialize(['one' => 'two'])],
+            'PDO::PARAM_*' => [1, \PDO::PARAM_INT, '1'],
+            'Connection::PARAM_*_ARRAY' => [[1, 2], Connection::PARAM_INT_ARRAY, '(1, 2)'],
+            'null value' => [null, \PDO::PARAM_NULL, 'NULL'],
+            'bad type' => [new \stdClass(), 'oops', '{}'],
         ];
     }
 


### PR DESCRIPTION
This uses the DBAL type system as a fallback when it can, and otherwise
runs the value through `json_encode` and hopes for the best. The
reasoning here is that on a dry or actual run shouldn't fail because
migrations doesn't know how to output a type.

Fixes #528 

I'm not 100% on this solution. Not sure if falling back to a DBAL type is a good idea -- maybe we should just `(string) $value` in those cases?