### PR TITLE
Show diff command output in verbose mode only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.1] - 2017-11-18
+
+### Fixed
+  - [572: Only show generated migration in verbose mode](https://github.com/doctrine/migrations/pull/572) - @alcaeus
+
 ## [1.6.0] - 2017-11-09
 
 ### Fixed

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/DiffCommand.php
@@ -110,7 +110,7 @@ EOT
         $path    = $this->generateMigration($configuration, $input, $version, $up, $down);
 
         $output->writeln(sprintf('Generated new migration class to "<info>%s</info>" from schema differences.', $path));
-        $output->writeln(file_get_contents($path));
+        $output->writeln(file_get_contents($path), OutputInterface::VERBOSITY_VERBOSE);
     }
 
     private function buildCodeFromSql(Configuration $configuration, array $sql, $formatted = false, $lineLength = 120)


### PR DESCRIPTION
Changes the code added in #497 to only show the migration code in verbose mode. For one, there really isn't an advantage to showing the migration code and it makes the output of the new Symfony Maker commands quite ugly. #SymfonyConHackday2017