### PR TITLE
Change RecursiveRegexFinder to follow symlinks.

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -30,7 +30,7 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
     {
         return new \RegexIterator(
             new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS),
                 \RecursiveIteratorIterator::LEAVES_ONLY
             ),
             $this->getPattern(),

--- a/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -34,7 +34,7 @@ class RecursiveRegexFinderTest extends MigrationTestCase
     {
         $migrations = $this->finder->findMigrations(__DIR__ . '/_files', 'TestMigrations');
 
-        self::assertCount(6, $migrations);
+        self::assertCount(7, $migrations);
 
         $tests = [
             '20150502000000' => 'TestMigrations\\Version20150502000000',
@@ -43,6 +43,7 @@ class RecursiveRegexFinderTest extends MigrationTestCase
             '20150502000004' => 'TestMigrations\\Version20150502000004',
             '20150502000005' => 'TestMigrations\\Version20150502000005',
             '1_reset_versions' => 'TestMigrations\\Version1_reset_versions',
+            '1_symlinked_file' => 'TestMigrations\\Version1_symlinked_file',
         ];
         foreach ($tests as $version => $namespace) {
             self::assertArrayHasKey($version, $migrations);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Finder/_files/_symlinked_files
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Finder/_files/_symlinked_files
@@ -1,0 +1,1 @@
+../_symlinked_files/


### PR DESCRIPTION
We have a monolithic repository with shared entities and migrations between different instances of the default implementation.

The core entities related migrations are in a separated shared folder which we are symlinking into the migration folder (the namespace is the same).

Project structure:
```
vendor/something/something-migrations/DoctrineMigrations/
        Version20150101000000.php
        Version20150101000001.php
       ...

app /
    DoctrineMigrations /
        shared -> ../../vendor/something/something-migrations/DoctrineMigrations/
        Version20160101000000.php
        Version20160101000001.php
        ...
```

This change in RecursiveRegexFinder solves to handle the symlink.