### PR TITLE
Do not create migration_versions when running with --dry-run

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -540,7 +540,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        if (!$this->migrationTableCreated && $this->isDryRun) {
+        if ( ! $this->migrationTableCreated && $this->isDryRun) {
             return [];
         }
 
@@ -580,7 +580,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        if (!$this->migrationTableCreated && $this->isDryRun) {
+        if ( ! $this->migrationTableCreated && $this->isDryRun) {
             return '0';
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -78,6 +78,9 @@ EOT
 
         $timeAllqueries = $input->getOption('query-time');
 
+        $dryRun = (boolean) $input->getOption('dry-run');
+        $configuration->setIsDryRun($dryRun);
+
         $executedMigrations  = $configuration->getMigratedVersions();
         $availableMigrations = $configuration->getAvailableVersions();
 
@@ -115,8 +118,6 @@ EOT
             $migration->writeSqlFile($path, $version);
             return 0;
         }
-
-        $dryRun = (boolean) $input->getOption('dry-run');
 
         $cancelled = false;
         $migration->setNoMigrationException($input->getOption('allow-no-migration'));

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -108,6 +108,15 @@ class MigrateCommandTest extends CommandTestCase
             ->method('migrate')
             ->with(self::VERSION, true, true);
 
+        // dry run is set before getting the migrated versions
+        $this->config->expects($this->at(2))
+            ->method('setIsDryRun')
+            ->with(true);
+        $this->config->expects($this->at(3))
+            ->method('getMigratedVersions');
+        $this->config->expects($this->at(4))
+            ->method('getAvailableVersions');
+
         list($tester, $statusCode) = $this->executeCommand([
             '--dry-run' => true,
             '--query-time' => true,


### PR DESCRIPTION
The `migration_versions` table is being created when running `doctrine:migrations:migrate` with `--dry-run` option, as described by @tehplague in #521

Here's my proposal to prevent the table creation when running with `--dry-run`.