### PR TITLE
Add ConfigurationHelperInterface

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ConnectionHelperLoa
 use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ConnectionConfigurationChainLoader;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
+use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelperInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -88,7 +89,7 @@ abstract class AbstractCommand extends Command
     {
         if ( ! $this->migrationConfiguration) {
             if ($this->getHelperSet()->has('configuration')
-                && $this->getHelperSet()->get('configuration') instanceof ConfigurationHelper) {
+                && $this->getHelperSet()->get('configuration') instanceof ConfigurationHelperInterface) {
                 $configHelper = $this->getHelperSet()->get('configuration');
             } else {
                 $configHelper = new ConfigurationHelper($this->getConnection($input), $this->configuration);

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Helper\Helper;
  * @package Doctrine\DBAL\Migrations\Tools\Console\Helper
  * @internal
  */
-class ConfigurationHelper extends Helper
+class ConfigurationHelper extends Helper implements ConfigurationHelperInterface
 {
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelperInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelperInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Doctrine\DBAL\Migrations\Tools\Console\Helper;
+
+use Doctrine\DBAL\Migrations\OutputWriter;
+use Symfony\Component\Console\Input\InputInterface;
+
+interface ConfigurationHelperInterface
+{
+    public function getMigrationConfig(InputInterface $input, OutputWriter $outputWriter);
+}


### PR DESCRIPTION
I had this problem a few days ago: needed to override the `ConfigurationHelper` to be able to inject a custom finder implementation in DoctrineMigrationsBundle. Since the class is marked as `internal` (and should probably be `final` in 2.0), it makes sense adding an interface to allow people to supply their own configuration helper.