### PR TITLE
Adding Symfony 4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": "^7.1",
         "doctrine/dbal": "~2.6",
-        "symfony/yaml": "~3.3",
-        "symfony/console": "~3.3",
+        "symfony/yaml": "~3.3|^4.0",
+        "symfony/console": "~3.3|^4.0",
         "ocramius/proxy-manager": "^1.0|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The DoctrineMigrationsBundle is currently uninstallable in Symfony 4 - as we need to allow Symfony 4 support in this library. I don't expect any issues, but let's see if the tests pass :).