### PR TITLE
Follow Doctrine CS for generated strict types declaration

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 class GenerateCommand extends AbstractCommand
 {
     private static $_template =
-            '<?php declare(strict_types = 1);
+            '<?php declare(strict_types=1);
 
 namespace <namespace>;
 


### PR DESCRIPTION
Per discussion in #577, also making strict types directive follow our CS in generated code.