### PR TITLE
Replace invalid method call on Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
 
     - stage: Lint
       before_script:
-        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.7
+        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
       script: vendor/bin/phpstan analyse -l 3 -c phpstan.neon lib
 
     - stage: Coverage

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -250,7 +250,7 @@ class Configuration
     /**
      * Returns the datetime of a migration
      *
-     * @param $version
+     * @param string $version
      * @return string
      */
     public function getDateTime($version)

--- a/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
@@ -29,8 +29,8 @@ abstract class AbstractFinder implements MigrationFinderInterface
 
     /**
      * Load the migrations and return an array of thoses loaded migrations
-     * @param $files array of migration filename found
-     * @param $namespace namespace of thoses migrations
+     * @param array $files array of migration filename found
+     * @param string $namespace namespace of thoses migrations
      * @return array constructed with the migration name as key and the value is the fully qualified name of the migration
      */
     protected function loadMigrations($files, $namespace)

--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -23,7 +23,7 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
 
     /**
      * Create a recursive iterator to find all the migrations in the subdirectories.
-     * @param $dir
+     * @param string $dir
      * @return \RegexIterator
      */
     private function createIterator($dir)
@@ -45,7 +45,7 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
 
     /**
      * Transform the recursiveIterator result array of array into the expected array of migration file
-     * @param $iteratorFilesMatch
+     * @param iterable $iteratorFilesMatch
      * @return array
      */
     private function getMatches($iteratorFilesMatch)

--- a/lib/Doctrine/DBAL/Migrations/MigrationsVersion.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationsVersion.php
@@ -17,7 +17,7 @@ class MigrationsVersion
     }
 
     /**
-     * @param $gitversion
+     * @param string $gitversion
      * @return bool
      *
      * Check if doctrine migration is installed by composer or

--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -45,7 +45,7 @@ class Version
     /**
      * The version in timestamp format (YYYYMMDDHHMMSS)
      *
-     * @param int
+     * @var string
      */
     private $version;
 
@@ -444,8 +444,8 @@ class Version
     /**
      * Formats a set of sql parameters for output with dry run.
      *
-     * @param $params The query parameters
-     * @param $types The types of the query params. Default type is a string
+     * @param array $params The query parameters
+     * @param array $types The types of the query params. Default type is a string
      * @return string|null a string of the parameters present.
      */
     private function formatParamsForOutput(array $params, array $types)

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -253,7 +253,7 @@ class AbstractCommandTest extends MigrationTestCase
         self::assertSame($configuration, $actualConfiguration);
     }
 
-    public function invokeAbstractCommandConfirmation($input, $helper, $response = "y", $question = "There is no question?")
+    private function invokeAbstractCommandConfirmation($input, $helper, $response = "y", $question = "There is no question?")
     {
         $class  = new \ReflectionClass(AbstractCommand::class);
         $method = $class->getMethod('askConfirmation');
@@ -265,7 +265,7 @@ class AbstractCommandTest extends MigrationTestCase
             ['command']
         );
 
-        $helper->setInputStream($this->getInputStream($response . "\n"));
+        $input->setStream($this->getInputStream($response . "\n"));
         if ($helper instanceof QuestionHelper) {
             $helperSet = new HelperSet([
                 'question' => $helper
@@ -287,12 +287,9 @@ class AbstractCommandTest extends MigrationTestCase
 
     public function testAskConfirmation()
     {
-        $input = $this->getMockBuilder(ArrayInput::class)
-            ->setConstructorArgs([[]])
-            ->setMethods(['getOption'])
-            ->getMock();
-
+        $input  = new ArrayInput([]);
         $helper = new QuestionHelper();
+
         self::assertTrue($this->invokeAbstractCommandConfirmation($input, $helper));
         self::assertFalse($this->invokeAbstractCommandConfirmation($input, $helper, "n"));
     }


### PR DESCRIPTION
This fixes a failing bug when running on Symfony 4: the `setInputStream` method in `QuestionHelper` has been removed; we now have to call `setStream` on the input itself.