### PR TITLE
Ability to change the class template

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php
@@ -57,6 +57,7 @@ abstract class AbstractFileConfiguration extends Configuration
         'name' => 'setName',
         'migrations_directory' => 'loadMigrationsFromDirectory',
         'migrations' => 'loadMigrations',
+        'custom_template' => 'setCustomTemplate',
     ];
 
     protected function setConfiguration(array $config)

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -154,6 +154,13 @@ class Configuration
     private $migrationsAreOrganizedByYearAndMonth = false;
 
     /**
+     * The custom template path to be used in generate command
+     *
+     * @var string
+     */
+    private $customTemplate;
+
+    /**
      * Construct a migration configuration object.
      *
      * @param Connection               $connection   A Connection instance
@@ -363,6 +370,26 @@ class Configuration
     public function getMigrationsNamespace()
     {
         return $this->migrationsNamespace;
+    }
+
+    /**
+     * Returns the custom template path
+     *
+     * @return string $customTemplate The custom template path
+     */
+    public function getCustomTemplate()
+    {
+        return $this->customTemplate;
+    }
+
+    /**
+     * Set the custom template path
+     *
+     * @param string $customTemplate The custom template path
+     */
+    public function setCustomTemplate($customTemplate)
+    {
+        $this->customTemplate = $customTemplate;
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -377,7 +377,7 @@ class Configuration
      *
      * @return string $customTemplate The custom template path
      */
-    public function getCustomTemplate()
+    public function getCustomTemplate() : ?string
     {
         return $this->customTemplate;
     }
@@ -387,7 +387,7 @@ class Configuration
      *
      * @param string $customTemplate The custom template path
      */
-    public function setCustomTemplate($customTemplate)
+    public function setCustomTemplate(string $customTemplate) : void
     {
         $this->customTemplate = $customTemplate;
     }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -89,7 +89,7 @@ EOT
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
 
-        $this->manageCustomTemplate($configuration, $input, $output);
+        $this->loadCustomTemplate($configuration, $output);
 
         $version = $configuration->generateVersionNumber();
         $path    = $this->generateMigration($configuration, $input, $version);
@@ -137,31 +137,29 @@ EOT
         return $path;
     }
 
