### PR TITLE
Move symfony/yaml into Dev Requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     "require": {
         "php": "^7.1",
         "doctrine/dbal": "~2.6",
-        "symfony/yaml": "~3.3|^4.0",
         "symfony/console": "~3.3|^4.0",
         "ocramius/proxy-manager": "^1.0|^2.0"
     },
     "require-dev": {
         "doctrine/orm": "~2.5",
+        "symfony/yaml": "~3.3|^4.0",
         "phpunit/phpunit": "~6.2",
         "doctrine/coding-standard": "^1.0",
         "jdorn/sql-formatter": "~1.1",
@@ -26,7 +26,8 @@
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {
-        "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command."
+        "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+        "symfony/yaml": "Allows the use of yaml for migration configuration files."
     },
     "autoload": {
         "psr-4": {

--- a/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
@@ -4,6 +4,8 @@ namespace Doctrine\DBAL\Migrations\Configuration;
 
 use Symfony\Component\Yaml\Yaml;
 
+use Doctrine\DBAL\Migrations\MigrationException;
+
 /**
  * Load migration configuration information from a YAML configuration file.
  *
@@ -19,6 +21,10 @@ class YamlConfiguration extends AbstractFileConfiguration
      */
     protected function doLoad($file)
     {
+        if ( ! class_exists(Yaml::class)) {
+            throw MigrationException::yamlConfigurationNotAvailable();
+        }
+
         $config = Yaml::parse(file_get_contents($file));
 
         if ( ! is_array($config)) {

--- a/lib/Doctrine/DBAL/Migrations/MigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationException.php
@@ -49,6 +49,11 @@ class MigrationException extends \Exception
         return new self(sprintf('Migrations configuration file already loaded'), 8);
     }
 
+    public static function yamlConfigurationNotAvailable() : self
+    {
+        return new self('Unable to load yaml configuration files, please `composer require symfony/yaml` load yaml configuration files');
+    }
+
     public static function configurationIncompatibleWithFinder(
         $configurationParameterName,
         MigrationFinderInterface $finder


### PR DESCRIPTION
And throw an exception in YamlConfiguration::doLoad if yaml isn't
available.

This also includes a composer suggestion to install symfony/yaml.

Closes #573 

Really not sure how to add a test to cover this. [Symfony uses this strategy](https://github.com/symfony/symfony/blob/e04b4f4a1b6830e3bad7b484db81915efed14813/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php#L601-L603), but doesn't [seem to test it](https://github.com/symfony/symfony/blob/e04b4f4a1b6830e3bad7b484db81915efed14813/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php).