### PR TITLE
use yoda style comparison in generated migrations

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -159,7 +159,7 @@ EOT
             array_unshift(
                 $code,
                 sprintf(
-                    "\$this->abortIf(\$this->connection->getDatabasePlatform()->getName() !== %s, %s);",
+                    "\$this->abortIf(%s !== \$this->connection->getDatabasePlatform()->getName(), %s);",
                     var_export($currentPlatform, true),
                     var_export(sprintf("Migration can only be executed safely on '%s'.", $currentPlatform), true)
                 ),


### PR DESCRIPTION
small nitpick, but it does not hurt to have generated code follow best practices.

(and popular code sniffers complain when code is not doing yoda style comparisons...)