-    protected function manageCustomTemplate(
-        Configuration $configuration,
-        InputInterface $input,
-        OutputInterface $output
-    ) : void {
+    private function loadCustomTemplate(Configuration $configuration, OutputInterface $output) : void
+    {
         $customTemplate = $configuration->getCustomTemplate();
 
-        if ($customTemplate !== null) {
-            $this->loadTemplateFile($customTemplate, $output);
+        if ($customTemplate === null) {
+            return;
         }
-    }
 
-    private function loadTemplateFile(string $customTemplate, OutputInterface $output) : void
-    {
-        $customTemplate = getcwd() . '/' . $customTemplate;
+        $filePath = getcwd() . '/' . $customTemplate;
 
-        if ( ! is_file($customTemplate) || ! is_readable($customTemplate)) {
+        if ( ! is_file($filePath) || ! is_readable($filePath)) {
             throw new \InvalidArgumentException(
                 'The specified template "' . $customTemplate . '" cannot be found or is not readable.'
             );
         }
 
-        $templateContent = file_get_contents($customTemplate);
+        $content = file_get_contents($filePath);
+
+        if ($content === false) {
+            throw new \InvalidArgumentException('The specified template "' . $customTemplate . '" could not be read.');
+        }
 
         $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $customTemplate));
-        $this->instanceTemplate = $templateContent;
+        $this->instanceTemplate = $content;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -137,8 +137,11 @@ EOT
         return $path;
     }
 
-    protected function manageCustomTemplate(Configuration $configuration, InputInterface $input, OutputInterface $output)
-    {
+    protected function manageCustomTemplate(
+        Configuration $configuration,
+        InputInterface $input,
+        OutputInterface $output
+    ) : void {
         $customTemplate = $configuration->getCustomTemplate();
 
         if ($customTemplate !== null) {
@@ -146,9 +149,10 @@ EOT
         }
     }
 
-    private function loadTemplateFile(string $customTemplate, OutputInterface $output): void
+    private function loadTemplateFile(string $customTemplate, OutputInterface $output) : void
     {
         $customTemplate = getcwd() . '/' . $customTemplate;
+
         if ( ! is_file($customTemplate)) {
             throw new \InvalidArgumentException('The specified template « ' . $customTemplate . ' » cannot be found.');
         }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -36,6 +36,8 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class GenerateCommand extends AbstractCommand
 {
+    private $_instanceTemplate;
+
     private static $_template =
             '<?php
 
@@ -104,7 +106,11 @@ EOT
 
     protected function getTemplate()
     {
-        return self::$_template;
+        if ($this->_instanceTemplate === null) {
+            $this->_instanceTemplate = self::$_template;
+        }
+
+        return $this->_instanceTemplate;
     }
 
     protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
@@ -140,7 +146,7 @@ EOT
 
     protected function manageCustomTemplate(Configuration $configuration, InputInterface $input, OutputInterface $output)
     {
-        $customTemplate = $input->getOption('template') ? $configuration->getCustomTemplate() : null;
+        $customTemplate = $input->getOption('template') ?? $configuration->getCustomTemplate();
 
         if ($customTemplate !== null) {
             $this->loadTemplateFile($customTemplate, $output);
@@ -161,6 +167,6 @@ EOT
         }
 
         $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $customTemplate));
-        self::$_template = $templateContent;
+        $this->_instanceTemplate = $templateContent;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -140,9 +140,9 @@ EOT
 
     protected function manageCustomTemplate(Configuration $configuration, InputInterface $input, OutputInterface $output)
     {
-        if ($tpl = $input->getOption('template') !== null) {
+        if ($tpl = $input->getOption('template')) {
             $this->loadTemplateFile($tpl, $output);
-        } elseif ($configuredTemplate = $configuration->getCustomTemplate() !== null) {
+        } elseif ($configuredTemplate = $configuration->getCustomTemplate()) {
             $this->loadTemplateFile($configuredTemplate, $output);
         }
     }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -94,7 +94,7 @@ EOT
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
 
-        $this->manageCustomTemplate($input, $output);
+        $this->manageCustomTemplate($configuration, $input, $output);
 
         $version = $configuration->generateVersionNumber();
         $path    = $this->generateMigration($configuration, $input, $version);
@@ -138,21 +138,29 @@ EOT
         return $path;
     }
 
-    protected function manageCustomTemplate(InputInterface $input, OutputInterface $output) {
-        if ($tpl = $input->getOption('template')) {
-            $tpl = getcwd() . '/' . $tpl;
-            if(!is_file($tpl)) {
-                throw new \InvalidArgumentException('The specified template « ' . $tpl . ' » cannot be found.');
-            }
-
-            $tplContent = file_get_contents($tpl);
-
-            if($tplContent === false) {
-                throw new \InvalidArgumentException('Cannot read file contents of template « ' . $tpl . ' ».');
-            }
-
-            $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $tpl));
-            self::$_template = $tplContent;
+    protected function manageCustomTemplate(Configuration $configuration, InputInterface $input, OutputInterface $output)
+    {
+        if ($tpl = $input->getOption('template') !== null) {
+            $this->loadTemplateFile($tpl, $output);
+        } elseif ($configuredTemplate = $configuration->getCustomTemplate() !== null) {
+            $this->loadTemplateFile($configuredTemplate, $output);
         }
+    }
+
+    private function loadTemplateFile($tpl, OutputInterface $output)
+    {
+        $tpl = getcwd() . '/' . $tpl;
+        if(!is_file($tpl)) {
+            throw new \InvalidArgumentException('The specified template « ' . $tpl . ' » cannot be found.');
+        }
+
+        $tplContent = file_get_contents($tpl);
+
+        if($tplContent === false) {
+            throw new \InvalidArgumentException('Cannot read file contents of template « ' . $tpl . ' ».');
+        }
+
+        $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $tpl));
+        self::$_template = $tplContent;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -140,27 +140,27 @@ EOT
 
     protected function manageCustomTemplate(Configuration $configuration, InputInterface $input, OutputInterface $output)
     {
-        if ($tpl = $input->getOption('template')) {
-            $this->loadTemplateFile($tpl, $output);
-        } elseif ($configuredTemplate = $configuration->getCustomTemplate()) {
-            $this->loadTemplateFile($configuredTemplate, $output);
+        $customTemplate = $input->getOption('template') ? $configuration->getCustomTemplate() : null;
+
+        if ($customTemplate !== null) {
+            $this->loadTemplateFile($customTemplate, $output);
         }
     }
 
-    private function loadTemplateFile($tpl, OutputInterface $output)
+    private function loadTemplateFile(string $customTemplate, OutputInterface $output): void
     {
-        $tpl = getcwd() . '/' . $tpl;
-        if(!is_file($tpl)) {
-            throw new \InvalidArgumentException('The specified template « ' . $tpl . ' » cannot be found.');
+        $customTemplate = getcwd() . '/' . $customTemplate;
+        if ( ! is_file($customTemplate)) {
+            throw new \InvalidArgumentException('The specified template « ' . $customTemplate . ' » cannot be found.');
         }
 
-        $tplContent = file_get_contents($tpl);
+        $templateContent = file_get_contents($customTemplate);
 
-        if($tplContent === false) {
-            throw new \InvalidArgumentException('Cannot read file contents of template « ' . $tpl . ' ».');
+        if ($templateContent === false) {
+            throw new \InvalidArgumentException('Cannot read file contents of template « ' . $customTemplate . ' ».');
         }
 
-        $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $tpl));
-        self::$_template = $tplContent;
+        $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $customTemplate));
+        self::$_template = $templateContent;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -36,8 +36,6 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class GenerateCommand extends AbstractCommand
 {
-    private $_instanceTemplate;
-
     private static $_template =
             '<?php
 
@@ -64,6 +62,8 @@ class Version<version> extends AbstractMigration
     }
 }
 ';
+
+    private $instanceTemplate;
 
     protected function configure()
     {
@@ -99,11 +99,11 @@ EOT
 
     protected function getTemplate()
     {
-        if ($this->_instanceTemplate === null) {
-            $this->_instanceTemplate = self::$_template;
+        if ($this->instanceTemplate === null) {
+            $this->instanceTemplate = self::$_template;
         }
 
-        return $this->_instanceTemplate;
+        return $this->instanceTemplate;
     }
 
     protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
@@ -160,6 +160,6 @@ EOT
         }
 
         $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $customTemplate));
-        $this->_instanceTemplate = $templateContent;
+        $this->instanceTemplate = $templateContent;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -94,7 +94,7 @@ EOT
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
 
-        $this->manageCustomTemplate();
+        $this->manageCustomTemplate($input, $output);
 
         $version = $configuration->generateVersionNumber();
         $path    = $this->generateMigration($configuration, $input, $version);

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -154,13 +154,13 @@ EOT
         $customTemplate = getcwd() . '/' . $customTemplate;
 
         if ( ! is_file($customTemplate)) {
-            throw new \InvalidArgumentException('The specified template « ' . $customTemplate . ' » cannot be found.');
+            throw new \InvalidArgumentException('The specified template "' . $customTemplate . '" cannot be found.');
         }
 
         $templateContent = file_get_contents($customTemplate);
 
         if ($templateContent === false) {
-            throw new \InvalidArgumentException('Cannot read file contents of template « ' . $customTemplate . ' ».');
+            throw new \InvalidArgumentException('Cannot read file contents of template "' . $customTemplate . '".');
         }
 
         $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $customTemplate));

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -71,7 +71,6 @@ class Version<version> extends AbstractMigration
                 ->setName('migrations:generate')
                 ->setDescription('Generate a blank migration class.')
                 ->addOption('editor-cmd', null, InputOption::VALUE_OPTIONAL, 'Open file with this command upon creation.')
-                ->addOption('template', null, InputOption::VALUE_OPTIONAL, 'The project relative path to a custom class template')
                 ->setHelp(<<<EOT
 The <info>%command.name%</info> command generates a blank migration class:
 
@@ -80,12 +79,6 @@ The <info>%command.name%</info> command generates a blank migration class:
 You can optionally specify a <comment>--editor-cmd</comment> option to open the generated file in your favorite editor:
 
     <info>%command.full_name% --editor-cmd=mate</info>
-
-You can optionally specify a <comment>--template</comment> option to use a custom class template:
-
-    <info>%command.full_name% --template=src/MyApp/Resources/tpl/MyDoctrineMigrationTemplate.tpl</info>
-
-This template will not be handled by a template engine (like Twig).
 EOT
         );
 
@@ -146,7 +139,7 @@ EOT
 
     protected function manageCustomTemplate(Configuration $configuration, InputInterface $input, OutputInterface $output)
     {
-        $customTemplate = $input->getOption('template') ?? $configuration->getCustomTemplate();
+        $customTemplate = $configuration->getCustomTemplate();
 
         if ($customTemplate !== null) {
             $this->loadTemplateFile($customTemplate, $output);

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -153,15 +153,13 @@ EOT
     {
         $customTemplate = getcwd() . '/' . $customTemplate;
 
-        if ( ! is_file($customTemplate)) {
-            throw new \InvalidArgumentException('The specified template "' . $customTemplate . '" cannot be found.');
+        if ( ! is_file($customTemplate) || ! is_readable($customTemplate)) {
+            throw new \InvalidArgumentException(
+                'The specified template "' . $customTemplate . '" cannot be found or is not readable.'
+            );
         }
 
         $templateContent = file_get_contents($customTemplate);
-
-        if ($templateContent === false) {
-            throw new \InvalidArgumentException('Cannot read file contents of template "' . $customTemplate . '".');
-        }
 
         $output->writeln(sprintf('Using custom migration template "<info>%s</info>"', $customTemplate));
         $this->instanceTemplate = $templateContent;

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 class GenerateCommandTest extends CommandTestCase
 {
     const VERSION = '20160705000000';
+    const CUSTOM_TEMPLATE_NAME = 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl';
 
     private $root;
     private $migrationFile;
@@ -24,6 +25,24 @@ class GenerateCommandTest extends CommandTestCase
         self::assertContains($this->migrationFile, $tester->getDisplay());
         self::assertTrue($this->root->hasChild($this->migrationFile));
         self::assertContains('class Version' . self::VERSION, $this->root->getChild($this->migrationFile)->getContent());
+    }
+
+    public function testCommandCreatesNewMigrationsFileWithACustomTemplateFromConfiguration()
+    {
+        $this->config->expects($this->once())
+            ->method('generateVersionNumber')
+            ->willReturn(self::VERSION);
+
+        $this->config->expects($this->once())
+            ->method('getCustomTemplate')
+            ->willReturn(self::CUSTOM_TEMPLATE_NAME);
+
+        list($tester, $statusCode) = $this->executeCommand([]);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertContains($this->migrationFile, $tester->getDisplay());
+        $this->assertTrue($this->root->hasChild($this->migrationFile));
+        $this->assertContains('public function customTemplate()', $this->root->getChild($this->migrationFile)->getContent());
     }
 
     protected function setUp()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -37,7 +37,7 @@ class GenerateCommandTest extends CommandTestCase
             ->method('getCustomTemplate')
             ->willReturn(self::CUSTOM_TEMPLATE_NAME);
 
-        list($tester, $statusCode) = $this->executeCommand([]);
+        [$tester, $statusCode] = $this->executeCommand([]);
 
         self::assertSame(0, $statusCode);
         self::assertContains($this->migrationFile, $tester->getDisplay());

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -39,10 +39,10 @@ class GenerateCommandTest extends CommandTestCase
 
         list($tester, $statusCode) = $this->executeCommand([]);
 
-        $this->assertSame(0, $statusCode);
-        $this->assertContains($this->migrationFile, $tester->getDisplay());
-        $this->assertTrue($this->root->hasChild($this->migrationFile));
-        $this->assertContains('public function customTemplate()', $this->root->getChild($this->migrationFile)->getContent());
+        self::assertSame(0, $statusCode);
+        self::assertContains($this->migrationFile, $tester->getDisplay());
+        self::assertTrue($this->root->hasChild($this->migrationFile));
+        self::assertContains('public function customTemplate()', $this->root->getChild($this->migrationFile)->getContent());
     }
 
     protected function setUp()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 
 class GenerateCommandTest extends CommandTestCase
 {
-    const VERSION = '20160705000000';
+    const VERSION              = '20160705000000';
     const CUSTOM_TEMPLATE_NAME = 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl';
 
     private $root;

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/config.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/config.yml
@@ -1,3 +1,4 @@
 name: "name"
 table_name: "migrations_table_name"
 migrations_namespace: "migrations_namespace"
+custom_template: "tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl"

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl
@@ -1,0 +1,28 @@
+<?php
+
+namespace <namespace>;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+* Auto-generated Migration: Please modify to your needs!
+*/
+class Version<version> extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+<up>
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+<down>
+    }
+
+    public function customTemplate() {
+        // this method is for test asserts
+    }
+}

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migrations.yml
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migrations.yml
@@ -2,3 +2,4 @@
 name: "name"
 table_name: "migrations_table_name"
 migrations_namespace: "migrations_namespace"
+custom_template: "tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl"


### PR DESCRIPTION
Related to this issue : https://github.com/doctrine/DoctrineMigrationsBundle/issues/199

Related to PR : https://github.com/doctrine/DoctrineMigrationsBundle/pull/200

Here's the PR that introduce custom template for command doctrine:migrations:generate.
It also add a command option in order to set custom template just for the current command.

E.G: bin/console do:mi:ge --template src/MyBundle/Resources/tpl/migration.tpl