### PR TITLE
Apply Doctrine CS 4.0, version composer.lock, merge stages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@ build.properties.dev    export-ignore
 build.xml               export-ignore
 /phpunit.xml.dist       export-ignore
 /phpcs.xml.dist         export-ignore
+composer.lock           export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ reports/
 dist/
 tests/phpunit.xml
 vendor/
-composer.lock
 box.phar
 phpunit.xml
 /phpcs.xml

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,10 +1,22 @@
 build:
-    environment:
-        php:
-            version: 7.1
-
-before_commands:
-    - "composer install --no-dev --prefer-source"
+    nodes:
+        analysis:
+            environment:
+                php:
+                    version: 7.1
+            cache:
+                disabled: false
+                directories:
+                    - ~/.composer/cache
+            project_setup:
+                override: true
+            tests:
+                override:
+                    - php-scrutinizer-run
+                    - phpcs-run
+    dependencies:
+        override:
+            - composer install --ignore-platform-reqs --no-interaction
 
 tools:
     external_code_coverage:
@@ -15,5 +27,3 @@ build_failure_conditions:
     - 'issues.label("coding-style").new.exists'                 # No new coding style issues allowed
     - 'issues.severity(>= MAJOR).new.exists'                    # New issues of major or higher severity
     - 'project.metric_change("scrutinizer.test_coverage", < 0)' # Code Coverage decreased from previous inspection
-    - 'patches.label("Doc Comments").new.exists'                # No new doc comments patches allowed
-    - 'patches.label("Unused Use Statements").new.exists'       # No new unused imports patches allowed

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ cache:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
-  - composer self-update
+  - travis_retry composer self-update
 
-install: travis_retry composer update --prefer-dist
+install:
+  - rm composer.lock
+  - travis_retry composer update --prefer-dist
 
 script:
   - ./vendor/bin/phpunit
@@ -27,11 +29,12 @@ jobs:
   include:
     - stage: Test
       env: DEPENDENCIES=low
-      install: travis_retry composer update --prefer-dist --prefer-lowest
+      install:
+        - rm composer.lock
+        - travis_retry composer update --prefer-dist --prefer-lowest
 
     - stage: Lint
-      before_script:
-        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.9
+      install: travis_retry composer install --prefer-dist
       script: vendor/bin/phpstan analyse -l 3 -c phpstan.neon lib
 
     - stage: Coverage
@@ -45,5 +48,6 @@ jobs:
         - php ocular.phar code-coverage:upload --format=php-clover clover.xml
 
     - stage: Coding standard
+      install: travis_retry composer install --prefer-dist
       script:
         - ./vendor/bin/phpcs

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,8 @@ jobs:
         - rm composer.lock
         - travis_retry composer update --prefer-dist --prefer-lowest
 
-    - stage: Lint
-      install: travis_retry composer install --prefer-dist
-      script: vendor/bin/phpstan analyse -l 3 -c phpstan.neon lib
-
-    - stage: Coverage
+    - stage: Test
+      env: COVERAGE
       before_script:
         - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{.disabled,}
         - if [[ ! $(php -m | grep -si xdebug) ]]; then echo "xdebug required for coverage"; exit 1; fi
@@ -47,7 +44,12 @@ jobs:
         - wget https://scrutinizer-ci.com/ocular.phar
         - php ocular.phar code-coverage:upload --format=php-clover clover.xml
 
-    - stage: Coding standard
+    - stage: Code Quality
+      env: CODING_STANDARDS
       install: travis_retry composer install --prefer-dist
-      script:
-        - ./vendor/bin/phpcs
+      script: ./vendor/bin/phpcs
+
+    - stage: Code Quality
+      env: STATIC_ANALYSIS
+      install: travis_retry composer install --prefer-dist
+      script: vendor/bin/phpstan analyse -l 3 -c phpstan.neon lib

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "phpunit/phpunit": "~7.0",
         "doctrine/coding-standard": "^4.0",
         "jdorn/sql-formatter": "~1.1",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsStream": "^1.6",
+        "phpstan/phpstan-shim": "^0.9.2"
     },
     "suggest": {
         "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command.",

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,9 @@
         "doctrine/orm": "~2.5",
         "symfony/yaml": "~3.3|^4.0",
         "phpunit/phpunit": "~7.0",
-        "doctrine/coding-standard": "^1.0",
+        "doctrine/coding-standard": "^4.0",
         "jdorn/sql-formatter": "~1.1",
-        "mikey179/vfsStream": "^1.6",
-        "squizlabs/php_codesniffer": "^3.0"
+        "mikey179/vfsStream": "^1.6"
     },
     "suggest": {
         "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command.",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,2793 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "fb2107c1189bb14a2a2518c204b5cd6b",
+    "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-12-06T07:11:42+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "v1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "reference": "b3217d58609e9c8e661cd41357a54d926c4a2a1a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^5.7",
+                "predis/predis": "~1.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Caching library offering an object-oriented API for many cache backends",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "cache",
+                "caching"
+            ],
+            "time": "2017-08-25T07:02:50+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "reference": "a01ee38fcd999f34d9bfbcee59dbda5105449cbf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Collections\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Collections Abstraction library",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "array",
+                "collections",
+                "iterator"
+            ],
+            "time": "2017-07-22T10:37:32+00:00"
+        },
+        {
+            "name": "doctrine/common",
+            "version": "v2.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "reference": "f68c297ce6455e8fd794aa8ffaf9fa458f6ade66",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "1.*",
+                "doctrine/cache": "1.*",
+                "doctrine/collections": "1.*",
+                "doctrine/inflector": "1.*",
+                "doctrine/lexer": "1.*",
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common Library for Doctrine projects",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "collections",
+                "eventmanager",
+                "persistence",
+                "spl"
+            ],
+            "time": "2017-08-31T08:43:38+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "v2.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "e3eed9b1facbb0ced3a0995244843a189e7d1b13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/e3eed9b1facbb0ced3a0995244843a189e7d1b13",
+                "reference": "e3eed9b1facbb0ced3a0995244843a189e7d1b13",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.7.1",
+                "ext-pdo": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4.6",
+                "phpunit/phpunit-mock-objects": "!=3.2.4,!=3.2.5",
+                "symfony/console": "2.*||^3.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\DBAL\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Database Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "persistence",
+                "queryobject"
+            ],
+            "time": "2017-11-19T13:38:54+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5527a48b7313d15261292c149e55e26eae771b0a",
+                "reference": "5527a48b7313d15261292c149e55e26eae771b0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2018-01-09T20:05:19+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "reference": "4489d5002c49d55576fa0ba786f42dbb009be46f",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": "^7.1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.6.3",
+                "ext-zip": "*",
+                "infection/infection": "^0.7.1",
+                "phpunit/phpunit": "^7.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2018-02-05T13:05:30+00:00"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.1.1",
+                "php": "^7.1.0",
+                "zendframework/zend-code": "^3.1.0"
+            },
+            "require-dev": {
+                "couscous/couscous": "^1.5.2",
+                "ext-phar": "*",
+                "humbug/humbug": "dev-master@DEV",
+                "nikic/php-parser": "^3.0.4",
+                "phpbench/phpbench": "^0.12.2",
+                "phpstan/phpstan": "^0.6.4",
+                "phpunit/phpunit": "^5.6.4",
+                "phpunit/phpunit-mock-objects": "^3.4.1",
+                "squizlabs/php_codesniffer": "^2.7.0"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ProxyManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2017-05-04T11:12:50+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~3.4|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~3.4|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.4|~4.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-26T15:55:47+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "reference": "78be803ce01e55d3491c1397cf1c64beb9c1b63b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-01-30T19:27:44+00:00"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "zendframework/zend-eventmanager": "^2.6 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2017-10-20T15:21:32+00:00"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "^0.1",
+                "container-interop/container-interop": "^1.1.0",
+                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
+            },
+            "suggest": {
+                "container-interop/container-interop": "^1.1.0, to use the lazy listeners feature",
+                "zendframework/zend-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "zf2"
+            ],
+            "time": "2017-07-11T19:17:22+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06T16:27:17+00:00"
+        },
+        {
+            "name": "doctrine/coding-standard",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/coding-standard.git",
+                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "reference": "0469c18a1a4724c278f2879c0dd7b1fa860b52de",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.2",
+                "php": "^7.1",
+                "slevomat/coding-standard": "^4.5.0",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Sniffs\\": "lib/Doctrine/Sniffs"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Steve Müller",
+                    "email": "st.mueller@dzh-online.de"
+                }
+            ],
+            "description": "Doctrine Coding Standard",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "code",
+                "coding",
+                "cs",
+                "doctrine",
+                "sniffer",
+                "standard",
+                "style"
+            ],
+            "time": "2018-03-03T23:49:15+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "doctrine/orm",
+            "version": "v2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/doctrine2.git",
+                "reference": "87ee409783a4a322b5597ebaae558661404055a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/87ee409783a4a322b5597ebaae558661404055a7",
+                "reference": "87ee409783a4a322b5597ebaae558661404055a7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "~1.5",
+                "doctrine/cache": "~1.6",
+                "doctrine/collections": "^1.4",
+                "doctrine/common": "^2.7.1",
+                "doctrine/dbal": "^2.6",
+                "doctrine/instantiator": "~1.1",
+                "ext-pdo": "*",
+                "php": "^7.1",
+                "symfony/console": "~3.0|~4.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^1.0",
+                "phpunit/phpunit": "^6.5",
+                "squizlabs/php_codesniffer": "^3.2",
+                "symfony/yaml": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/yaml": "If you want to use YAML Metadata Mapping Driver"
+            },
+            "bin": [
+                "bin/doctrine"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\ORM\\": "lib/Doctrine/ORM"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Object-Relational-Mapper for PHP",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "orm"
+            ],
+            "time": "2018-02-27T07:30:56+00:00"
+        },
+        {
+            "name": "jdorn/sql-formatter",
+            "version": "v1.2.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jdorn/sql-formatter.git",
+                "reference": "64990d96e0959dff8e059dfcdc1af130728d92bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jdorn/sql-formatter/zipball/64990d96e0959dff8e059dfcdc1af130728d92bc",
+                "reference": "64990d96e0959dff8e059dfcdc1af130728d92bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "3.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "lib"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Dorn",
+                    "email": "jeremy@jeremydorn.com",
+                    "homepage": "http://jeremydorn.com/"
+                }
+            ],
+            "description": "a PHP SQL highlighting library",
+            "homepage": "https://github.com/jdorn/sql-formatter/",
+            "keywords": [
+                "highlight",
+                "sql"
+            ],
+            "time": "2014-01-12T16:20:24+00:00"
+        },
+        {
+            "name": "mikey179/vfsStream",
+            "version": "v1.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikey179/vfsStream.git",
+                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "reference": "d5fec95f541d4d71c4823bb5e30cf9b9e5b96145",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2017-08-01T08:02:14+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-30T07:14:17+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2018-02-19T10:16:54+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-shim",
+            "version": "0.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-shim.git",
+                "reference": "e4720fb2916be05de02869780072253e7e0e8a75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-shim/zipball/e4720fb2916be05de02869780072253e7e0e8a75",
+                "reference": "e4720fb2916be05de02869780072253e7e0e8a75",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.0"
+            },
+            "replace": {
+                "phpstan/phpstan": "self.version"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.9-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan Phar distribution",
+            "time": "2018-01-28T14:29:27+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-02T07:01:41+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2017-11-27T13:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2018-02-01T13:07:23+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2018-02-01T13:16:43+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-26T07:03:12+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2018-02-15T05:27:38+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-02-01T13:46:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2018-02-01T13:45:15+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2017-07-01T08:51:00+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2017-04-03T13:19:02+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "4.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "3957603813d466aa820231a6ac9d4d73d0dcf935"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/3957603813d466aa820231a6ac9d4d73d0dcf935",
+                "reference": "3957603813d466aa820231a6ac9d4d73d0dcf935",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "squizlabs/php_codesniffer": "^3.2.3"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "phing/phing": "2.16",
+                "phpstan/phpstan": "0.9.2",
+                "phpstan/phpstan-phpunit": "0.9.4",
+                "phpstan/phpstan-strict-rules": "0.9",
+                "phpunit/php-code-coverage": "6.0.1",
+                "phpunit/phpunit": "7.0.2"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2018-03-02T15:11:15+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4842476c434e375f9d3182ff7b89059583aa8b27",
+                "reference": "4842476c434e375f9d3182ff7b89059583aa8b27",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2018-02-20T21:35:23+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "de5f125ea39de846b90b313b2cfb031a0152d223"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/de5f125ea39de846b90b313b2cfb031a0152d223",
+                "reference": "de5f125ea39de846b90b313b2cfb031a0152d223",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-02-19T20:08:53+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^7.1"
+    },
+    "platform-dev": []
+}

--- a/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/DBAL/Migrations/AbstractMigration.php
@@ -6,11 +6,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Abstract class for individual migrations to extend from.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 abstract class AbstractMigration
 {
@@ -87,26 +82,28 @@ abstract class AbstractMigration
     /**
      * Print a warning message if the condition evaluates to TRUE.
      *
-     * @param boolean $condition
-     * @param string  $message
+     * @param bool   $condition
+     * @param string $message
      */
     public function warnIf($condition, $message = '')
     {
-        if ($condition) {
-            $message = $message ?: 'Unknown Reason';
-            $this->outputWriter->write(sprintf(
-                '    <comment>Warning during %s: %s</comment>',
-                $this->version->getExecutionState(),
-                $message
-            ));
+        if (! $condition) {
+            return;
         }
+
+        $message = $message ?: 'Unknown Reason';
+        $this->outputWriter->write(sprintf(
+            '    <comment>Warning during %s: %s</comment>',
+            $this->version->getExecutionState(),
+            $message
+        ));
     }
 
     /**
      * Abort the migration if the condition evaluates to TRUE.
      *
-     * @param boolean $condition
-     * @param string  $message
+     * @param bool   $condition
+     * @param string $message
      *
      * @throws AbortMigrationException
      */
@@ -120,8 +117,8 @@ abstract class AbstractMigration
     /**
      * Skip this migration (but not the next ones) if condition evaluates to TRUE.
      *
-     * @param boolean $condition
-     * @param string  $message
+     * @param bool   $condition
+     * @param string $message
      *
      * @throws SkipMigrationException
      */
@@ -151,6 +148,10 @@ abstract class AbstractMigration
     abstract public function up(Schema $schema);
     abstract public function down(Schema $schema);
 
+    /**
+     * @param string[] $params
+     * @param mixed[]  $types
+     */
     protected function addSql($sql, array $params = [], array $types = [])
     {
         $this->version->addSql($sql, $params, $types);
@@ -163,7 +164,7 @@ abstract class AbstractMigration
 
     protected function throwIrreversibleMigrationException($message = null)
     {
-        if (null === $message) {
+        if ($message === null) {
             $message = 'This migration is irreversible and cannot be reverted.';
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Configuration/ArrayConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/ArrayConfiguration.php
@@ -4,11 +4,6 @@ namespace Doctrine\DBAL\Migrations\Configuration;
 
 /**
  * Load migration configuration information from a PHP configuration file.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      David Havl <contact@davidhavl.com>
  */
 class ArrayConfiguration extends AbstractFileConfiguration
 {

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -7,12 +7,12 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Migrations\FileQueryWriter;
 use Doctrine\DBAL\Migrations\Finder\MigrationDeepFinderInterface;
+use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
+use Doctrine\DBAL\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\DBAL\Migrations\MigrationException;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\QueryWriter;
 use Doctrine\DBAL\Migrations\Version;
-use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
-use Doctrine\DBAL\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
@@ -21,30 +21,25 @@ use Doctrine\DBAL\Types\Type;
  * Default Migration Configuration object used for configuring an instance of
  * the Migration class. Set the connection, version table name, register migration
  * classes/versions, etc.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class Configuration
 {
     /**
      * Configure versions to be organized by year.
      */
-    const VERSIONS_ORGANIZATION_BY_YEAR = 'year';
+    public const VERSIONS_ORGANIZATION_BY_YEAR = 'year';
 
     /**
      * Configure versions to be organized by year and month.
      *
      * @var string
      */
-    const VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH = 'year_and_month';
+    public const VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH = 'year_and_month';
 
     /**
      * The date format for new version numbers
      */
-    const VERSION_FORMAT = 'YmdHis';
+    public const VERSION_FORMAT = 'YmdHis';
 
     /**
      * Name of this set of migrations
@@ -56,7 +51,7 @@ class Configuration
     /**
      * Flag for whether or not the migration table has been created
      *
-     * @var boolean
+     * @var bool
      */
     private $migrationTableCreated = false;
 
@@ -82,9 +77,7 @@ class Configuration
      */
     private $migrationFinder;
 
-    /**
-     * @var QueryWriter
-     */
+    /** @var QueryWriter */
     private $queryWriter;
 
     /**
@@ -125,14 +118,14 @@ class Configuration
     /**
      * Versions are organized by year.
      *
-     * @var boolean
+     * @var bool
      */
     private $migrationsAreOrganizedByYear = false;
 
     /**
      * Versions are organized by year and month.
      *
-     * @var boolean
+     * @var bool
      */
     private $migrationsAreOrganizedByYearAndMonth = false;
 
@@ -156,13 +149,12 @@ class Configuration
      * @param Connection               $connection   A Connection instance
      * @param OutputWriter             $outputWriter A OutputWriter instance
      * @param MigrationFinderInterface $finder       Migration files finder
-     * @param QueryWriter|null         $queryWriter
      */
     public function __construct(
         Connection $connection,
-        OutputWriter $outputWriter = null,
-        MigrationFinderInterface $finder = null,
-        QueryWriter $queryWriter = null
+        ?OutputWriter $outputWriter = null,
+        ?MigrationFinderInterface $finder = null,
+        ?QueryWriter $queryWriter = null
     ) {
         $this->connection      = $connection;
         $this->outputWriter    = $outputWriter ?? new OutputWriter();
@@ -193,10 +185,10 @@ class Configuration
      */
     public function validate()
     {
-        if ( ! $this->migrationsNamespace) {
+        if (! $this->migrationsNamespace) {
             throw MigrationException::migrationsNamespaceRequired();
         }
-        if ( ! $this->migrationsDirectory) {
+        if (! $this->migrationsDirectory) {
             throw MigrationException::migrationsDirectoryRequired();
         }
     }
@@ -223,8 +215,6 @@ class Configuration
 
     /**
      * Sets the output writer.
-     *
-     * @param OutputWriter $outputWriter
      */
     public function setOutputWriter(OutputWriter $outputWriter)
     {
@@ -258,6 +248,7 @@ class Configuration
      * Returns the datetime of a migration
      *
      * @param string $version
+     *
      * @return string
      */
     public function getDateTime($version)
@@ -386,6 +377,7 @@ class Configuration
      * Set the implementation of the migration finder.
      *
      * @param MigrationFinderInterface $finder The new migration finder
+     *
      * @throws MigrationException
      */
     public function setMigrationsFinder(MigrationFinderInterface $finder)
@@ -448,8 +440,7 @@ class Configuration
      * Register an array of migrations. Each key of the array is the version and
      * the value is the migration class name.
      *
-     *
-     * @param array $migrations
+     * @param string[] $migrations
      *
      * @return Version[]
      */
@@ -488,7 +479,7 @@ class Configuration
             $this->registerMigrationsFromDirectory($this->getMigrationsDirectory());
         }
 
-        if ( ! isset($this->migrations[$version])) {
+        if (! isset($this->migrations[$version])) {
             throw MigrationException::unknownMigrationVersion($version);
         }
 
@@ -500,7 +491,7 @@ class Configuration
      *
      * @param string $version
      *
-     * @return boolean
+     * @return bool
      */
     public function hasVersion($version)
     {
@@ -514,9 +505,7 @@ class Configuration
     /**
      * Check if a version has been migrated or not yet
      *
-     * @param Version $version
-     *
-     * @return boolean
+     * @return bool
      */
     public function hasVersionMigrated(Version $version)
     {
@@ -524,7 +513,7 @@ class Configuration
         $this->createMigrationTable();
 
         $version = $this->connection->fetchColumn(
-            "SELECT " . $this->migrationsColumnName . " FROM " . $this->migrationsTableName . " WHERE " . $this->migrationsColumnName . " = ?",
+            'SELECT ' . $this->migrationsColumnName . ' FROM ' . $this->migrationsTableName . ' WHERE ' . $this->migrationsColumnName . ' = ?',
             [$version->getVersion()]
         );
 
@@ -534,19 +523,19 @@ class Configuration
     /**
      * Returns all migrated versions from the versions table, in an array.
      *
-     * @return Version[]
+     * @return string[]
      */
     public function getMigratedVersions()
     {
         $this->createMigrationTable();
 
-        if ( ! $this->migrationTableCreated && $this->isDryRun) {
+        if (! $this->migrationTableCreated && $this->isDryRun) {
             return [];
         }
 
         $this->connect();
 
-        $ret = $this->connection->fetchAll("SELECT " . $this->migrationsColumnName . " FROM " . $this->migrationsTableName);
+        $ret = $this->connection->fetchAll('SELECT ' . $this->migrationsColumnName . ' FROM ' . $this->migrationsTableName);
 
         return array_map('current', $ret);
     }
@@ -554,7 +543,7 @@ class Configuration
     /**
      * Returns an array of available migration version numbers.
      *
-     * @return array
+     * @return string[]
      */
     public function getAvailableVersions()
     {
@@ -580,7 +569,7 @@ class Configuration
     {
         $this->createMigrationTable();
 
-        if ( ! $this->migrationTableCreated && $this->isDryRun) {
+        if (! $this->migrationTableCreated && $this->isDryRun) {
             return '0';
         }
 
@@ -591,16 +580,16 @@ class Configuration
         }
 
         $where = null;
-        if ( ! empty($this->migrations)) {
+        if (! empty($this->migrations)) {
             $migratedVersions = [];
             foreach ($this->migrations as $migration) {
                 $migratedVersions[] = sprintf("'%s'", $migration->getVersion());
             }
-            $where = " WHERE " . $this->migrationsColumnName . " IN (" . implode(', ', $migratedVersions) . ")";
+            $where = ' WHERE ' . $this->migrationsColumnName . ' IN (' . implode(', ', $migratedVersions) . ')';
         }
 
         $sql = sprintf(
-            "SELECT %s FROM %s%s ORDER BY %s DESC",
+            'SELECT %s FROM %s%s ORDER BY %s DESC',
             $this->migrationsColumnName,
             $this->migrationsTableName,
             $where,
@@ -640,6 +629,7 @@ class Configuration
      *
      * @param string $version
      * @param string $delta
+     *
      * @return null|string A version string, or null if the specified version
      *                     is unknown or the specified delta is not within the
      *                     list of available versions.
@@ -665,6 +655,7 @@ class Configuration
      * Returns the version with the specified to the current version.
      *
      * @param string $delta
+     *
      * @return null|string A version string, or null if the specified delta is
      *                     not within the list of available versions.
      */
@@ -677,7 +668,7 @@ class Configuration
             return null;
         }
 
-        if ($symbol == "+" || $symbol == "-") {
+        if ($symbol === '+' || $symbol === '-') {
             return $this->getRelativeVersion($this->getCurrentVersion(), (int) $delta);
         }
 
@@ -697,6 +688,7 @@ class Configuration
      * If an existing version number is specified, it is returned verbatimly.
      *
      * @param string $alias
+     *
      * @return null|string A version number, or null if the specified alias
      *                     does not map to an existing version, e.g. if "next"
      *                     is passed but the current version is already the
@@ -719,7 +711,7 @@ class Configuration
             case 'latest':
                 return $this->getLatestVersion();
             default:
-                if (substr($alias, 0, 7) == 'current') {
+                if (substr($alias, 0, 7) === 'current') {
                     return $this->getDeltaVersion(substr($alias, 7));
                 }
                 return null;
@@ -729,14 +721,14 @@ class Configuration
     /**
      * Returns the total number of executed migration versions
      *
-     * @return integer
+     * @return int
      */
     public function getNumberOfExecutedMigrations()
     {
         $this->connect();
         $this->createMigrationTable();
 
-        $result = $this->connection->fetchColumn("SELECT COUNT(" . $this->migrationsColumnName . ") FROM " . $this->migrationsTableName);
+        $result = $this->connection->fetchColumn('SELECT COUNT(' . $this->migrationsColumnName . ') FROM ' . $this->migrationsTableName);
 
         return $result !== false ? $result : 0;
     }
@@ -744,7 +736,7 @@ class Configuration
     /**
      * Returns the total number of available migration versions
      *
-     * @return integer
+     * @return int
      */
     public function getNumberOfAvailableMigrations()
     {
@@ -775,7 +767,7 @@ class Configuration
     /**
      * Create the migration table to track migrations with.
      *
-     * @return boolean Whether or not the table was created.
+     * @return bool Whether or not the table was created.
      */
     public function createMigrationTable()
     {
@@ -837,9 +829,11 @@ class Configuration
         $versions = [];
         $migrated = $this->getMigratedVersions();
         foreach ($allVersions as $version) {
-            if ($this->shouldExecuteMigration($direction, $version, $to, $migrated)) {
-                $versions[$version->getVersion()] = $version;
+            if (! $this->shouldExecuteMigration($direction, $version, $to, $migrated)) {
+                continue;
             }
+
+            $versions[$version->getVersion()] = $version;
         }
 
         return $versions;
@@ -848,10 +842,10 @@ class Configuration
     /**
      * Use the connection's event manager to emit an event.
      *
-     * @param string $eventName The event to emit.
-     * @param EventArgs $args The event args instance to emit.
+     * @param string    $eventName The event to emit.
+     * @param EventArgs $args      The event args instance to emit.
      */
-    public function dispatchEvent($eventName, EventArgs $args = null)
+    public function dispatchEvent($eventName, ?EventArgs $args = null)
     {
         $this->connection->getEventManager()->dispatchEvent($eventName, $args);
     }
@@ -860,7 +854,8 @@ class Configuration
      * Find all the migrations in a given directory.
      *
      * @param   string $path the directory to search.
-     * @return  array
+     *
+     * @return  string[]
      */
     protected function findMigrations($path)
     {
@@ -869,6 +864,7 @@ class Configuration
 
     /**
      * @param bool $migrationsAreOrganizedByYear
+     *
      * @throws MigrationException
      */
     public function setMigrationsAreOrganizedByYear($migrationsAreOrganizedByYear = true)
@@ -880,6 +876,7 @@ class Configuration
 
     /**
      * @param bool $migrationsAreOrganizedByYearAndMonth
+     *
      * @throws MigrationException
      */
     public function setMigrationsAreOrganizedByYearAndMonth($migrationsAreOrganizedByYearAndMonth = true)
@@ -894,9 +891,10 @@ class Configuration
      * Generate a new migration version. A version is (usually) a datetime string.
      *
      * @param \DateTimeInterface|null $now Defaults to the current time in UTC
+     *
      * @return string The newly generated version
      */
-    public function generateVersionNumber(\DateTimeInterface $now = null)
+    public function generateVersionNumber(?\DateTimeInterface $now = null)
     {
         $now = $now ?: new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -926,7 +924,7 @@ class Configuration
      */
     private function ensureOrganizeMigrationsIsCompatibleWithFinder()
     {
-        if ( ! ($this->migrationFinder instanceof MigrationDeepFinderInterface)) {
+        if (! ($this->migrationFinder instanceof MigrationDeepFinderInterface)) {
             throw MigrationException::configurationIncompatibleWithFinder(
                 'organize-migrations',
                 $this->migrationFinder
@@ -938,17 +936,17 @@ class Configuration
      * Check if we should execute a migration for a given direction and target
      * migration version.
      *
-     * @param string  $direction The direction we are migrating.
-     * @param Version $version   The Version instance to check.
-     * @param string  $to        The version we are migrating to.
-     * @param array   $migrated  Migrated versions array.
+     * @param string   $direction The direction we are migrating.
+     * @param Version  $version   The Version instance to check.
+     * @param string   $to        The version we are migrating to.
+     * @param string[] $migrated  Migrated versions array.
      *
-     * @return boolean
+     * @return bool
      */
     private function shouldExecuteMigration($direction, Version $version, $to, $migrated)
     {
         if ($direction === Version::DIRECTION_DOWN) {
-            if ( ! in_array($version->getVersion(), $migrated, true)) {
+            if (! in_array($version->getVersion(), $migrated, true)) {
                 return false;
             }
 
@@ -966,11 +964,12 @@ class Configuration
 
     /**
      * @param string $class
+     *
      * @throws MigrationException
      */
     private function ensureMigrationClassExists($class)
     {
-        if ( ! class_exists($class)) {
+        if (! class_exists($class)) {
             throw MigrationException::migrationClassNotFound($class, $this->getMigrationsNamespace());
         }
     }

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ArrayConnectionConfigurationLoader.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ArrayConnectionConfigurationLoader.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Migrations\Configuration\Connection\ConnectionLoaderInterface;
 
 class ArrayConnectionConfigurationLoader implements ConnectionLoaderInterface
 {
+    /** @var string */
     private $filename;
 
     public function __construct($filename)
@@ -18,6 +19,7 @@ class ArrayConnectionConfigurationLoader implements ConnectionLoaderInterface
     /**
      * read the input and return a Configuration, returns `false` if the config
      * is not supported
+     *
      * @return Connection|null
      */
     public function chosen()
@@ -26,12 +28,12 @@ class ArrayConnectionConfigurationLoader implements ConnectionLoaderInterface
             return null;
         }
 
-        if ( ! file_exists($this->filename)) {
+        if (! file_exists($this->filename)) {
             return null;
         }
 
         $params = include $this->filename;
-        if ( ! is_array($params)) {
+        if (! is_array($params)) {
             throw new \InvalidArgumentException('The connection file has to return an array with database configuration parameters.');
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ConnectionConfigurationChainLoader.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ConnectionConfigurationChainLoader.php
@@ -10,7 +10,9 @@ final class ConnectionConfigurationChainLoader implements ConnectionLoaderInterf
     /** @var  ConnectionLoaderInterface[] */
     private $loaders;
 
-
+    /**
+     * @param ConnectionLoaderInterface[] $loaders
+     */
     public function __construct(array $loaders)
     {
         $this->loaders = $loaders;
@@ -24,7 +26,8 @@ final class ConnectionConfigurationChainLoader implements ConnectionLoaderInterf
     public function chosen()
     {
         foreach ($this->loaders as $loader) {
-            if (null !== $confObj = $loader->chosen()) {
+            $confObj = $loader->chosen();
+            if ($confObj !== null) {
                 return $confObj;
             }
         }

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ConnectionConfigurationLoader.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ConnectionConfigurationLoader.php
@@ -11,16 +11,15 @@ class ConnectionConfigurationLoader implements ConnectionLoaderInterface
     /** @var Configuration */
     private $configuration;
 
-    public function __construct(Configuration $configuration = null)
+    public function __construct(?Configuration $configuration = null)
     {
-        if ($configuration !== null) {
-            $this->configuration = $configuration;
-        }
+        $this->configuration = $configuration;
     }
 
     /**
      * read the input and return a Configuration, returns `false` if the config
      * is not supported
+     *
      * @return Connection|null
      */
     public function chosen()

--- a/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ConnectionHelperLoader.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Connection/Loader/ConnectionHelperLoader.php
@@ -9,9 +9,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 
 class ConnectionHelperLoader implements ConnectionLoaderInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $helperName;
 
     /** @var  HelperSet */
@@ -19,11 +17,9 @@ class ConnectionHelperLoader implements ConnectionLoaderInterface
 
 
     /**
-     * ConnectionHelperLoader constructor.
-     * @param HelperSet $helperSet
      * @param string $helperName
      */
-    public function __construct(HelperSet $helperSet = null, $helperName)
+    public function __construct(?HelperSet $helperSet = null, $helperName)
     {
         $this->helperName = $helperName;
         if ($helperSet === null) {
@@ -35,6 +31,7 @@ class ConnectionHelperLoader implements ConnectionLoaderInterface
     /**
      * read the input and return a Configuration, returns `false` if the config
      * is not supported
+     *
      * @return Connection|null
      */
     public function chosen()

--- a/lib/Doctrine/DBAL/Migrations/Configuration/JsonConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/JsonConfiguration.php
@@ -4,11 +4,6 @@ namespace Doctrine\DBAL\Migrations\Configuration;
 
 /**
  * Load migration configuration information from a PHP configuration file.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      David Havl <contact@davidhavl.com>
  */
 class JsonConfiguration extends AbstractFileConfiguration
 {

--- a/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/XmlConfiguration.php
@@ -6,11 +6,6 @@ use Doctrine\DBAL\Migrations\MigrationException;
 
 /**
  * Load migration configuration information from a XML configuration file.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class XmlConfiguration extends AbstractFileConfiguration
 {
@@ -22,12 +17,12 @@ class XmlConfiguration extends AbstractFileConfiguration
         libxml_use_internal_errors(true);
         $xml = new \DOMDocument();
         $xml->load($file);
-        if ( ! $xml->schemaValidate(__DIR__ . DIRECTORY_SEPARATOR . "XML" . DIRECTORY_SEPARATOR . "configuration.xsd")) {
+        if (! $xml->schemaValidate(__DIR__ . DIRECTORY_SEPARATOR . 'XML' . DIRECTORY_SEPARATOR . 'configuration.xsd')) {
             libxml_clear_errors();
             throw MigrationException::configurationNotValid('XML configuration did not pass the validation test.');
         }
 
-        $xml    = simplexml_load_file($file, "SimpleXMLElement", LIBXML_NOCDATA);
+        $xml    = simplexml_load_file($file, 'SimpleXMLElement', LIBXML_NOCDATA);
         $config = [];
 
         if (isset($xml->name)) {

--- a/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/YamlConfiguration.php
@@ -2,17 +2,11 @@
 
 namespace Doctrine\DBAL\Migrations\Configuration;
 
-use Symfony\Component\Yaml\Yaml;
-
 use Doctrine\DBAL\Migrations\MigrationException;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Load migration configuration information from a YAML configuration file.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class YamlConfiguration extends AbstractFileConfiguration
 {
@@ -21,13 +15,13 @@ class YamlConfiguration extends AbstractFileConfiguration
      */
     protected function doLoad($file)
     {
-        if ( ! class_exists(Yaml::class)) {
+        if (! class_exists(Yaml::class)) {
             throw MigrationException::yamlConfigurationNotAvailable();
         }
 
         $config = Yaml::parse(file_get_contents($file));
 
-        if ( ! is_array($config)) {
+        if (! is_array($config)) {
             throw new \InvalidArgumentException('Not valid configuration.');
         }
 

--- a/lib/Doctrine/DBAL/Migrations/Event/Listeners/AutoCommitListener.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/Listeners/AutoCommitListener.php
@@ -3,23 +3,24 @@
 namespace Doctrine\DBAL\Migrations\Event\Listeners;
 
 use Doctrine\Common\EventSubscriber;
-use Doctrine\DBAL\Migrations\Events;
 use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
+use Doctrine\DBAL\Migrations\Events;
 
 /**
  * Listens for `onMigrationsMigrated` and, if the conneciton is has autocommit
  * makes sure to do the final commit to ensure changes stick around.
- *
- * @since 1.6
  */
 final class AutoCommitListener implements EventSubscriber
 {
     public function onMigrationsMigrated(MigrationsEventArgs $args)
     {
         $conn = $args->getConnection();
-        if ( ! $args->isDryRun() && ! $conn->isAutoCommit()) {
-            $conn->commit();
+
+        if ($args->isDryRun() || $conn->isAutoCommit()) {
+            return;
         }
+
+        $conn->commit();
     }
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Event/MigrationsEventArgs.php
+++ b/lib/Doctrine/DBAL/Migrations/Event/MigrationsEventArgs.php
@@ -7,9 +7,7 @@ use Doctrine\DBAL\Migrations\Configuration\Configuration;
 
 class MigrationsEventArgs extends EventArgs
 {
-    /**
-     * @var Configuration
-     */
+    /** @var Configuration */
     private $config;
 
     /**

--- a/lib/Doctrine/DBAL/Migrations/Events.php
+++ b/lib/Doctrine/DBAL/Migrations/Events.php
@@ -11,9 +11,9 @@ final class Events
     {
     }
 
-    const onMigrationsMigrating        = 'onMigrationsMigrating';
-    const onMigrationsMigrated         = 'onMigrationsMigrated';
-    const onMigrationsVersionExecuting = 'onMigrationsVersionExecuting';
-    const onMigrationsVersionExecuted  = 'onMigrationsVersionExecuted';
-    const onMigrationsVersionSkipped   = 'onMigrationsVersionSkipped';
+    public const onMigrationsMigrating        = 'onMigrationsMigrating';
+    public const onMigrationsMigrated         = 'onMigrationsMigrated';
+    public const onMigrationsVersionExecuting = 'onMigrationsVersionExecuting';
+    public const onMigrationsVersionExecuted  = 'onMigrationsVersionExecuted';
+    public const onMigrationsVersionSkipped   = 'onMigrationsVersionSkipped';
 }

--- a/lib/Doctrine/DBAL/Migrations/FileQueryWriter.php
+++ b/lib/Doctrine/DBAL/Migrations/FileQueryWriter.php
@@ -4,25 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Migrations;
 
-/**
- * @since  1.6.0
- * @author Luís Cobucci <lcobucci@gmail.com>
- */
 final class FileQueryWriter implements QueryWriter
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     private $columnName;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $tableName;
 
-    /**
-     * @var null|OutputWriter
-     */
+    /** @var null|OutputWriter */
     private $outputWriter;
 
     public function __construct(string $columnName, string $tableName, ?OutputWriter $outputWriter)
@@ -34,10 +24,7 @@ final class FileQueryWriter implements QueryWriter
 
     /**
      * TODO: move SqlFileWriter's behaviour to this class - and kill it with fire (on the next major release)
-     * @param string $path
-     * @param string $direction
-     * @param array $queriesByVersion
-     * @return bool
+     * @param string[][] $queriesByVersion
      */
     public function write(string $path, string $direction, array $queriesByVersion) : bool
     {

--- a/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php
@@ -5,7 +5,6 @@ namespace Doctrine\DBAL\Migrations\Finder;
 /**
  * Abstract base class for MigrationFinders
  *
- * @since   1.0.0-alpha3
  */
 abstract class AbstractFinder implements MigrationFinderInterface
 {
@@ -17,7 +16,7 @@ abstract class AbstractFinder implements MigrationFinderInterface
     protected function getRealPath($directory)
     {
         $dir = realpath($directory);
-        if (false === $dir || ! is_dir($dir)) {
+        if ($dir === false || ! is_dir($dir)) {
             throw new \InvalidArgumentException(sprintf(
                 'Cannot load migrations from "%s" because it is not a valid directory',
                 $directory
@@ -29,9 +28,9 @@ abstract class AbstractFinder implements MigrationFinderInterface
 
     /**
      * Load the migrations and return an array of thoses loaded migrations
-     * @param array $files array of migration filename found
-     * @param string $namespace namespace of thoses migrations
-     * @return array constructed with the migration name as key and the value is the fully qualified name of the migration
+     * @param string[] $files     array of migration filename found
+     * @param string   $namespace namespace of thoses migrations
+     * @return string[] constructed with the migration name as key and the value is the fully qualified name of the migration
      */
     protected function loadMigrations($files, $namespace)
     {

--- a/lib/Doctrine/DBAL/Migrations/Finder/GlobFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/GlobFinder.php
@@ -9,8 +9,6 @@ namespace Doctrine\DBAL\Migrations\Finder;
  * The migrations are expected to reside in files with the filename
  * `VersionYYYYMMDDHHMMSS.php`. Each file should contain one class named
  * `VersionYYYYMMDDHHMMSS`.
- *
- * @since   1.0.0-alpha3
  */
 final class GlobFinder extends AbstractFinder
 {

--- a/lib/Doctrine/DBAL/Migrations/Finder/MigrationFinderInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/MigrationFinderInterface.php
@@ -5,19 +5,19 @@ namespace Doctrine\DBAL\Migrations\Finder;
 /**
  * MigrationFinderInterface implementations locate migrations (classes that extend
  * `Doctrine\DBAL\Migrations\AbstractMigration`) in a directory.
- *
- * @since   1.0.0-alpha3
  */
 interface MigrationFinderInterface
 {
     /**
      * Find all the migrations in a directory for the given path and namespace.
      *
-     * @param   string $directory The directory in which to look for migrations
+     * @param   string      $directory The directory in which to look for migrations
      * @param   string|null $namespace The namespace of the classes to load
-     * @throws  \InvalidArgumentException if the directory does not exist
+     *
      * @return  string[] An array of class names that were found with the version
      *          as keys.
+     *
+     * @throws  \InvalidArgumentException If the directory does not exist.
      */
     public function findMigrations($directory, $namespace = null);
 }

--- a/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/DBAL/Migrations/Finder/RecursiveRegexFinder.php
@@ -5,12 +5,9 @@ namespace Doctrine\DBAL\Migrations\Finder;
 /**
  * A MigrationFinderInterface implementation that uses a RegexIterator along with a
  * RecursiveDirectoryIterator.
- *
- * @since   1.0.0-alpha3
  */
 final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeepFinderInterface
 {
-
     /**
      * {@inheritdoc}
      */
@@ -45,8 +42,8 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
 
     /**
      * Transform the recursiveIterator result array of array into the expected array of migration file
-     * @param iterable $iteratorFilesMatch
-     * @return array
+     * @param iterable|string[][] $iteratorFilesMatch
+     * @return string[]
      */
     private function getMatches($iteratorFilesMatch)
     {
@@ -54,7 +51,7 @@ final class RecursiveRegexFinder extends AbstractFinder implements MigrationDeep
         foreach ($iteratorFilesMatch as $file) {
             $files[] = $file[0];
         }
-        
+
         return $files;
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/IrreversibleMigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/IrreversibleMigrationException.php
@@ -5,11 +5,6 @@ namespace Doctrine\DBAL\Migrations;
 /**
  * Exception to be thrown in the down() methods of migrations that signifies it
  * is an irreversible migration and stops execution.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class IrreversibleMigrationException extends \Exception
 {

--- a/lib/Doctrine/DBAL/Migrations/Migration.php
+++ b/lib/Doctrine/DBAL/Migrations/Migration.php
@@ -7,11 +7,6 @@ use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
 
 /**
  * Class for running migrations to the current version or a manually specified version.
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class Migration
 {
@@ -22,14 +17,10 @@ class Migration
      */
     private $outputWriter;
 
-    /**
-     * @var Configuration
-     */
+    /** @var Configuration */
     private $configuration;
 
-    /**
-     * @var boolean
-     */
+    /** @var bool */
     private $noMigrationException;
 
     /**
@@ -50,7 +41,7 @@ class Migration
      *
      * @param string $to The version to migrate to.
      *
-     * @return array $sql  The array of SQL queries.
+     * @return string[][] The array of SQL queries.
      */
     public function getSql($to = null)
     {
@@ -63,7 +54,7 @@ class Migration
      * @param string $path The path to write the migration SQL file.
      * @param string $to   The version to migrate to.
      *
-     * @return boolean $written
+     * @return bool
      */
     public function writeSqlFile($path, $to = null)
     {
@@ -87,7 +78,7 @@ class Migration
     }
 
     /**
-     * @param boolean $noMigrationException Throw an exception or not if no migration is found. Mostly for Continuous Integration.
+     * @param bool $noMigrationException Throw an exception or not if no migration is found. Mostly for Continuous Integration.
      */
     public function setNoMigrationException($noMigrationException = false)
     {
@@ -97,16 +88,16 @@ class Migration
     /**
      * Run a migration to the current version or the given target version.
      *
-     * @param string  $to             The version to migrate to.
-     * @param boolean $dryRun         Whether or not to make this a dry run and not execute anything.
-     * @param boolean $timeAllQueries Measuring or not the execution time of each SQL query.
-     * @param callable|null $confirm A callback to confirm whether the migrations should be executed.
+     * @param string        $to             The version to migrate to.
+     * @param bool          $dryRun         Whether or not to make this a dry run and not execute anything.
+     * @param bool          $timeAllQueries Measuring or not the execution time of each SQL query.
+     * @param callable|null $confirm        A callback to confirm whether the migrations should be executed.
      *
-     * @return array An array of migration sql statements. This will be empty if the the $confirm callback declines to execute the migration
+     * @return string[][] An array of migration sql statements. This will be empty if the the $confirm callback declines to execute the migration
      *
      * @throws MigrationException
      */
-    public function migrate($to = null, $dryRun = false, $timeAllQueries = false, callable $confirm = null)
+    public function migrate($to = null, $dryRun = false, $timeAllQueries = false, ?callable $confirm = null)
     {
         /**
          * If no version to migrate to is given we default to the last available one.
@@ -123,7 +114,7 @@ class Migration
          * migrations.
          */
         $migrations = $this->configuration->getMigrations();
-        if ( ! isset($migrations[$to]) && $to > 0) {
+        if (! isset($migrations[$to]) && $to > 0) {
             throw MigrationException::unknownMigrationVersion($to);
         }
 
@@ -142,7 +133,7 @@ class Migration
             return $this->noMigrations();
         }
 
-        if ( ! $dryRun && false === $this->migrationsCanExecute($confirm)) {
+        if (! $dryRun && $this->migrationsCanExecute($confirm) === false) {
             return [];
         }
 
@@ -179,13 +170,16 @@ class Migration
         );
 
         $this->outputWriter->write("\n  <comment>------------------------</comment>\n");
-        $this->outputWriter->write(sprintf("  <info>++</info> finished in %ss", $time));
-        $this->outputWriter->write(sprintf("  <info>++</info> %s migrations executed", count($migrationsToExecute)));
-        $this->outputWriter->write(sprintf("  <info>++</info> %s sql queries", count($sql, true) - count($sql)));
+        $this->outputWriter->write(sprintf('  <info>++</info> finished in %ss', $time));
+        $this->outputWriter->write(sprintf('  <info>++</info> %s migrations executed', count($migrationsToExecute)));
+        $this->outputWriter->write(sprintf('  <info>++</info> %s sql queries', count($sql, true) - count($sql)));
 
         return $sql;
     }
 
+    /**
+     * @return string[][]
+     */
     private function noMigrations() : array
     {
         $this->outputWriter->write('<comment>No migrations to execute.</comment>');
@@ -193,8 +187,8 @@ class Migration
         return [];
     }
 
-    private function migrationsCanExecute(callable $confirm = null) : bool
+    private function migrationsCanExecute(?callable $confirm = null) : bool
     {
-        return null === $confirm ? true : (bool) $confirm();
+        return $confirm === null ? true : (bool) $confirm();
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/MigrationException.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationException.php
@@ -2,15 +2,10 @@
 
 namespace Doctrine\DBAL\Migrations;
 
-use \Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
+use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
 
 /**
  * Class for Migrations specific exceptions
- *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class MigrationException extends \Exception
 {

--- a/lib/Doctrine/DBAL/Migrations/MigrationsVersion.php
+++ b/lib/Doctrine/DBAL/Migrations/MigrationsVersion.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Migrations;
 
 class MigrationsVersion
 {
+    /** @var string */
     private static $version = 'v1.6.2';
 
     public static function VERSION()
@@ -17,11 +18,12 @@ class MigrationsVersion
     }
 
     /**
-     * @param string $gitversion
-     * @return bool
-     *
      * Check if doctrine migration is installed by composer or
      * in a modified (not tagged) phar version.
+     *
+     * @param string $gitversion
+     *
+     * @return bool
      */
     private static function isACustomPharBuild($gitversion)
     {

--- a/lib/Doctrine/DBAL/Migrations/OutputWriter.php
+++ b/lib/Doctrine/DBAL/Migrations/OutputWriter.php
@@ -5,16 +5,14 @@ namespace Doctrine\DBAL\Migrations;
 /**
  * Simple class for outputting information from migrations.
  *
- * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
  * @link        www.doctrine-project.org
- * @since       2.0
- * @author      Jonathan H. Wage <jonwage@gmail.com>
  */
 class OutputWriter
 {
+    /** @var \Closure|null */
     private $closure;
 
-    public function __construct(\Closure $closure = null)
+    public function __construct(?\Closure $closure = null)
     {
         if ($closure === null) {
             $closure = function ($message) {

--- a/lib/Doctrine/DBAL/Migrations/Provider/LazySchemaDiffProvider.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/LazySchemaDiffProvider.php
@@ -63,7 +63,6 @@ class LazySchemaDiffProvider implements SchemaDiffProviderInterface
     }
 
     /**
-     * @param Schema $fromSchema
      * @return Schema
      */
     public function createToSchema(Schema $fromSchema)
@@ -86,9 +85,6 @@ class LazySchemaDiffProvider implements SchemaDiffProviderInterface
     }
 
     /**
-     * @param Schema $fromSchema
-     * @param Schema $toSchema
-     *
      * @return string[]
      */
     public function getSqlDiffToMigrate(Schema $fromSchema, Schema $toSchema)

--- a/lib/Doctrine/DBAL/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/OrmSchemaProvider.php
@@ -8,19 +8,15 @@ use Doctrine\ORM\Tools\SchemaTool;
 
 /**
  * A schema provider that uses the doctrine ORM to generate schemas.
- *
- * @since   1.0.0-alpha3
  */
 final class OrmSchemaProvider implements SchemaProviderInterface
 {
-    /**
-     * @var     EntityManagerInterface
-     */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
     public function __construct($em)
     {
-        if ( ! $this->isEntityManager($em)) {
+        if (! $this->isEntityManager($em)) {
             throw new \InvalidArgumentException(sprintf(
                 '$em is not a valid Doctrine ORM Entity Manager, got "%s"',
                 is_object($em) ? get_class($em) : gettype($em)
@@ -55,7 +51,7 @@ final class OrmSchemaProvider implements SchemaProviderInterface
      * doesn't care.
      *
      * @param   mixed $manager Hopefully an entity manager, but it may be anything
-     * @return  boolean
+     * @return  bool
      */
     private function isEntityManager($manager)
     {

--- a/lib/Doctrine/DBAL/Migrations/Provider/SchemaDiffProvider.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/SchemaDiffProvider.php
@@ -29,7 +29,6 @@ class SchemaDiffProvider implements SchemaDiffProviderInterface
     }
 
     /**
-     * @param Schema $fromSchema
      * @return Schema
      */
     public function createToSchema(Schema $fromSchema)
@@ -38,8 +37,6 @@ class SchemaDiffProvider implements SchemaDiffProviderInterface
     }
 
     /**
-     * @param Schema $fromSchema
-     * @param Schema $toSchema
      * @return string[]
      */
     public function getSqlDiffToMigrate(Schema $fromSchema, Schema $toSchema)

--- a/lib/Doctrine/DBAL/Migrations/Provider/SchemaDiffProviderInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/SchemaDiffProviderInterface.php
@@ -6,8 +6,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Generates `Schema` objects to be passed to the migrations class.
- *
- * @since   1.3
  */
 interface SchemaDiffProviderInterface
 {
@@ -21,7 +19,6 @@ interface SchemaDiffProviderInterface
     /**
      * Create the schema that will represent the future state of the database
      *
-     * @param Schema $fromSchema
      * @return Schema
      */
     public function createToSchema(Schema $fromSchema);
@@ -29,9 +26,6 @@ interface SchemaDiffProviderInterface
     /**
      * Return an array of sql statement that migrate the database state from the
      * fromSchema to the toSchema.
-     *
-     * @param Schema $fromSchema
-     * @param Schema $toSchema
      *
      * @return string[]
      */

--- a/lib/Doctrine/DBAL/Migrations/Provider/SchemaProviderInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/SchemaProviderInterface.php
@@ -5,8 +5,6 @@ namespace Doctrine\DBAL\Migrations\Provider;
 /**
  * Generates `Schema` objects for the diff command. A schema provider should
  * return the schema to which the database should be migrated.
- *
- * @since   1.0.0-alpha3
  */
 interface SchemaProviderInterface
 {

--- a/lib/Doctrine/DBAL/Migrations/Provider/StubSchemaProvider.php
+++ b/lib/Doctrine/DBAL/Migrations/Provider/StubSchemaProvider.php
@@ -6,14 +6,10 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * A schemea provider implementation that just returns the schema its given.
- *
- * @since   1.0.0-alpha3
  */
 final class StubSchemaProvider implements SchemaProviderInterface
 {
-    /**
-     * @var     Schema
-     */
+    /** @var     Schema */
     private $toSchema;
 
     public function __construct(Schema $schema)

--- a/lib/Doctrine/DBAL/Migrations/QueryWriter.php
+++ b/lib/Doctrine/DBAL/Migrations/QueryWriter.php
@@ -4,17 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\DBAL\Migrations;
 
-/**
- * @since  1.6.0
- * @author Luís Cobucci <lcobucci@gmail.com>
- */
 interface QueryWriter
 {
     /**
-     * @param string $path
-     * @param string $direction
-     * @param array $queriesByVersion
-     * @return bool
+     * @param string[][] $queriesByVersion
      */
     public function write(string $path, string $direction, array $queriesByVersion) : bool;
 }

--- a/lib/Doctrine/DBAL/Migrations/SqlFileWriter.php
+++ b/lib/Doctrine/DBAL/Migrations/SqlFileWriter.php
@@ -11,10 +11,13 @@ use Doctrine\DBAL\Exception\InvalidArgumentException;
  */
 class SqlFileWriter
 {
+    /** @var string */
     private $migrationsColumnName;
 
+    /** @var string */
     private $migrationsTableName;
 
+    /** @var string */
     private $destPath;
 
     /** @var null|OutputWriter */
@@ -24,13 +27,12 @@ class SqlFileWriter
      * @param string $migrationsColumnName
      * @param string $migrationsTableName
      * @param string $destPath
-     * @param \Doctrine\DBAL\Migrations\OutputWriter $outputWriter
      */
     public function __construct(
         $migrationsColumnName,
         $migrationsTableName,
         $destPath,
-        OutputWriter $outputWriter = null
+        ?OutputWriter $outputWriter = null
     ) {
         if (empty($migrationsColumnName)) {
             $this->throwInvalidArgumentException('Migrations column name cannot be empty.');
@@ -51,8 +53,8 @@ class SqlFileWriter
     }
 
     /**
-     * @param array $queriesByVersion array Keys are versions and values are arrays of SQL queries (they must be castable to string)
-     * @param string $direction
+     * @param string[][] $queriesByVersion array Keys are versions and values are arrays of SQL queries (they must be castable to string)
+     * @param string     $direction
      * @return int|bool
      */
     public function write(array $queriesByVersion, $direction)
@@ -67,6 +69,9 @@ class SqlFileWriter
         return file_put_contents($path, $string);
     }
 
+    /**
+     * @param string[][] $queriesByVersion
+     */
     private function buildMigrationFile(array $queriesByVersion, string $direction) : string
     {
         $string = sprintf("-- Doctrine Migration File Generated on %s\n", date('Y-m-d H:i:s'));
@@ -77,7 +82,6 @@ class SqlFileWriter
             foreach ($queries as $query) {
                 $string .= $query . ";\n";
             }
-
 
             $string .= $this->getVersionUpdateQuery($version, $direction);
         }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -4,25 +4,20 @@ namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ArrayConnectionConfigurationLoader;
+use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ConnectionConfigurationChainLoader;
 use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ConnectionConfigurationLoader;
 use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ConnectionHelperLoader;
-use Doctrine\DBAL\Migrations\Configuration\Connection\Loader\ConnectionConfigurationChainLoader;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelperInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * CLI Command for adding and deleting migration versions from the version table.
- *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Jonathan Wage <jonwage@gmail.com>
  */
 abstract class AbstractCommand extends Command
 {
@@ -41,14 +36,10 @@ abstract class AbstractCommand extends Command
      */
     private $migrationConfiguration;
 
-    /**
-     * @var OutputWriter
-     */
+    /** @var OutputWriter */
     private $outputWriter;
 
-    /**
-     * @var \Doctrine\DBAL\Connection
-     */
+    /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
     protected function configure()
@@ -80,14 +71,11 @@ abstract class AbstractCommand extends Command
      * of the configuration one (if any).
      * Else a new configuration is created and assigned to the migrationConfiguration property.
      *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     *
      * @return Configuration
      */
     protected function getMigrationConfiguration(InputInterface $input, OutputInterface $output)
     {
-        if ( ! $this->migrationConfiguration) {
+        if (! $this->migrationConfiguration) {
             if ($this->getHelperSet()->has('configuration')
                 && $this->getHelperSet()->get('configuration') instanceof ConfigurationHelperInterface) {
                 $configHelper = $this->getHelperSet()->get('configuration');
@@ -102,8 +90,6 @@ abstract class AbstractCommand extends Command
 
     /**
      * @param string $question
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return mixed
      */
     protected function askConfirmation($question, InputInterface $input, OutputInterface $output)
@@ -112,13 +98,11 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     *
      * @return \Doctrine\DBAL\Migrations\OutputWriter
      */
     private function getOutputWriter(OutputInterface $output)
     {
-        if ( ! $this->outputWriter) {
+        if (! $this->outputWriter) {
             $this->outputWriter = new OutputWriter(function ($message) use ($output) {
                 return $output->writeln($message);
             });
@@ -128,8 +112,6 @@ abstract class AbstractCommand extends Command
     }
 
     /**
-     * @param \Symfony\Component\Console\Input\InputInterface $input
-     *
      * @return \Doctrine\DBAL\Connection
      * @throws \Doctrine\DBAL\DBALException
      */

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -2,18 +2,13 @@
 
 namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command for executing single migrations up or down manually.
- *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Jonathan Wage <jonwage@gmail.com>
  */
 class ExecuteCommand extends AbstractCommand
 {
@@ -64,7 +59,9 @@ EOT
 
         $timeAllqueries = $input->getOption('query-time');
 
-        if ($path = $input->getOption('write-sql')) {
+        $path = $input->getOption('write-sql');
+
+        if ($path) {
             $path = is_bool($path) ? getcwd() : $path;
             $version->writeSqlFile($path, $direction);
         } else {
@@ -76,7 +73,7 @@ EOT
             }
 
             if ($execute) {
-                $version->execute($direction, (boolean) $input->getOption('dry-run'), $timeAllqueries);
+                $version->execute($direction, (bool) $input->getOption('dry-run'), $timeAllqueries);
             } else {
                 $output->writeln('<error>Migration cancelled!</error>');
             }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -6,19 +6,15 @@ namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\MigrationDirectoryHelper;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command for generating new blank migration classes
- *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Jonathan Wage <jonwage@gmail.com>
  */
 class GenerateCommand extends AbstractCommand
 {
+    /** @var string */
     private static $_template =
             '<?php declare(strict_types=1);
 
@@ -46,6 +42,7 @@ final class Version<version> extends AbstractMigration
 }
 ';
 
+    /** @var string */
     private $instanceTemplate;
 
     protected function configure()
@@ -100,8 +97,8 @@ EOT
         $replacements = [
             $configuration->getMigrationsNamespace(),
             $version,
-            $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
-            $down ? "        " . implode("\n        ", explode("\n", $down)) : null,
+            $up ? '        ' . implode("\n        ", explode("\n", $up)) : null,
+            $down ? '        ' . implode("\n        ", explode("\n", $down)) : null,
         ];
 
         $code = str_replace($placeHolders, $replacements, $this->getTemplate());
@@ -113,7 +110,9 @@ EOT
 
         file_put_contents($path, $code);
 
-        if ($editorCmd = $input->getOption('editor-cmd')) {
+        $editorCmd = $input->getOption('editor-cmd');
+
+        if ($editorCmd) {
             proc_open($editorCmd . ' ' . escapeshellarg($path), [], $pipes);
         }
 
@@ -128,7 +127,7 @@ EOT
             return;
         }
 
-        if ( ! is_file($customTemplate) || ! is_readable($customTemplate)) {
+        if (! is_file($customTemplate) || ! is_readable($customTemplate)) {
             throw new \InvalidArgumentException(
                 'The specified template "' . $customTemplate . '" cannot be found or is not readable.'
             );

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/LatestCommand.php
@@ -7,8 +7,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Outputs the latest version number.
- *
- * @author Kris Wallsmith <kris.wallsmith@gmail.com>
  */
 class LatestCommand extends AbstractCommand
 {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -5,18 +5,13 @@ namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Migration;
 use Symfony\Component\Console\Formatter\OutputFormatter;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command for executing a migration to a specified version or the latest available version.
- *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Jonathan Wage <jonwage@gmail.com>
  */
 class MigrateCommand extends AbstractCommand
 {
@@ -78,7 +73,7 @@ EOT
 
         $timeAllqueries = $input->getOption('query-time');
 
-        $dryRun = (boolean) $input->getOption('dry-run');
+        $dryRun = (bool) $input->getOption('dry-run');
         $configuration->setIsDryRun($dryRun);
 
         $executedMigrations  = $configuration->getMigratedVersions();
@@ -90,7 +85,7 @@ EOT
         }
 
         $executedUnavailableMigrations = array_diff($executedMigrations, $availableMigrations);
-        if ( ! empty($executedUnavailableMigrations)) {
+        if (! empty($executedUnavailableMigrations)) {
             $output->writeln(sprintf(
                 '<error>WARNING! You have %s previously executed migrations'
                 . ' in the database that are not registered migrations.</error>',
@@ -106,14 +101,16 @@ EOT
             }
 
             $question = 'Are you sure you wish to continue? (y/n)';
-            if ( ! $this->canExecute($question, $input, $output)) {
+            if (! $this->canExecute($question, $input, $output)) {
                 $output->writeln('<error>Migration cancelled!</error>');
 
                 return 1;
             }
         }
 
-        if ($path = $input->getOption('write-sql')) {
+        $path = $input->getOption('write-sql');
+
+        if ($path) {
             $path = is_bool($path) ? getcwd() : $path;
             $migration->writeSqlFile($path, $version);
             return 0;
@@ -150,8 +147,6 @@ EOT
 
     /**
      * @param string $question
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return bool
      */
     private function canExecute($question, InputInterface $input, OutputInterface $output)
@@ -165,23 +160,21 @@ EOT
 
     /**
      * @param string $versionAlias
-     * @param OutputInterface $output
-     * @param Configuration $configuration
      * @return bool|string
      */
     private function getVersionNameFromAlias($versionAlias, OutputInterface $output, Configuration $configuration)
     {
         $version = $configuration->resolveVersionAlias($versionAlias);
         if ($version === null) {
-            if ($versionAlias == 'prev') {
+            if ($versionAlias === 'prev') {
                 $output->writeln('<error>Already at first version.</error>');
                 return false;
             }
-            if ($versionAlias == 'next') {
+            if ($versionAlias === 'next') {
                 $output->writeln('<error>Already at latest version.</error>');
                 return false;
             }
-            if (substr($versionAlias, 0, 7) == 'current') {
+            if (substr($versionAlias, 0, 7) === 'current') {
                 $output->writeln('<error>The delta couldn\'t be reached.</error>');
                 return false;
             }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -5,16 +5,11 @@ namespace Doctrine\DBAL\Migrations\Tools\Console\Command;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\MigrationStatusInfosHelper;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command to view the status of a set of migrations.
- *
- * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @author  Jonathan Wage <jonwage@gmail.com>
  */
 class StatusCommand extends AbstractCommand
 {
@@ -46,29 +41,35 @@ EOT
 
         $output->writeln("\n <info>==</info> Configuration\n");
         foreach ($infos->getMigrationsInfos() as $name => $value) {
-            if ($name == 'New Migrations') {
+            if ($name === 'New Migrations') {
                 $value = $value > 0 ? '<question>' . $value . '</question>' : 0;
             }
-            if ($name == 'Executed Unavailable Migrations') {
+            if ($name === 'Executed Unavailable Migrations') {
                 $value = $value > 0 ? '<error>' . $value . '</error>' : 0;
             }
             $this->writeStatusInfosLineAligned($output, $name, $value);
         }
 
-        if ($input->getOption('show-versions')) {
-            if ($migrations = $configuration->getMigrations()) {
-                $output->writeln("\n <info>==</info> Available Migration Versions\n");
+        if (! $input->getOption('show-versions')) {
+            return;
+        }
 
-                $this->showVersions($migrations, $configuration, $output);
-            }
+        $migrations = $configuration->getMigrations();
 
-            if (count($infos->getExecutedUnavailableMigrations())) {
-                $output->writeln("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
-                foreach ($infos->getExecutedUnavailableMigrations() as $executedUnavailableMigration) {
-                    $output->writeln('    <comment>>></comment> ' . $configuration->getDateTime($executedUnavailableMigration) .
-                        ' (<comment>' . $executedUnavailableMigration . '</comment>)');
-                }
-            }
+        if ($migrations) {
+            $output->writeln("\n <info>==</info> Available Migration Versions\n");
+
+            $this->showVersions($migrations, $configuration, $output);
+        }
+
+        if (count($infos->getExecutedUnavailableMigrations()) === 0) {
+            return;
+        }
+
+        $output->writeln("\n <info>==</info> Previously Executed Unavailable Migration Versions\n");
+        foreach ($infos->getExecutedUnavailableMigrations() as $executedUnavailableMigration) {
+            $output->writeln('    <comment>>></comment> ' . $configuration->getDateTime($executedUnavailableMigration) .
+                ' (<comment>' . $executedUnavailableMigration . '</comment>)');
         }
     }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -26,23 +26,21 @@ EOT
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
      * @return int|null
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $configuration = $this->getMigrationConfiguration($input, $output);
-        
+
         $migrations          = count($configuration->getMigrations());
         $migratedVersions    = count($configuration->getMigratedVersions());
         $availableMigrations = $migrations - $migratedVersions;
-        
+
         if ($availableMigrations === 0) {
             $output->writeln('<comment>Up-to-date! No migrations to execute.</comment>');
             return 0;
         }
-        
+
         $output->writeln(sprintf(
             '<comment>Out-of-date! %u migration%s available to execute.</comment>',
             $availableMigrations,

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/ConsoleRunner.php
@@ -13,10 +13,7 @@ class ConsoleRunner
     /**
      * Runs console with the given helperset.
      *
-     * @param \Symfony\Component\Console\Helper\HelperSet  $helperSet
      * @param \Symfony\Component\Console\Command\Command[] $commands
-     *
-     * @return void
      */
     public static function run(HelperSet $helperSet, $commands = [])
     {
@@ -28,8 +25,7 @@ class ConsoleRunner
      * Creates a console application with the given helperset and
      * optional commands.
      *
-     * @param \Symfony\Component\Console\Helper\HelperSet $helperSet
-     * @param array $commands
+     * @param \Symfony\Component\Console\Command\Command[] $commands
      *
      * @return \Symfony\Component\Console\Application
      */
@@ -44,11 +40,6 @@ class ConsoleRunner
         return $cli;
     }
 
-    /**
-     * @param Application $cli
-     *
-     * @return void
-     */
     public static function addCommands(Application $cli)
     {
         $cli->addCommands([
@@ -61,8 +52,10 @@ class ConsoleRunner
             new Command\UpToDateCommand(),
         ]);
 
-        if ($cli->getHelperSet()->has('em')) {
-            $cli->add(new Command\DiffCommand());
+        if (! $cli->getHelperSet()->has('em')) {
+            return;
         }
+
+        $cli->add(new Command\DiffCommand());
     }
 }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -9,28 +9,21 @@ use Doctrine\DBAL\Migrations\Configuration\JsonConfiguration;
 use Doctrine\DBAL\Migrations\Configuration\XmlConfiguration;
 use Doctrine\DBAL\Migrations\Configuration\YamlConfiguration;
 use Doctrine\DBAL\Migrations\OutputWriter;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Helper\Helper;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
- * Class ConfigurationHelper
- * @package Doctrine\DBAL\Migrations\Tools\Console\Helper
  * @internal
  */
 class ConfigurationHelper extends Helper implements ConfigurationHelperInterface
 {
-
-    /**
-     * @var Connection
-     */
+    /** @var Connection|null */
     private $connection;
 
-    /**
-     * @var Configuration
-     */
+    /** @var Configuration|null */
     private $configuration;
 
-    public function __construct(Connection $connection = null, Configuration $configuration = null)
+    public function __construct(?Connection $connection = null, ?Configuration $configuration = null)
     {
         $this->connection    = $connection;
         $this->configuration = $configuration;
@@ -43,7 +36,7 @@ class ConfigurationHelper extends Helper implements ConfigurationHelperInterface
          * instead of any other one.
          */
         if ($input->getOption('configuration')) {
-            $outputWriter->write("Loading configuration from command option: " . $input->getOption('configuration'));
+            $outputWriter->write('Loading configuration from command option: ' . $input->getOption('configuration'));
 
             return $this->loadConfig($input->getOption('configuration'), $outputWriter);
         }
@@ -52,7 +45,7 @@ class ConfigurationHelper extends Helper implements ConfigurationHelperInterface
          * If a configuration has already been set using DI or a Setter use it.
          */
         if ($this->configuration) {
-            $outputWriter->write("Loading configuration from the integration code of your framework (setter).");
+            $outputWriter->write('Loading configuration from the integration code of your framework (setter).');
 
             return $this->configuration;
         }
@@ -69,7 +62,7 @@ class ConfigurationHelper extends Helper implements ConfigurationHelperInterface
         ];
         foreach ($defaultConfig as $config) {
             if ($this->configExists($config)) {
-                $outputWriter->write("Loading configuration from file: $config");
+                $outputWriter->write('Loading configuration from file: ' . $config);
 
                 return $this->loadConfig($config, $outputWriter);
             }

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelperInterface.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelperInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Doctrine\DBAL\Migrations\Tools\Console\Helper;
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/MigrationDirectoryHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/MigrationDirectoryHelper.php
@@ -6,19 +6,14 @@ use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Symfony\Component\Console\Helper\Helper;
 
 /**
- * Class ConfigurationHelper
- * @package Doctrine\DBAL\Migrations\Tools\Console\Helper
  * @internal
  */
 class MigrationDirectoryHelper extends Helper
 {
-
-    /**
-     * @var Configuration
-     */
+    /** @var Configuration */
     private $configuration;
 
-    public function __construct(Configuration $configuration = null)
+    public function __construct(?Configuration $configuration = null)
     {
         $this->configuration = $configuration;
     }
@@ -29,7 +24,7 @@ class MigrationDirectoryHelper extends Helper
         $dir = $dir ? $dir : getcwd();
         $dir = rtrim($dir, '/');
 
-        if ( ! file_exists($dir)) {
+        if (! file_exists($dir)) {
             throw new \InvalidArgumentException(sprintf('Migrations directory "%s" does not exist.', $dir));
         }
 
@@ -52,17 +47,17 @@ class MigrationDirectoryHelper extends Helper
 
     private function createDirIfNotExists($dir)
     {
-        if ( ! file_exists($dir)) {
-            mkdir($dir, 0755, true);
+        if (file_exists($dir)) {
+            return;
         }
+
+        mkdir($dir, 0755, true);
     }
 
     /**
      * Returns the canonical name of this helper.
      *
      * @return string The canonical name
-     *
-     * @api
      */
     public function getName()
     {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
@@ -4,17 +4,16 @@ namespace Doctrine\DBAL\Migrations\Tools\Console\Helper;
 
 use Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
-use Doctrine\DBAL\Migrations\Version;
 
 class MigrationStatusInfosHelper
 {
-    /** @var Version[] */
+    /** @var string[] */
     private $executedMigrations;
 
-    /** @var Version[] */
+    /** @var string[] */
     private $availableMigrations;
 
-    /** @var Version[] */
+    /** @var string[] */
     private $executedUnavailableMigrations;
 
     /** @var Configuration  */
@@ -78,7 +77,7 @@ class MigrationStatusInfosHelper
     }
 
     /**
-     * @return Version[]
+     * @return string[]
      */
     public function getExecutedUnavailableMigrations()
     {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,26 +1,68 @@
 <?xml version="1.0"?>
-<ruleset name="Coding Standards for doctrine">
-    <description>Coding Standards for doctrine.</description>
-
+<ruleset>
     <arg name="basepath" value="."/>
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors" />
 
-    <!-- Ignore warnings and show progress of the run -->
-    <arg value="np"/>
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
 
     <file>lib</file>
     <file>tests</file>
 
-    <rule ref="Doctrine"/>
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint"/>
+        <exclude name="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly.ReferencedGeneralException"/>
+        <exclude name="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
+    </rule>
 
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <exclude-pattern>*/tests/*</exclude-pattern>
     </rule>
 
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
+
     <rule ref="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase">
         <exclude-pattern>lib/Doctrine/DBAL/Migrations/Events.php</exclude-pattern>
+    </rule>
+
+    <rule ref="Generic.Strings.UnnecessaryStringConcat.Found">
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/MigrationsVersion.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedMethod">
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming">
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Configuration/AbstractFileConfiguration.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Finder/AbstractFinder.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/AbstractMigration.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming.SuperfluousSuffix">
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/AbortMigrationException.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/MigrationException.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/IrreversibleMigrationException.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/SkipMigrationException.php</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummyException.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming">
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Configuration/Connection/ConnectionLoaderInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Provider/SchemaDiffProviderInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Provider/SchemaProviderInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelperInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Finder/MigrationFinderInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/DBAL/Migrations/Finder/MigrationDeepFinderInterface.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/AbstractMigrationTest.php
@@ -5,24 +5,31 @@ namespace Doctrine\DBAL\Migrations\Tests;
 use Doctrine\DBAL\Migrations\AbortMigrationException;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\IrreversibleMigrationException;
+use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Migrations\Tests\Stub\AbstractMigrationStub;
 use Doctrine\DBAL\Migrations\Tests\Stub\VersionDummy;
 use Doctrine\DBAL\Migrations\Version;
+use Symfony\Component\Console\Output\StreamOutput;
 
 /**
  * Class AbstractMigrationTest
- * @package Doctrine\DBAL\Migrations\Tests
- *
- * @author Robbert van den Bogerd <rvdbogerd@ibuildings.nl>
  */
 class AbstractMigrationTest extends MigrationTestCase
 {
+    /** @var Configuration */
     private $config;
+
+    /** @var Version */
     private $version;
+
     /** @var  AbstractMigrationStub */
     private $migration;
+
+    /** @var OutputWriter */
     protected $outputWriter;
+
+    /** @var StreamOutput */
     protected $output;
 
     protected function setUp()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -13,15 +13,13 @@ use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 abstract class AbstractConfigurationTest extends MigrationTestCase
 {
     /**
-     * @param string                   $configFileSuffix Specify config to load.
-     * @param OutputWriter             $outputWriter
-     * @param MigrationFinderInterface $migrationFinder
+     * @param string $configFileSuffix Specify config to load.
      * @return \Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration
      */
     abstract public function loadConfiguration(
         $configFileSuffix = '',
-        OutputWriter $outputWriter = null,
-        MigrationFinderInterface $migrationFinder = null
+        ?OutputWriter $outputWriter = null,
+        ?MigrationFinderInterface $migrationFinder = null
     );
 
     public function testMigrationDirectory()
@@ -33,13 +31,13 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
     public function testMigrationNamespace()
     {
         $config = $this->loadConfiguration();
-        self::assertEquals("DoctrineMigrationsTest", $config->getMigrationsNamespace());
+        self::assertEquals('DoctrineMigrationsTest', $config->getMigrationsNamespace());
     }
 
     public function testMigrationName()
     {
         $config = $this->loadConfiguration();
-        self::assertEquals("Doctrine Sandbox Migrations", $config->getName());
+        self::assertEquals('Doctrine Sandbox Migrations', $config->getName());
     }
 
     public function testMigrationsTable()
@@ -64,7 +62,7 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
     public function testSetMigrationFinder()
     {
         $migrationFinderProphecy = $this->prophesize(MigrationFinderInterface::class);
-        /** @var $migrationFinder MigrationFinderInterface */
+        /** @var MigrationFinderInterface $migrationFinder */
         $migrationFinder = $migrationFinderProphecy->reveal();
 
         $config = $this->loadConfiguration();
@@ -150,6 +148,9 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
         self::assertInstanceOf(AbstractFileConfiguration::class, $this->loadConfiguration($file));
     }
 
+    /**
+     * @return string[][]
+     */
     public function getConfigWithKeysInVariousOrder()
     {
         return [

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ArrayConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ArrayConfigurationTest.php
@@ -10,17 +10,17 @@ class ArrayConfigurationTest extends AbstractConfigurationTest
 {
     public function loadConfiguration(
         $configFileSuffix = '',
-        OutputWriter $outputWriter = null,
-        MigrationFinderInterface $migrationFinder = null
+        ?OutputWriter $outputWriter = null,
+        ?MigrationFinderInterface $migrationFinder = null
     ) {
         $configFile = 'config.php';
 
-        if ('' !== $configFileSuffix) {
+        if ($configFileSuffix !== '') {
             $configFile = 'config_' . $configFileSuffix . '.php';
         }
 
         $config = new ArrayConfiguration($this->getSqliteConnection(), $outputWriter, $migrationFinder);
-        $config->load(__DIR__ . DIRECTORY_SEPARATOR . "_files" . DIRECTORY_SEPARATOR . $configFile);
+        $config->load(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile);
 
         return $config;
     }
@@ -34,6 +34,6 @@ class ArrayConfigurationTest extends AbstractConfigurationTest
         $this->expectExceptionMessage('Given config file does not exist');
 
         $config = new ArrayConfiguration($this->getSqliteConnection());
-        $config->load(__DIR__ . "/_files/none.php");
+        $config->load(__DIR__ . '/_files/none.php');
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -4,15 +4,14 @@ namespace Doctrine\DBAL\Migrations\Tests\Configuration;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
-use Doctrine\DBAL\Migrations\QueryWriter;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Migration;
 use Doctrine\DBAL\Migrations\MigrationException;
 use Doctrine\DBAL\Migrations\OutputWriter;
+use Doctrine\DBAL\Migrations\QueryWriter;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions\Version1Test;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
 class ConfigurationTest extends MigrationTestCase
 {
@@ -121,7 +120,7 @@ class ConfigurationTest extends MigrationTestCase
         $configuration->setMigrationsDirectory(__DIR__ . '/../Stub/Configuration/AutoloadVersions');
 
         $result = call_user_func_array([$configuration, $method], $args);
-        if ($method == 'getMigrationsToExecute') {
+        if ($method === 'getMigrationsToExecute') {
             $result = array_keys($result);
         }
         self::assertEquals($expectedResult, $result);
@@ -139,7 +138,7 @@ class ConfigurationTest extends MigrationTestCase
         $migration->migrate('3Test');
 
         $result = call_user_func_array([$configuration, $method], $args);
-        if ($method == 'getMigrationsToExecute') {
+        if ($method === 'getMigrationsToExecute') {
             $result = array_keys($result);
         }
         self::assertEquals($expectedResult, $result);
@@ -205,6 +204,9 @@ class ConfigurationTest extends MigrationTestCase
         $config->getMigratedVersions();
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function methodsThatNeedsVersionsLoadedWithAlreadyMigratedMigrations()
     {
         return [
@@ -214,24 +216,32 @@ class ConfigurationTest extends MigrationTestCase
             ['getRelativeVersion', ['3Test', -1], '2Test'],
             ['getNumberOfAvailableMigrations', [], 5],
             ['getLatestVersion', [], '5Test'],
-            ['getMigrationsToExecute', ['up', 5], [
-                '4Test',
-                '5Test',
-            ]],
-            ['getMigrationsToExecute', ['up', 4], [
-                '4Test',
-            ]],
-            ['getMigrationsToExecute', ['down', 0], [
-                '3Test',
-                '2Test',
-                '1Test',
-            ]],
-            ['getMigrationsToExecute', ['down', 2], [
-                '3Test',
-            ]],
+            [
+                'getMigrationsToExecute',
+                ['up', 5],
+                ['4Test', '5Test'],
+            ],
+            [
+                'getMigrationsToExecute',
+                ['up', 4],
+                ['4Test'],
+            ],
+            [
+                'getMigrationsToExecute',
+                ['down', 0],
+                ['3Test', '2Test', '1Test'],
+            ],
+            [
+                'getMigrationsToExecute',
+                ['down', 2],
+                ['3Test'],
+            ],
         ];
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function methodsThatNeedsVersionsLoaded()
     {
         return [
@@ -241,13 +251,17 @@ class ConfigurationTest extends MigrationTestCase
             ['getRelativeVersion', ['3Test', -1], '2Test'],
             ['getNumberOfAvailableMigrations', [], 5],
             ['getLatestVersion', [], '5Test'],
-            ['getMigrationsToExecute', ['up', 5], [
+            [
+        'getMigrationsToExecute',
+        ['up', 5],
+        [
                 '1Test',
                 '2Test',
                 '3Test',
                 '4Test',
                 '5Test',
-            ]],
+            ],
+            ],
             ['getMigrationsToExecute', ['down', 0], []],
             ['getMigrationsToExecute', ['down', 2], []],
         ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTestSource/Migrations/Version123.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/ConfigurationTestSource/Migrations/Version123.php
@@ -4,5 +4,4 @@ namespace Migrations\IncorrectNamespace;
 
 class Version123
 {
-
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/JsonConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/JsonConfigurationTest.php
@@ -10,17 +10,17 @@ class JsonConfigurationTest extends AbstractConfigurationTest
 {
     public function loadConfiguration(
         $configFileSuffix = '',
-        OutputWriter $outputWriter = null,
-        MigrationFinderInterface $migrationFinder = null
+        ?OutputWriter $outputWriter = null,
+        ?MigrationFinderInterface $migrationFinder = null
     ) {
         $configFile = 'config.json';
 
-        if ('' !== $configFileSuffix) {
+        if ($configFileSuffix !== '') {
             $configFile = 'config_' . $configFileSuffix . '.json';
         }
 
         $config = new JsonConfiguration($this->getSqliteConnection(), $outputWriter, $migrationFinder);
-        $config->load(__DIR__ . DIRECTORY_SEPARATOR . "_files" . DIRECTORY_SEPARATOR . $configFile);
+        $config->load(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile);
 
         return $config;
     }
@@ -35,6 +35,6 @@ class JsonConfigurationTest extends AbstractConfigurationTest
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Given config file does not exist');
 
-        $config->load(__DIR__ . "/_files/none.json");
+        $config->load(__DIR__ . '/_files/none.json');
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/XmlConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/XmlConfigurationTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Configuration;
 
-use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Configuration\XmlConfiguration;
 use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
+use Doctrine\DBAL\Migrations\OutputWriter;
 
 class XmlConfigurationTest extends AbstractConfigurationTest
 {
@@ -13,11 +13,11 @@ class XmlConfigurationTest extends AbstractConfigurationTest
      */
     public function loadConfiguration(
         $configFileSuffix = '',
-        OutputWriter $outputWriter = null,
-        MigrationFinderInterface $migrationFinder = null
+        ?OutputWriter $outputWriter = null,
+        ?MigrationFinderInterface $migrationFinder = null
     ) {
         $configFile = 'config.xml';
-        if ('' !== $configFileSuffix) {
+        if ($configFileSuffix !== '') {
             $configFile = 'config_' . $configFileSuffix . '.xml';
         }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/YamlConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/YamlConfigurationTest.php
@@ -2,9 +2,9 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Configuration;
 
-use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Configuration\YamlConfiguration;
 use Doctrine\DBAL\Migrations\Finder\MigrationFinderInterface;
+use Doctrine\DBAL\Migrations\OutputWriter;
 
 class YamlConfigurationTest extends AbstractConfigurationTest
 {
@@ -13,11 +13,11 @@ class YamlConfigurationTest extends AbstractConfigurationTest
      */
     public function loadConfiguration(
         $configFileSuffix = '',
-        OutputWriter $outputWriter = null,
-        MigrationFinderInterface $migrationFinder = null
+        ?OutputWriter $outputWriter = null,
+        ?MigrationFinderInterface $migrationFinder = null
     ) {
         $configFile = 'config.yml';
-        if ('' !== $configFileSuffix) {
+        if ($configFileSuffix !== '') {
             $configFile = 'config_' . $configFileSuffix . '.yml';
         }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config.php
@@ -5,5 +5,5 @@ return [
 'table_name'           => 'doctrine_migration_versions_test',
 'column_name'          => 'doctrine_migration_column_test',
 'migrations_directory' => '.',
-'migrations'           => []
+'migrations'           => [],
 ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_invalid.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_invalid.php
@@ -1,4 +1,2 @@
 <?php
-return [
-'OptionThatDoesNotExists' => 'Doctrine Sandbox Migrations',
-];
+return ['OptionThatDoesNotExists' => 'Doctrine Sandbox Migrations'];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list.php
@@ -4,16 +4,16 @@ return [
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations'           => [
     [
-        "class" => "Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version1Test",
-        "version" => "Version1Test",
+        'class' => 'Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version1Test',
+        'version' => 'Version1Test',
     ],
     [
-        "class" => "Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version2Test",
-        "version" => "Version2Test",
+        'class' => 'Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version2Test',
+        'version' => 'Version2Test',
     ],
     [
-        "class" => "Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version3Test",
-        "version" => "Version3Test",
-    ]
-]
+        'class' => 'Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version3Test',
+        'version' => 'Version3Test',
+    ],
+],
 ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list2.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_migrations_list2.php
@@ -3,20 +3,20 @@ return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations'           => [
-    "migration1" =>
+    'migration1' =>
         [
-            "class" => "Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version1Test",
-            "version" => "Version1Test",
+            'class' => 'Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version1Test',
+            'version' => 'Version1Test',
         ],
-    "migration2" =>
+    'migration2' =>
         [
-            "class" => "Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version2Test",
-            "version" => "Version2Test",
+            'class' => 'Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version2Test',
+            'version' => 'Version2Test',
         ],
-    "migration3" =>
+    'migration3' =>
         [
-            "class" => "Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version3Test",
-            "version" => "Version3Test",
-        ]
-]
+            'class' => 'Doctrine\\DBAL\\Migrations\\Tests\\Stub\\Version3Test',
+            'version' => 'Version3Test',
+        ],
+],
 ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_1.php
@@ -4,5 +4,5 @@ return [
 'migrations_namespace' => 'DoctrineMigrationsTest',
 'table_name'           => 'doctrine_migration_versions_test',
 'migrations_directory' => '.',
-'migrations'           => []
+'migrations'           => [],
 ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_order_2.php
@@ -4,5 +4,5 @@ return [
     'migrations_directory' => '.',
     'migrations_namespace' => 'DoctrineMigrationsTest',
     'table_name'           => 'doctrine_migration_versions_test',
-    'migrations'           => []
+    'migrations'           => [],
 ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year.php
@@ -1,2 +1,2 @@
 <?php
-return ["organize_migrations" => "year"];
+return ['organize_migrations' => 'year'];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year_and_month.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_by_year_and_month.php
@@ -1,2 +1,2 @@
 <?php
-return ["organize_migrations" => "year_AND_MOnth"];
+return ['organize_migrations' => 'year_AND_MOnth'];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_invalid.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Configuration/_files/config_organize_invalid.php
@@ -1,2 +1,2 @@
 <?php
-return ["organize_migrations" => "foo-bar"];
+return ['organize_migrations' => 'foo-bar'];

--- a/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/ConfigurationTest.php
@@ -3,8 +3,8 @@
 namespace Doctrine\DBAL\Migrations\Tests;
 
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
-use Doctrine\DBAL\Migrations\Events;
 use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
+use Doctrine\DBAL\Migrations\Events;
 use Doctrine\DBAL\Migrations\MigrationException;
 use Doctrine\DBAL\Migrations\Tests\Stub\EventVerificationListener;
 use Doctrine\DBAL\Migrations\Tests\Stub\Version1Test;
@@ -34,7 +34,7 @@ class ConfigurationTest extends MigrationTestCase
     public function testValidateMigrationsDirectoryRequired()
     {
         $config = new Configuration($this->getSqliteConnection());
-        $config->setMigrationsNamespace("DoctrineMigrations\\");
+        $config->setMigrationsNamespace('DoctrineMigrations\\');
 
         $this->expectException(MigrationException::class);
         $this->expectExceptionMessage('Migrations directory must be configured in order to use Doctrine migrations.');
@@ -45,7 +45,7 @@ class ConfigurationTest extends MigrationTestCase
     public function testValidateMigrations()
     {
         $config = new Configuration($this->getSqliteConnection());
-        $config->setMigrationsNamespace("DoctrineMigrations\\");
+        $config->setMigrationsNamespace('DoctrineMigrations\\');
         $config->setMigrationsDirectory(sys_get_temp_dir());
 
         $config->validate();
@@ -65,18 +65,18 @@ class ConfigurationTest extends MigrationTestCase
     {
         $config = new Configuration($this->getSqliteConnection());
 
-        self::assertEquals("doctrine_migration_versions", $config->getMigrationsTableName());
+        self::assertEquals('doctrine_migration_versions', $config->getMigrationsTableName());
     }
 
     public function testEmptyProjectDefaults()
     {
         $config = $this->getSqliteConfiguration();
-        self::assertNull($config->getPrevVersion(), "no prev version");
-        self::assertNull($config->getNextVersion(), "no next version");
-        self::assertSame('0', $config->getCurrentVersion(), "current version 0");
-        self::assertSame('0', $config->getLatestVersion(), "latest version 0");
-        self::assertEquals(0, $config->getNumberOfAvailableMigrations(), "number of available migrations 0");
-        self::assertEquals(0, $config->getNumberOfExecutedMigrations(), "number of executed migrations 0");
+        self::assertNull($config->getPrevVersion(), 'no prev version');
+        self::assertNull($config->getNextVersion(), 'no next version');
+        self::assertSame('0', $config->getCurrentVersion(), 'current version 0');
+        self::assertSame('0', $config->getLatestVersion(), 'latest version 0');
+        self::assertEquals(0, $config->getNumberOfAvailableMigrations(), 'number of available migrations 0');
+        self::assertEquals(0, $config->getNumberOfExecutedMigrations(), 'number of executed migrations 0');
         self::assertEquals([], $config->getMigrations());
     }
 
@@ -95,7 +95,7 @@ class ConfigurationTest extends MigrationTestCase
         $config = $this->getSqliteConfiguration();
         $config->registerMigration(1234, Version1Test::class);
 
-        self::assertCount(1, $config->getMigrations(), "One Migration registered.");
+        self::assertCount(1, $config->getMigrations(), 'One Migration registered.');
         self::assertTrue($config->hasVersion(1234));
 
         $version = $config->getVersion(1234);
@@ -112,7 +112,7 @@ class ConfigurationTest extends MigrationTestCase
             1235 => Version2Test::class,
         ]);
 
-        self::assertCount(2, $config->getMigrations(), "Two Migration registered.");
+        self::assertCount(2, $config->getMigrations(), 'Two Migration registered.');
 
         $version = $config->getVersion(1234);
         self::assertInstanceOf(Version::class, $version);
@@ -206,39 +206,39 @@ class ConfigurationTest extends MigrationTestCase
             1236 => Version3Test::class,
         ]);
 
-        self::assertNull($config->getPrevVersion(), "no prev version");
-        self::assertSame('0', $config->getCurrentVersion(), "current version 0");
-        self::assertSame('1234', $config->getNextVersion(), "next version 1234");
-        self::assertSame('1236', $config->getLatestVersion(), "latest version 1236");
+        self::assertNull($config->getPrevVersion(), 'no prev version');
+        self::assertSame('0', $config->getCurrentVersion(), 'current version 0');
+        self::assertSame('1234', $config->getNextVersion(), 'next version 1234');
+        self::assertSame('1236', $config->getLatestVersion(), 'latest version 1236');
 
         $config->getVersion(1234)->markMigrated();
 
-        self::assertSame('0', $config->getPrevVersion(), "prev version 0");
-        self::assertSame('1234', $config->getCurrentVersion(), "current version 1234");
-        self::assertSame('1235', $config->getNextVersion(), "next version 1235");
-        self::assertSame('1236', $config->getLatestVersion(), "latest version 1236");
+        self::assertSame('0', $config->getPrevVersion(), 'prev version 0');
+        self::assertSame('1234', $config->getCurrentVersion(), 'current version 1234');
+        self::assertSame('1235', $config->getNextVersion(), 'next version 1235');
+        self::assertSame('1236', $config->getLatestVersion(), 'latest version 1236');
 
         $config->getVersion(1235)->markMigrated();
 
-        self::assertSame('1234', $config->getPrevVersion(), "prev version 1234");
-        self::assertSame('1235', $config->getCurrentVersion(), "current version 1235");
-        self::assertSame('1236', $config->getNextVersion(), "next version is 1236");
-        self::assertSame('1236', $config->getLatestVersion(), "latest version 1236");
+        self::assertSame('1234', $config->getPrevVersion(), 'prev version 1234');
+        self::assertSame('1235', $config->getCurrentVersion(), 'current version 1235');
+        self::assertSame('1236', $config->getNextVersion(), 'next version is 1236');
+        self::assertSame('1236', $config->getLatestVersion(), 'latest version 1236');
 
-        self::assertSame('0', $config->resolveVersionAlias('first'), "first version 0");
-        self::assertSame('1234', $config->resolveVersionAlias('prev'), "prev version 1234");
-        self::assertSame('1235', $config->resolveVersionAlias('current'), "current version 1235");
-        self::assertSame('1236', $config->resolveVersionAlias('next'), "next version is 1236");
-        self::assertSame('1236', $config->resolveVersionAlias('latest'), "latest version 1236");
-        self::assertSame('1236', $config->resolveVersionAlias('1236'), "identical version");
-        self::assertNull($config->resolveVersionAlias('123678'), "unknown version");
+        self::assertSame('0', $config->resolveVersionAlias('first'), 'first version 0');
+        self::assertSame('1234', $config->resolveVersionAlias('prev'), 'prev version 1234');
+        self::assertSame('1235', $config->resolveVersionAlias('current'), 'current version 1235');
+        self::assertSame('1236', $config->resolveVersionAlias('next'), 'next version is 1236');
+        self::assertSame('1236', $config->resolveVersionAlias('latest'), 'latest version 1236');
+        self::assertSame('1236', $config->resolveVersionAlias('1236'), 'identical version');
+        self::assertNull($config->resolveVersionAlias('123678'), 'unknown version');
 
         $config->getVersion(1236)->markMigrated();
 
-        self::assertSame('1235', $config->getPrevVersion(), "prev version 1235");
-        self::assertSame('1236', $config->getCurrentVersion(), "current version 1236");
-        self::assertNull($config->getNextVersion(), "no next version");
-        self::assertSame('1236', $config->getLatestVersion(), "latest version 1236");
+        self::assertSame('1235', $config->getPrevVersion(), 'prev version 1235');
+        self::assertSame('1236', $config->getCurrentVersion(), 'current version 1236');
+        self::assertNull($config->getNextVersion(), 'no next version');
+        self::assertSame('1236', $config->getLatestVersion(), 'latest version 1236');
     }
 
     public function testDeltaVersion()
@@ -250,35 +250,35 @@ class ConfigurationTest extends MigrationTestCase
             1236 => Version3Test::class,
         ]);
 
-        self::assertNull($config->getDeltaVersion('-1'), "no current-1 version");
-        self::assertSame('1234', $config->getDeltaVersion('+1'), "current+1 is 1234");
-        self::assertSame('1235', $config->getDeltaVersion('+2'), "current+2 is 1235");
-        self::assertSame('1236', $config->getDeltaVersion('+3'), "current+3 is 1236");
-        self::assertNull($config->getDeltaVersion('+4'), "no current+4 version");
+        self::assertNull($config->getDeltaVersion('-1'), 'no current-1 version');
+        self::assertSame('1234', $config->getDeltaVersion('+1'), 'current+1 is 1234');
+        self::assertSame('1235', $config->getDeltaVersion('+2'), 'current+2 is 1235');
+        self::assertSame('1236', $config->getDeltaVersion('+3'), 'current+3 is 1236');
+        self::assertNull($config->getDeltaVersion('+4'), 'no current+4 version');
 
         $config->getVersion(1234)->markMigrated();
 
-        self::assertNull($config->getDeltaVersion('-2'), "no current-2 version");
-        self::assertSame('0', $config->getDeltaVersion('-1'), "current-1 is 0");
-        self::assertSame('1235', $config->getDeltaVersion('+1'), "current+1 is 1235");
-        self::assertSame('1236', $config->getDeltaVersion('+2'), "current+2 is 1236");
-        self::assertNull($config->getDeltaVersion('+3'), "no current+3");
+        self::assertNull($config->getDeltaVersion('-2'), 'no current-2 version');
+        self::assertSame('0', $config->getDeltaVersion('-1'), 'current-1 is 0');
+        self::assertSame('1235', $config->getDeltaVersion('+1'), 'current+1 is 1235');
+        self::assertSame('1236', $config->getDeltaVersion('+2'), 'current+2 is 1236');
+        self::assertNull($config->getDeltaVersion('+3'), 'no current+3');
 
         $config->getVersion(1235)->markMigrated();
 
-        self::assertNull($config->getDeltaVersion('-3'), "no current-3 version");
-        self::assertSame('0', $config->getDeltaVersion('-2'), "current-2 is 0");
-        self::assertSame('1234', $config->getDeltaVersion('-1'), "current-1 is 1234");
-        self::assertSame('1236', $config->getDeltaVersion('+1'), "current+1 is 1236");
-        self::assertNull($config->getDeltaVersion('+2'), "no current+2");
+        self::assertNull($config->getDeltaVersion('-3'), 'no current-3 version');
+        self::assertSame('0', $config->getDeltaVersion('-2'), 'current-2 is 0');
+        self::assertSame('1234', $config->getDeltaVersion('-1'), 'current-1 is 1234');
+        self::assertSame('1236', $config->getDeltaVersion('+1'), 'current+1 is 1236');
+        self::assertNull($config->getDeltaVersion('+2'), 'no current+2');
 
         $config->getVersion(1236)->markMigrated();
 
-        self::assertNull($config->getDeltaVersion('-4'), "no current-4 version");
-        self::assertSame('0', $config->getDeltaVersion('-3'), "current-3 is 0");
-        self::assertSame('1234', $config->getDeltaVersion('-2'), "current-2 is 1234");
-        self::assertSame('1235', $config->getDeltaVersion('-1'), "current-1 is 1235");
-        self::assertNull($config->getDeltaVersion('+1'), "no current+1");
+        self::assertNull($config->getDeltaVersion('-4'), 'no current-4 version');
+        self::assertSame('0', $config->getDeltaVersion('-3'), 'current-3 is 0');
+        self::assertSame('1234', $config->getDeltaVersion('-2'), 'current-2 is 1234');
+        self::assertSame('1235', $config->getDeltaVersion('-1'), 'current-1 is 1235');
+        self::assertNull($config->getDeltaVersion('+1'), 'no current+1');
     }
 
     public function testGetAvailableVersions()
@@ -317,8 +317,6 @@ class ConfigurationTest extends MigrationTestCase
 
     /**
      * @dataProvider autoloadVersionProvider
-     *
-     * @param $version
      */
     public function testGetVersionAutoloadVersion($version)
     {
@@ -356,7 +354,7 @@ class ConfigurationTest extends MigrationTestCase
         $config1 = $this->getSqliteConfiguration();
         $config1->setIsDryRun(false);
 
-        self::assertSame('0', $config1->getCurrentVersion(), "current version 0");
+        self::assertSame('0', $config1->getCurrentVersion(), 'current version 0');
         $this->assertTrue($config1->getConnection()->getSchemaManager()->tablesExist([$config1->getMigrationsTableName()]));
 
         // migrations table created
@@ -370,7 +368,7 @@ class ConfigurationTest extends MigrationTestCase
         $config3 = $this->getSqliteConfiguration();
         $config3->setIsDryRun(true);
 
-        self::assertSame('0', $config3->getCurrentVersion(), "current version 0");
+        self::assertSame('0', $config3->getCurrentVersion(), 'current version 0');
         $this->assertFalse($config3->getConnection()->getSchemaManager()->tablesExist([$config3->getMigrationsTableName()]));
 
         self::assertEquals([], $config3->getMigratedVersions());
@@ -386,13 +384,16 @@ class ConfigurationTest extends MigrationTestCase
         $config->getVersion(1234)->markMigrated();
         $config->setIsDryRun(true);
 
-        self::assertSame('1234', $config->getCurrentVersion(), "current version 1234");
-        self::assertSame('1235', $config->getNextVersion(), "next version 1235");
+        self::assertSame('1234', $config->getCurrentVersion(), 'current version 1234');
+        self::assertSame('1235', $config->getNextVersion(), 'next version 1235');
 
         self::assertEquals(['1234'], $config->getMigratedVersions());
         $this->assertTrue($config->getConnection()->getSchemaManager()->tablesExist([$config->getMigrationsTableName()]));
     }
 
+    /**
+     * @return string[][]
+     */
     public function versionProvider()
     {
         return [
@@ -402,12 +403,12 @@ class ConfigurationTest extends MigrationTestCase
             ['0000254BaldlfqjdVersion', ''],
             ['20130101123545Version', '2013-01-01 12:35:45'],
             ['20150202042811', '2015-02-02 04:28:11'],
-            ['20150202162811', '2015-02-02 16:28:11']
+            ['20150202162811', '2015-02-02 16:28:11'],
         ];
     }
 
     /**
-     * @return array
+     * @return string[][]
      */
     public function autoloadVersionProvider()
     {
@@ -431,6 +432,9 @@ class ConfigurationTest extends MigrationTestCase
         self::assertSame($template, $config->getCustomTemplate());
     }
 
+    /**
+     * @return string[]|null[]
+     */
     public function validCustomTemplates() : array
     {
         return [

--- a/tests/Doctrine/DBAL/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
@@ -4,14 +4,26 @@ namespace Doctrine\DBAL\Migrations\Tests\Event\Listeners;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
-use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
 use Doctrine\DBAL\Migrations\Event\Listeners\AutoCommitListener;
+use Doctrine\DBAL\Migrations\Event\MigrationsEventArgs;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
+use PHPUnit\Framework\MockObject\MockBuilder;
 
 class AutoCommitListenerTest extends MigrationTestCase
 {
+    /** @var Connection|MockBuilder */
     private $conn;
+
+    /** @var AutoCommitListener */
     private $listener;
+
+    protected function setUp()
+    {
+        $this->conn     = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->listener = new AutoCommitListener();
+    }
 
     public function testListenerDoesNothingDuringADryRun()
     {
@@ -39,14 +51,6 @@ class AutoCommitListenerTest extends MigrationTestCase
             ->method('commit');
 
         $this->listener->onMigrationsMigrated($this->createArgs(false));
-    }
-
-    protected function setUp()
-    {
-        $this->conn     = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->listener = new AutoCommitListener();
     }
 
     private function willNotCommit()

--- a/tests/Doctrine/DBAL/Migrations/Tests/FileQueryWriterTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/FileQueryWriterTest.php
@@ -16,6 +16,7 @@ final class FileQueryWriterTest extends MigrationTestCase
     private const DOWN_QUERY  = 'DELETE FROM %s WHERE %s = \'1\'';
 
     /**
+     * @param string[] $queries
      * @dataProvider writeProvider
      */
     public function testWrite(string $path, string $direction, array $queries, ?OutputWriter $outputWriter) : void
@@ -39,6 +40,9 @@ final class FileQueryWriterTest extends MigrationTestCase
         }
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function writeProvider() : array
     {
         $outputWriter = $this->createMock(OutputWriter::class);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Finder/GlobFinderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Finder/GlobFinderTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 
 class GlobFinderTest extends MigrationTestCase
 {
+    /** @var GlobFinder */
     private $finder;
 
     public function testBadFilenameCausesErrorWhenFindingMigrations()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 
 class RecursiveRegexFinderTest extends MigrationTestCase
 {
+    /** @var RecursiveRegexFinder */
     private $finder;
 
     public function testVersionNameCausesErrorWhen0()
@@ -53,7 +54,7 @@ class RecursiveRegexFinderTest extends MigrationTestCase
 
         asort($migrationsForTestSort);
 
-        self::assertSame($migrations, $migrationsForTestSort, "Finder have to return sorted list of the files.");
+        self::assertSame($migrations, $migrationsForTestSort, 'Finder have to return sorted list of the files.');
         self::assertArrayNotHasKey('InvalidVersion20150502000002', $migrations);
         self::assertArrayNotHasKey('Version20150502000002', $migrations);
         self::assertArrayNotHasKey('20150502000002', $migrations);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -431,8 +431,8 @@ class FunctionalTest extends MigrationTestCase
      */
     public function testMigrateWithConnectionWithAutoCommitOffStillPersistsChanges()
     {
-        $listener            = new AutoCommitListener();
-        list($conn, $config) = self::fileConnectionAndConfig();
+        $listener        = new AutoCommitListener();
+        [$conn, $config] = self::fileConnectionAndConfig();
         $config->registerMigration(1, MigrateWithDataModification::class);
         $migration = new Migration($config);
         $conn->getEventManager()->addEventSubscriber($listener);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Functional/FunctionalTest.php
@@ -5,9 +5,10 @@ namespace Doctrine\DBAL\Migrations\Tests\Functional;
 use Doctrine\DBAL\Configuration as DbalConfig;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Event\Listeners\AutoCommitListener;
 use Doctrine\DBAL\Migrations\Events;
 use Doctrine\DBAL\Migrations\Migration;
-use Doctrine\DBAL\Migrations\Event\Listeners\AutoCommitListener;
 use Doctrine\DBAL\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tests\Stub\EventVerificationListener;
@@ -17,22 +18,17 @@ use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateNotTouchingTheSchema;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateWithDataModification;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationMigrateFurther;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationMigrateUp;
+use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationModifySchemaInPreAndPost;
 use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationSkipMigration;
 use Doctrine\DBAL\Migrations\Version;
-use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrationModifySchemaInPreAndPost;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Migrations\Configuration\Configuration;
 
 class FunctionalTest extends MigrationTestCase
 {
-    /**
-     * @var Configuration
-     */
+    /** @var Configuration */
     private $config;
 
-    /**
-     * @var \Doctrine\DBAL\Connection
-     */
+    /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
     protected function setUp()
@@ -197,7 +193,7 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration(1, MigrateAddSqlPostAndPreUpAndDownTest::class);
         $tableName = MigrateAddSqlPostAndPreUpAndDownTest::TABLE_NAME;
 
-        $this->config->getConnection()->executeQuery(sprintf("CREATE TABLE IF NOT EXISTS %s (test INT)", $tableName));
+        $this->config->getConnection()->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (test INT)', $tableName));
 
         $migration = new Migration($this->config);
         $migration->migrate(1);
@@ -205,19 +201,18 @@ class FunctionalTest extends MigrationTestCase
         $migrations = $this->config->getMigrations();
         self::assertTrue($migrations[1]->isMigrated());
 
-        $check = $this->config->getConnection()->fetchColumn("select SUM(test) as sum from $tableName");
+        $check = $this->config->getConnection()->fetchColumn('select SUM(test) as sum from ' . $tableName);
 
         self::assertNotEmpty($check);
         self::assertEquals(3, $check);
 
         $migration->migrate(0);
         self::assertFalse($migrations[1]->isMigrated());
-        $check = $this->config->getConnection()->fetchColumn("select SUM(test) as sum from $tableName");
+        $check = $this->config->getConnection()->fetchColumn('select SUM(test) as sum from ' . $tableName);
         self::assertNotEmpty($check);
         self::assertEquals(12, $check);
 
-
-        $this->config->getConnection()->executeQuery(sprintf("DROP TABLE %s ", $tableName));
+        $this->config->getConnection()->executeQuery(sprintf('DROP TABLE %s ', $tableName));
     }
 
     public function testVersionInDatabaseWithoutRegisteredMigrationStillMigrates()
@@ -298,6 +293,7 @@ class FunctionalTest extends MigrationTestCase
     }
 
     /**
+     * @param string[] $migrations
      * @see https://github.com/doctrine/migrations/issues/61
      * @group regresion
      * @dataProvider provideTestMigrationNames
@@ -342,17 +338,22 @@ class FunctionalTest extends MigrationTestCase
         };
     }
 
+    /**
+     * @return string[][]
+     */
     public function provideTestMigrationNames()
     {
         return [
             [[
                 '20120228123443' => MigrateAddSqlTest::class,
                 '20120228114838' => MigrationMigrateFurther::class,
-            ]],
+            ],
+            ],
             [[
                 '002Test' => MigrateAddSqlTest::class,
                 '001Test' => MigrationMigrateFurther::class,
-            ]]
+            ],
+            ],
         ];
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Helper.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Helper.php
@@ -4,7 +4,6 @@ namespace Doctrine\DBAL\Migrations\Tests;
 
 class Helper
 {
-
     /**
      * Delete a directory.
      *
@@ -15,7 +14,7 @@ class Helper
      */
     public static function deleteDir($path)
     {
-        if ('' === $path) {
+        if ($path === '') {
             return false;
         }
         $class_func = [__CLASS__, __FUNCTION__];

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -29,19 +29,19 @@ use Doctrine\DBAL\Migrations\Tests\Stub\Functional\MigrateNotTouchingTheSchema;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
 use PHPUnit\Framework\Constraint\RegularExpression;
+use Symfony\Component\Console\Output\StreamOutput;
 
 require_once __DIR__ . '/realpath.php';
 
 class MigrationTest extends MigrationTestCase
 {
-    /**
-     * @var Connection
-     */
+    /** @var Connection */
     private $conn;
 
     /** @var Configuration */
     private $config;
 
+    /** @var StreamOutput|null */
     protected $output;
 
     protected function setUp()
@@ -89,8 +89,6 @@ class MigrationTest extends MigrationTestCase
     }
 
     /**
-     * @param $to
-     *
      * @dataProvider getSqlProvider
      */
     public function testGetSql($to)
@@ -115,7 +113,7 @@ class MigrationTest extends MigrationTestCase
 
     /**
      * Data provider for ::testGetSql()
-     * @return array
+     * @return mixed[][]
      */
     public function getSqlProvider()
     {
@@ -126,9 +124,7 @@ class MigrationTest extends MigrationTestCase
     }
 
     /**
-     * @param $path
-     * @param $to
-     * @param $getSqlReturn
+     * @param string[] $getSqlReturn
      *
      * @dataProvider writeSqlFileProvider
      */
@@ -178,6 +174,9 @@ class MigrationTest extends MigrationTestCase
         self::assertTrue($migration->writeSqlFile($path, $to));
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function writeSqlFileProvider()
     {
         return [
@@ -236,9 +235,7 @@ class MigrationTest extends MigrationTestCase
         $this->config->setMigrationsNamespace('DoctrineMigrations\\');
         $this->config->registerMigration('20160707000000', MigrateNotTouchingTheSchema::class);
         $this->config->createMigrationTable();
-        $this->conn->insert($this->config->getMigrationsTableName(), [
-            'version' => '20160707000000',
-        ]);
+        $this->conn->insert($this->config->getMigrationsTableName(), ['version' => '20160707000000']);
 
         $migration = new Migration($this->config);
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTestCase.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTestCase.php
@@ -5,17 +5,16 @@ namespace Doctrine\DBAL\Migrations\Tests;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\OutputWriter;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
 
-abstract class MigrationTestCase extends \PHPUnit\Framework\TestCase
+abstract class MigrationTestCase extends TestCase
 {
-    /**
-     * @var OutputWriter
-     */
+    /** @var OutputWriter */
     private $outputWriter;
 
-    /** @var  Output */
+    /** @var Output */
     protected $output;
 
     public function getSqliteConnection()
@@ -56,7 +55,7 @@ abstract class MigrationTestCase extends \PHPUnit\Framework\TestCase
     public function getInputStream($input)
     {
         $stream = fopen('php://memory', 'r+', false);
-        fputs($stream, $input);
+        fwrite($stream, $input);
         rewind($stream);
 
         return $stream;
@@ -64,7 +63,7 @@ abstract class MigrationTestCase extends \PHPUnit\Framework\TestCase
 
     protected function getOutputWriter()
     {
-        if ( ! $this->outputWriter) {
+        if (! $this->outputWriter) {
             $this->output       = $this->getOutputStream();
             $output             = $this->output;
             $this->outputWriter = new OutputWriter(function ($message) use ($output) {
@@ -76,7 +75,7 @@ abstract class MigrationTestCase extends \PHPUnit\Framework\TestCase
 
     protected function createTempDirForMigrations($path)
     {
-        if ( ! mkdir($path)) {
+        if (! mkdir($path)) {
             throw new \Exception('fail to create a temporary folder for the tests at ' . $path);
         }
     }
@@ -85,8 +84,12 @@ abstract class MigrationTestCase extends \PHPUnit\Framework\TestCase
     {
         if (is_dir($path)) {
             return glob(realpath($path) . '/*.sql');
-        } elseif (is_file($path)) {
+        }
+
+        if (is_file($path)) {
             return [$path];
         }
+
+        return null;
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -14,22 +14,28 @@ use Doctrine\ORM\Tools\Setup;
 
 /**
  * Tests the OrmSchemaProvider using a real entity manager.
- *
- * @since   1.0.0-alpha3
  */
 class OrmSchemaProviderTest extends MigrationTestCase
 {
-    /** @var  Connection */
+    /** @var Connection */
     private $conn;
 
-    /** @var  Configuration */
+    /** @var Configuration */
     private $config;
 
-    /** @var  EntityManagerInterface */
+    /** @var EntityManagerInterface */
     private $entityManager;
 
-    /** @var  OrmSchemaProvider */
+    /** @var OrmSchemaProvider */
     private $ormProvider;
+
+    protected function setUp()
+    {
+        $this->conn          = $this->getSqliteConnection();
+        $this->config        = Setup::createXMLMetadataConfiguration([__DIR__ . '/_files'], true);
+        $this->entityManager = EntityManager::create($this->conn, $this->config);
+        $this->ormProvider   = new OrmSchemaProvider($this->entityManager);
+    }
 
     public function testCreateSchemaFetchesMetadataFromEntityManager()
     {
@@ -49,10 +55,13 @@ class OrmSchemaProviderTest extends MigrationTestCase
         $this->ormProvider->createSchema();
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function notEntityManagers()
     {
         return [
-            [new \stdClass],
+            [new \stdClass()],
             [false],
             [1],
             ['oops'],
@@ -68,13 +77,5 @@ class OrmSchemaProviderTest extends MigrationTestCase
         $this->expectException(\InvalidArgumentException::class);
 
         new OrmSchemaProvider($em);
-    }
-
-    protected function setUp()
-    {
-        $this->conn          = $this->getSqliteConnection();
-        $this->config        = Setup::createXMLMetadataConfiguration([__DIR__ . '/_files'], true);
-        $this->entityManager = EntityManager::create($this->conn, $this->config);
-        $this->ormProvider   = new OrmSchemaProvider($this->entityManager);
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Provider/SampleEntity.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Provider/SampleEntity.php
@@ -4,5 +4,11 @@ namespace Doctrine\DBAL\Migrations\Tests\Provider;
 
 class SampleEntity
 {
+    /** @var mixed */
     private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/SqlFileWriterTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/SqlFileWriterTest.php
@@ -1,21 +1,4 @@
 <?php
-/*
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * This software consists of voluntary contributions made by many individuals
- * and is licensed under the LGPL. For more information, see
- * <http://www.doctrine-project.org>.
-*/
 
 namespace Doctrine\DBAL\Migrations\Tests;
 
@@ -23,12 +6,11 @@ use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\SqlFileWriter;
 use Doctrine\DBAL\Migrations\Version;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SqlFileWriterTest extends MigrationTestCase
 {
-    /**
-     * @var OutputWriter|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var OutputWriter|MockObject */
     protected $ow;
 
     protected function setUp()
@@ -67,10 +49,7 @@ class SqlFileWriterTest extends MigrationTestCase
     }
 
     /**
-     * @param $path
-     * @param $direction
-     * @param array $queries
-     * @param $withOw
+     * @param string[][] $queries
      *
      * @dataProvider writeProvider
      */
@@ -95,15 +74,18 @@ class SqlFileWriterTest extends MigrationTestCase
         foreach ($files as $file) {
             $contents = file_get_contents($file);
             self::assertNotEmpty($contents);
-            if ($direction == Version::DIRECTION_UP) {
-                self::assertContains("INSERT INTO $tableName ($columnName) VALUES ('1');", $contents);
+            if ($direction === Version::DIRECTION_UP) {
+                self::assertContains('INSERT INTO ' . $tableName . ' (' . $columnName . ") VALUES ('1');", $contents);
             } else {
-                self::assertContains("DELETE FROM $tableName WHERE $columnName = '1'", $contents);
+                self::assertContains('DELETE FROM ' . $tableName . ' WHERE ' . $columnName . " = '1'", $contents);
             }
             unlink($file);
         }
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function writeProvider()
     {
         return [

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/AbstractMigrationStub.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/AbstractMigrationStub.php
@@ -9,13 +9,9 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Class AbstractMigrationStub
- * @package Doctrine\DBAL\Migrations\Tests\Stub
- *
- * @author Robbert van den Bogerd <rvdbogerd@ibuildings.nl>
  */
 class AbstractMigrationStub extends AbstractMigration
 {
-
     public function up(Schema $schema)
     {
     }
@@ -34,6 +30,10 @@ class AbstractMigrationStub extends AbstractMigration
         $this->throwIrreversibleMigrationException($message);
     }
 
+    /**
+     * @param mixed[]  $params
+     * @param string[] $types
+     */
     public function exposedAddSql($sql, $params = [], $types = [])
     {
         $this->addSql($sql, $params, $types);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version1Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version1Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version1Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version2Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version2Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version2Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version3Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version3Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version3Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version4Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version4Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version4Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version5Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Configuration/AutoloadVersions/Version5Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub\Configuration\AutoloadVersions;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version5Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/EventVerificationListener.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/EventVerificationListener.php
@@ -8,8 +8,12 @@ use Doctrine\DBAL\Migrations\Events;
 
 final class EventVerificationListener implements EventSubscriber
 {
+    /** @var EventArgs[][] */
     public $events = [];
 
+    /**
+     * @return string[]
+     */
     public function getSubscribedEvents()
     {
         return [

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlPostAndPreUpAndDownTest.php
@@ -7,12 +7,12 @@ use Doctrine\DBAL\Schema\Schema;
 
 class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
 {
-    const TABLE_NAME = 'test_add_sql_post_up_table';
+    public const TABLE_NAME = 'test_add_sql_post_up_table';
 
     public function preUp(Schema $schema)
     {
         $this->addSql(
-            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            sprintf('INSERT INTO %s (test) values (?)', self::TABLE_NAME),
             [1]
         );
     }
@@ -20,7 +20,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
     public function up(Schema $schema)
     {
         $this->addSql(
-            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            sprintf('INSERT INTO %s (test) values (?)', self::TABLE_NAME),
             [2]
         );
     }
@@ -28,7 +28,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
     public function postUp(Schema $schema)
     {
         $this->addSql(
-            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            sprintf('INSERT INTO %s (test) values (?)', self::TABLE_NAME),
             [3]
         );
     }
@@ -36,7 +36,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
     public function preDown(Schema $schema)
     {
         $this->addSql(
-            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            sprintf('INSERT INTO %s (test) values (?)', self::TABLE_NAME),
             [4]
         );
     }
@@ -44,7 +44,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
     public function down(Schema $schema)
     {
         $this->addSql(
-            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            sprintf('INSERT INTO %s (test) values (?)', self::TABLE_NAME),
             [5]
         );
     }
@@ -52,7 +52,7 @@ class MigrateAddSqlPostAndPreUpAndDownTest extends AbstractMigration
     public function postDown(Schema $schema)
     {
         $this->addSql(
-            sprintf("INSERT INTO %s (test) values (?)", self::TABLE_NAME),
+            sprintf('INSERT INTO %s (test) values (?)', self::TABLE_NAME),
             [6]
         );
     }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateAddSqlTest.php
@@ -9,12 +9,12 @@ class MigrateAddSqlTest extends AbstractMigration
 {
     public function up(Schema $schema)
     {
-        $this->addSql("CREATE TABLE test_add_sql_table (test varchar(255))");
-        $this->addSql("INSERT INTO test_add_sql_table (test) values (?)", ['test']);
+        $this->addSql('CREATE TABLE test_add_sql_table (test varchar(255))');
+        $this->addSql('INSERT INTO test_add_sql_table (test) values (?)', ['test']);
     }
 
     public function down(Schema $schema)
     {
-        $this->addSql("DROP TABLE test_add_sql_table");
+        $this->addSql('DROP TABLE test_add_sql_table');
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrateNotTouchingTheSchema.php
@@ -13,7 +13,7 @@ class MigrateNotTouchingTheSchema extends AbstractMigration
 
     public function up(Schema $schema)
     {
-        $this->addSql("SELECT 1");
+        $this->addSql('SELECT 1');
     }
 
     public function postUp(Schema $schema)
@@ -26,7 +26,7 @@ class MigrateNotTouchingTheSchema extends AbstractMigration
 
     public function down(Schema $schema)
     {
-        $this->addSql("SELECT 1");
+        $this->addSql('SELECT 1');
     }
 
     public function postDown(Schema $schema)

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationMigrateFurther.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationMigrateFurther.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 class MigrationMigrateFurther extends AbstractMigration
 {
-
     public function down(Schema $schema)
     {
         $schema->dropTable('bar');

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationModifySchemaInPreAndPost.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 class MigrationModifySchemaInPreAndPost extends AbstractMigration
 {
-
     private function addTable(Schema $schema, $tableName)
     {
         $table = $schema->createTable($tableName);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Functional/MigrationSkipMigration.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 class MigrationSkipMigration extends MigrationMigrateUp
 {
-
     public function preUp(Schema $schema)
     {
         $this->skipIf(true);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Version1Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Version1Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version1Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Version2Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Version2Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version2Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/Version3Test.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/Version3Test.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class Version3Test extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunTypes.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDryRunTypes.php
@@ -7,7 +7,10 @@ use Doctrine\DBAL\Schema\Schema;
 
 class VersionDryRunTypes extends AbstractMigration
 {
+    /** @var mixed */
     private $value;
+
+    /** @var string */
     private $type;
 
     public function setParam($value, $type)

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummy.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummy.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Class DummyMigration
- *
- * @author Robbert van den Bogerd <rvdbogerd@ibuildings.nl>
  */
 class VersionDummy extends AbstractMigration
 {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummyDescription.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummyDescription.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Class DummyMigration
- *
- * @author Robbert van den Bogerd <rvdbogerd@ibuildings.nl>
  */
 class VersionDummyDescription extends AbstractMigration
 {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummyException.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionDummyException.php
@@ -7,8 +7,6 @@ use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Class DummyMigration
- *
- * @author Robbert van den Bogerd <rvdbogerd@ibuildings.nl>
  */
 class VersionDummyException extends AbstractMigration
 {

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSql.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSql.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class VersionOutputSql extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSqlWithParam.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Stub/VersionOutputSqlWithParam.php
@@ -2,7 +2,7 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Stub;
 
-use \Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
 
 class VersionOutputSqlWithParam extends AbstractMigration

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/AbstractCommandTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\AbstractCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
-use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -16,6 +15,7 @@ use Symfony\Component\Console\Output\Output;
 
 class AbstractCommandTest extends MigrationTestCase
 {
+    /** @var string */
     private $originalCwd;
 
     /**
@@ -23,7 +23,7 @@ class AbstractCommandTest extends MigrationTestCase
      *
      * @param mixed $input
      * @param mixed $configuration
-     * @param bool $noConnection
+     * @param bool  $noConnection
      * @param mixed $helperSet
      *
      * @return Configuration
@@ -40,20 +40,20 @@ class AbstractCommandTest extends MigrationTestCase
             ['command']
         );
 
-        if ($helperSet != null && $helperSet instanceof HelperSet) {
+        if ($helperSet !== null && $helperSet instanceof HelperSet) {
             $command->setHelperSet($helperSet);
         } else {
             $command->setHelperSet(new HelperSet());
         }
 
-        if ( ! $noConnection) {
+        if (! $noConnection) {
             $command->getHelperSet()->set(
                 new ConnectionHelper($this->getSqliteConnection()),
                 'connection'
             );
         }
 
-        if (null !== $configuration) {
+        if ($configuration !== null) {
             $command->setMigrationConfiguration($configuration);
         }
 
@@ -116,7 +116,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $input->method('getOption')
             ->will($this->returnValueMap([
-                ['db-configuration', __DIR__ . '/_files/db-config.php']
+                ['db-configuration', __DIR__ . '/_files/db-config.php'],
             ]));
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
@@ -137,7 +137,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $input->method('getOption')
             ->will($this->returnValueMap([
-                ['configuration', __DIR__ . '/_files/config.yml']
+                ['configuration', __DIR__ . '/_files/config.yml'],
             ]));
 
         $actualConfiguration = $this->invokeMigrationConfigurationGetter($input);
@@ -190,7 +190,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $input->method('getOption')
             ->will($this->returnValueMap([
-                ['configuration', __DIR__ . '/_files/config.yml']
+                ['configuration', __DIR__ . '/_files/config.yml'],
             ]));
 
         $configuration = $this
@@ -219,7 +219,7 @@ class AbstractCommandTest extends MigrationTestCase
 
         $input->method('getOption')
             ->will($this->returnValueMap([
-                ['configuration', null]
+                ['configuration', null],
             ]));
 
         $configuration = $this->createMock(Configuration::class);
@@ -253,7 +253,7 @@ class AbstractCommandTest extends MigrationTestCase
         self::assertSame($configuration, $actualConfiguration);
     }
 
-    private function invokeAbstractCommandConfirmation($input, $helper, $response = "y", $question = "There is no question?")
+    private function invokeAbstractCommandConfirmation($input, $helper, $response = 'y', $question = 'There is no question?')
     {
         $class  = new \ReflectionClass(AbstractCommand::class);
         $method = $class->getMethod('askConfirmation');
@@ -267,13 +267,9 @@ class AbstractCommandTest extends MigrationTestCase
 
         $input->setStream($this->getInputStream($response . "\n"));
         if ($helper instanceof QuestionHelper) {
-            $helperSet = new HelperSet([
-                'question' => $helper
-            ]);
+            $helperSet = new HelperSet(['question' => $helper]);
         } else {
-            $helperSet = new HelperSet([
-                'dialog' => $helper
-            ]);
+            $helperSet = new HelperSet(['dialog' => $helper]);
         }
 
         $command->setHelperSet($helperSet);
@@ -291,7 +287,7 @@ class AbstractCommandTest extends MigrationTestCase
         $helper = new QuestionHelper();
 
         self::assertTrue($this->invokeAbstractCommandConfirmation($input, $helper));
-        self::assertFalse($this->invokeAbstractCommandConfirmation($input, $helper, "n"));
+        self::assertFalse($this->invokeAbstractCommandConfirmation($input, $helper, 'n'));
     }
 
     protected function setUp()
@@ -301,8 +297,10 @@ class AbstractCommandTest extends MigrationTestCase
 
     protected function tearDown()
     {
-        if (getcwd() !== $this->originalCwd) {
-            chdir($this->originalCwd);
+        if (getcwd() === $this->originalCwd) {
+            return;
         }
+
+        chdir($this->originalCwd);
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/CommandTestCase.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/CommandTestCase.php
@@ -11,24 +11,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 abstract class CommandTestCase extends MigrationTestCase
 {
-    /**
-     * @var AbstractCommand
-     */
+    /** @var AbstractCommand */
     protected $command;
 
-    /**
-     * @var Application
-     */
+    /** @var Application */
     protected $app;
 
-    /**
-     * @var Configuration|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject */
     protected $config;
 
-    /**
-     * @var Connection
-     */
+    /** @var Connection */
     protected $connection;
 
     protected function setUp()
@@ -57,6 +49,11 @@ abstract class CommandTestCase extends MigrationTestCase
         return new CommandTester($this->app->find($this->command->getName()));
     }
 
+    /**
+     * @param mixed[] $args
+     * @param mixed[] $options
+     * @return mixed[]
+     */
     protected function executeCommand(array $args, array $options = [])
     {
         $tester     = $this->createCommandTester();

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DialogSupport.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DialogSupport.php
@@ -2,15 +2,13 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Helper\DialogHelper;
 
 trait DialogSupport
 {
-    /**
-     * @var QuestionHelper|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var QuestionHelper|MockObject */
     protected $questions;
 
     protected function configureDialogs(Application $app)

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -2,20 +2,32 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
-use org\bovigo\vfs\vfsStream;
-use Doctrine\DBAL\Schema\Schema;
-use Doctrine\DBAL\Migrations\Provider\SchemaProviderInterface;
 use Doctrine\DBAL\Migrations\Provider\StubSchemaProvider;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand;
+use Doctrine\DBAL\Schema\Schema;
+use org\bovigo\vfs\vfsStream;
 
 class DiffCommandTest extends CommandTestCase
 {
-    const VERSION                       = '20160705000000';
-    const CUSTOM_RELATIVE_TEMPLATE_NAME = 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl';
-    const CUSTOM_ABSOLUTE_TEMPLATE_NAME = __DIR__ . '/_files/migration.tpl';
+    private const VERSION                       = '20160705000000';
+    private const CUSTOM_RELATIVE_TEMPLATE_NAME = 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl';
+    private const CUSTOM_ABSOLUTE_TEMPLATE_NAME = __DIR__ . '/_files/migration.tpl';
 
+    /** @var string */
     private $root;
+
+    /** @var string */
     private $migrationFile;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->migrationFile = sprintf('Version%s.php', self::VERSION);
+        $this->root          = vfsStream::setup('migrations');
+        $this->config->method('getMigrationsDirectory')
+            ->willReturn(vfsStream::url('migrations'));
+    }
 
     public function testCommandCreatesNewMigrationsFileWithAVersionFromConfiguration() : void
     {
@@ -33,6 +45,9 @@ class DiffCommandTest extends CommandTestCase
         self::assertContains('CREATE TABLE example', $content);
     }
 
+    /**
+     * @return string[][]
+     */
     public static function provideCustomTemplateNames() : array
     {
         return [
@@ -63,16 +78,6 @@ class DiffCommandTest extends CommandTestCase
         self::assertContains('class Version' . self::VERSION, $content);
         self::assertContains('CREATE TABLE example', $content);
         self::assertContains('public function customTemplate()', $content);
-    }
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->migrationFile = sprintf('Version%s.php', self::VERSION);
-        $this->root          = vfsStream::setup('migrations');
-        $this->config->method('getMigrationsDirectory')
-            ->willReturn(vfsStream::url('migrations'));
     }
 
     protected function createCommand()

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -20,7 +20,7 @@ class ExecuteCommandTest extends CommandTestCase
             ->method('writeSqlFile')
             ->with(getcwd(), 'up');
 
-        list(, $statusCode) = $this->executeCommand([
+        [, $statusCode] = $this->executeCommand([
             '--write-sql' => true,
             '--up' => true,
         ]);
@@ -34,7 +34,7 @@ class ExecuteCommandTest extends CommandTestCase
             ->method('writeSqlFile')
             ->with(__DIR__, 'down');
 
-        list(, $statusCode) = $this->executeCommand([
+        [, $statusCode] = $this->executeCommand([
             '--write-sql' => __DIR__,
             '--down' => true,
         ]);
@@ -48,7 +48,7 @@ class ExecuteCommandTest extends CommandTestCase
         $this->version->expects($this->never())
             ->method('execute');
 
-        list($tester, $statusCode) = $this->executeCommand([]);
+        [$tester, $statusCode] = $this->executeCommand([]);
 
         self::assertSame(0, $statusCode);
         self::assertContains('Migration cancelled', $tester->getDisplay());
@@ -61,7 +61,7 @@ class ExecuteCommandTest extends CommandTestCase
             ->method('execute')
             ->with('up', true, true);
 
-        list(, $statusCode) = $this->executeCommand([
+        [, $statusCode] = $this->executeCommand([
             '--dry-run' => true,
             '--query-time' => true,
         ]);
@@ -78,7 +78,7 @@ class ExecuteCommandTest extends CommandTestCase
             ->method('execute')
             ->with('up', true, true);
 
-        list(, $statusCode) = $this->executeCommand([
+        [, $statusCode] = $this->executeCommand([
             '--dry-run' => true,
             '--query-time' => true,
         ], ['interactive' => false]);

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -2,18 +2,16 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Helper\DialogHelper;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Doctrine\DBAL\Migrations\Version;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand;
+use Doctrine\DBAL\Migrations\Version;
 
 class ExecuteCommandTest extends CommandTestCase
 {
     use DialogSupport;
 
-    const VERSION = '20160705000000';
+    private const VERSION = '20160705000000';
 
+    /** @var Version */
     private $version;
 
     public function testWriteSqlCommandOutputsSqlFileToTheCurrentWorkingDirectory()
@@ -105,6 +103,11 @@ class ExecuteCommandTest extends CommandTestCase
         return new ExecuteCommand();
     }
 
+    /**
+     * @param mixed[] $args
+     * @param mixed[] $options
+     * @return mixed[]
+     */
     protected function executeCommand(array $args, array $options = [])
     {
         $args['version'] = self::VERSION;

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -2,16 +2,19 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
-use org\bovigo\vfs\vfsStream;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
+use org\bovigo\vfs\vfsStream;
 
 class GenerateCommandTest extends CommandTestCase
 {
-    const VERSION                       = '20160705000000';
-    const CUSTOM_RELATIVE_TEMPLATE_NAME = 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl';
-    const CUSTOM_ABSOLUTE_TEMPLATE_NAME = __DIR__ . '/_files/migration.tpl';
+    private const VERSION                       = '20160705000000';
+    private const CUSTOM_RELATIVE_TEMPLATE_NAME = 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/_files/migration.tpl';
+    private const CUSTOM_ABSOLUTE_TEMPLATE_NAME = __DIR__ . '/_files/migration.tpl';
 
+    /** @var string */
     private $root;
+
+    /** @var string */
     private $migrationFile;
 
     protected function setUp()
@@ -39,6 +42,9 @@ class GenerateCommandTest extends CommandTestCase
         self::assertContains('class Version' . self::VERSION, $this->root->getChild($this->migrationFile)->getContent());
     }
 
+    /**
+     * @return string[][]
+     */
     public static function provideCustomTemplateNames() : array
     {
         return [

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -34,7 +34,7 @@ class GenerateCommandTest extends CommandTestCase
             ->method('generateVersionNumber')
             ->willReturn(self::VERSION);
 
-        list($tester, $statusCode) = $this->executeCommand([]);
+        [$tester, $statusCode] = $this->executeCommand([]);
 
         self::assertSame(0, $statusCode);
         self::assertContains($this->migrationFile, $tester->getDisplay());

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -25,7 +25,7 @@ class MigrateCommandTest extends CommandTestCase
     {
         $this->willResolveVersionAlias('prev', null);
 
-        list($tester, $statusCode) = $this->executeCommand(['version' => 'prev']);
+        [$tester, $statusCode] = $this->executeCommand(['version' => 'prev']);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Already at first version', $tester->getDisplay());
@@ -35,7 +35,7 @@ class MigrateCommandTest extends CommandTestCase
     {
         $this->willResolveVersionAlias('next', null);
 
-        list($tester, $statusCode) = $this->executeCommand(['version' => 'next']);
+        [$tester, $statusCode] = $this->executeCommand(['version' => 'next']);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Already at latest version', $tester->getDisplay());
@@ -45,7 +45,7 @@ class MigrateCommandTest extends CommandTestCase
     {
         $this->willResolveVersionAlias('nope', null);
 
-        list($tester, $statusCode) = $this->executeCommand(['version' => 'nope']);
+        [$tester, $statusCode] = $this->executeCommand(['version' => 'nope']);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Unknown version: nope', $tester->getDisplay());
@@ -62,7 +62,7 @@ class MigrateCommandTest extends CommandTestCase
             ->willReturn([]);
         $this->willAskConfirmationAndReturn(false);
 
-        list($tester, $statusCode) = $this->executeCommand([]);
+        [$tester, $statusCode] = $this->executeCommand([]);
 
         self::assertSame(1, $statusCode);
         self::assertContains('previously executed migrations in the database that are not registered', $tester->getDisplay());
@@ -76,7 +76,7 @@ class MigrateCommandTest extends CommandTestCase
             ->method('writeSqlFile')
             ->with(getcwd(), self::VERSION);
 
-        list($tester, $statusCode) = $this->executeCommand(['--write-sql' => true]);
+        [$tester, $statusCode] = $this->executeCommand(['--write-sql' => true]);
 
         self::assertSame(0, $statusCode);
     }
@@ -89,7 +89,7 @@ class MigrateCommandTest extends CommandTestCase
             ->method('writeSqlFile')
             ->with(__DIR__, self::VERSION);
 
-        list($tester, $statusCode) = $this->executeCommand(['--write-sql' => __DIR__]);
+        [$tester, $statusCode] = $this->executeCommand(['--write-sql' => __DIR__]);
 
         self::assertSame(0, $statusCode);
     }
@@ -111,7 +111,7 @@ class MigrateCommandTest extends CommandTestCase
         $this->config->expects($this->at(4))
             ->method('getAvailableVersions');
 
-        list($tester, $statusCode) = $this->executeCommand([
+        [$tester, $statusCode] = $this->executeCommand([
             '--dry-run' => true,
             '--query-time' => true,
         ]);
@@ -131,7 +131,7 @@ class MigrateCommandTest extends CommandTestCase
                 return $confirm();
             });
 
-        list($tester, $statusCode) = $this->executeCommand(['--dry-run' => false]);
+        [$tester, $statusCode] = $this->executeCommand(['--dry-run' => false]);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Migration cancelled', $tester->getDisplay());
@@ -150,7 +150,7 @@ class MigrateCommandTest extends CommandTestCase
                 return ['SELECT 1'];
             });
 
-        list($tester, $statusCode) = $this->executeCommand(['--dry-run' => false]);
+        [$tester, $statusCode] = $this->executeCommand(['--dry-run' => false]);
 
         self::assertSame(0, $statusCode);
     }
@@ -167,7 +167,7 @@ class MigrateCommandTest extends CommandTestCase
                 return ['SELECT 1'];
             });
 
-        list($tester, $statusCode) = $this->executeCommand(['--dry-run' => false], ['interactive' => false]);
+        [$tester, $statusCode] = $this->executeCommand(['--dry-run' => false], ['interactive' => false]);
 
         self::assertSame(0, $statusCode);
     }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -2,28 +2,30 @@
 
 namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Command;
 
-use Doctrine\DBAL\Migrations\Migration;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Migration;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand;
-use Symfony\Component\Console\Helper\HelperSet;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Input\ArrayInput;
 
 class MigrateCommandTest extends CommandTestCase
 {
     use DialogSupport;
 
-    const VERSION = '20160705000000';
+    private const VERSION = '20160705000000';
 
+    /** @var Migration */
     private $migration;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->configureDialogs($this->app);
+    }
 
     public function testPreviousVersionErrorsWhenThereIsNoPreviousVersion()
     {
         $this->willResolveVersionAlias('prev', null);
 
-        list($tester, $statusCode) = $this->executeCommand([
-            'version' => 'prev',
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['version' => 'prev']);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Already at first version', $tester->getDisplay());
@@ -33,9 +35,7 @@ class MigrateCommandTest extends CommandTestCase
     {
         $this->willResolveVersionAlias('next', null);
 
-        list($tester, $statusCode) = $this->executeCommand([
-            'version' => 'next',
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['version' => 'next']);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Already at latest version', $tester->getDisplay());
@@ -45,9 +45,7 @@ class MigrateCommandTest extends CommandTestCase
     {
         $this->willResolveVersionAlias('nope', null);
 
-        list($tester, $statusCode) = $this->executeCommand([
-            'version' => 'nope',
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['version' => 'nope']);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Unknown version: nope', $tester->getDisplay());
@@ -78,9 +76,7 @@ class MigrateCommandTest extends CommandTestCase
             ->method('writeSqlFile')
             ->with(getcwd(), self::VERSION);
 
-        list($tester, $statusCode) = $this->executeCommand([
-            '--write-sql' => true,
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['--write-sql' => true]);
 
         self::assertSame(0, $statusCode);
     }
@@ -93,9 +89,7 @@ class MigrateCommandTest extends CommandTestCase
             ->method('writeSqlFile')
             ->with(__DIR__, self::VERSION);
 
-        list($tester, $statusCode) = $this->executeCommand([
-            '--write-sql' => __DIR__,
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['--write-sql' => __DIR__]);
 
         self::assertSame(0, $statusCode);
     }
@@ -137,9 +131,7 @@ class MigrateCommandTest extends CommandTestCase
                 return $confirm();
             });
 
-        list($tester, $statusCode) = $this->executeCommand([
-            '--dry-run' => false
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['--dry-run' => false]);
 
         self::assertSame(1, $statusCode);
         self::assertContains('Migration cancelled', $tester->getDisplay());
@@ -158,9 +150,7 @@ class MigrateCommandTest extends CommandTestCase
                 return ['SELECT 1'];
             });
 
-        list($tester, $statusCode) = $this->executeCommand([
-            '--dry-run' => false
-        ]);
+        list($tester, $statusCode) = $this->executeCommand(['--dry-run' => false]);
 
         self::assertSame(0, $statusCode);
     }
@@ -177,17 +167,9 @@ class MigrateCommandTest extends CommandTestCase
                 return ['SELECT 1'];
             });
 
-        list($tester, $statusCode) = $this->executeCommand([
-            '--dry-run' => false
-        ], ['interactive' => false]);
+        list($tester, $statusCode) = $this->executeCommand(['--dry-run' => false], ['interactive' => false]);
 
         self::assertSame(0, $statusCode);
-    }
-
-    protected function setUp()
-    {
-        parent::setUp();
-        $this->configureDialogs($this->app);
     }
 
     /**

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationStatusTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class MigrationStatusTest extends MigrationTestCase
 {
-
+    /** @var string */
     private $migrationDirectory;
 
     public function __construct()
@@ -50,9 +50,7 @@ class MigrationStatusTest extends MigrationTestCase
             ->getMockBuilder(StatusCommand::class)
             ->setConstructorArgs(['migrations:status'])
             ->setMethods(
-                [
-                    'getMigrationConfiguration',
-                ]
+                ['getMigrationConfiguration']
             )
             ->getMock();
 
@@ -106,9 +104,7 @@ class MigrationStatusTest extends MigrationTestCase
             ->getMockBuilder(StatusCommand::class)
             ->setConstructorArgs(['migrations:status'])
             ->setMethods(
-                [
-                    'getMigrationConfiguration',
-                ]
+                ['getMigrationConfiguration']
             )
             ->getMock();
 
@@ -120,12 +116,12 @@ class MigrationStatusTest extends MigrationTestCase
         $configuration
             ->expects($this->once())
             ->method('getMigratedVersions')
-            ->will($this->returnValue([1234,1235,1237,1238,1239]));
+            ->will($this->returnValue([1234, 1235, 1237, 1238, 1239]));
 
         $configuration
             ->expects($this->once())
             ->method('getAvailableVersions')
-            ->will($this->returnValue([1234,1235,1239,1240]));
+            ->will($this->returnValue([1234, 1235, 1239, 1240]));
 
         $configuration
             ->method('getCurrentVersion')

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
@@ -6,10 +6,12 @@ use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tests\Stub\Version1Test;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class MigrationVersionTest extends MigrationTestCase
 {
+    /** @var Command */
     private $command;
 
     /** @var Configuration */
@@ -51,9 +53,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--range-from' => '1234',
                 '--range-to'   => '1239',
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
 
         self::assertFalse($this->configuration->getVersion('1233')->isMigrated());
@@ -78,9 +78,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--add'        => true,
                 '--range-from' => '1233',
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
     }
 
@@ -99,9 +97,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--add'      => true,
                 '--range-to' => '1233',
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
     }
 
@@ -121,9 +117,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--all'      => true,
                 '--range-to' => '1233',
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
     }
 
@@ -143,9 +137,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--all'      => true,
                 '--range-from' => '1233',
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
     }
 
@@ -165,7 +157,6 @@ class MigrationVersionTest extends MigrationTestCase
         $this->configuration->getVersion('1239')->markMigrated();
         $this->configuration->getVersion('1240')->markMigrated();
 
-
         $commandTester = new CommandTester($this->command);
         $commandTester->execute(
             [
@@ -173,9 +164,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--range-from' => '1234',
                 '--range-to'   => '1239',
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
 
         self::assertTrue($this->configuration->getVersion('1233')->isMigrated());
@@ -202,9 +191,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--add' => true,
                 '--all' => true,
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
 
         self::assertTrue($this->configuration->getVersion('1233')->isMigrated());
@@ -234,9 +221,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--delete' => true,
                 '--all'    => true,
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
 
         self::assertFalse($this->configuration->getVersion('1233')->isMigrated());
@@ -263,9 +248,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--add'   => true,
                 'version' => 1234,
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
 
         self::assertTrue($this->configuration->getVersion('1233')->isMigrated());
@@ -290,9 +273,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--delete' => true,
                 'version'  => 1234,
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
 
         self::assertFalse($this->configuration->getVersion('1233')->isMigrated());
@@ -318,9 +299,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--add'   => true,
                 'version' => 1233,
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
     }
 
@@ -341,9 +320,7 @@ class MigrationVersionTest extends MigrationTestCase
                 '--delete' => true,
                 'version'  => 1233,
             ],
-            [
-                'interactive' => false,
-            ]
+            ['interactive' => false]
         );
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
 use Doctrine\DBAL\Migrations\Version;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,15 +15,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @covers \Doctrine\DBAL\Migrations\Tools\Console\Command\UpToDateCommand
  */
-class UpToDateCommandTest extends \PHPUnit\Framework\TestCase
+class UpToDateCommandTest extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject|OutputInterface */
+    /** @var OutputInterface|MockObject */
     private $commandOutput;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|Configuration */
+    /** @var Configuration|MockObject */
     private $configuration;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|ConfigurationHelper */
+    /** @var ConfigurationHelper|MockObject */
     private $configurationHelper;
 
     /** @var UpToDateCommand */
@@ -42,16 +44,16 @@ class UpToDateCommandTest extends \PHPUnit\Framework\TestCase
         $this->commandOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
         $this->sut = new UpToDateCommand();
-        $this->sut->setHelperSet(new HelperSet(array(
+        $this->sut->setHelperSet(new HelperSet([
             'configuration' => $this->configurationHelper,
-        )));
+        ]));
     }
 
     /**
      * @dataProvider dataIsUpToDate
      * @param Version[] $migrations
-     * @param string[] $migratedVersions
-     * @param int $exitCode
+     * @param string[]  $migratedVersions
+     * @param int       $exitCode
      */
     public function testIsUpToDate($migrations, $migratedVersions, $exitCode)
     {
@@ -70,7 +72,7 @@ class UpToDateCommandTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @return array[]
+     * @return mixed[][]
      */
     public function dataIsUpToDate()
     {
@@ -79,28 +81,20 @@ class UpToDateCommandTest extends \PHPUnit\Framework\TestCase
                 [
                     $this->createVersion('20160614015627'),
                 ],
-                [
-                    '20160614015627',
-                ],
-                0
+                ['20160614015627'],
+                0,
             ],
             'empty-migration-set' => [
-                [
-
-                ],
-                [
-
-                ],
-                0
+                [],
+                [],
+                0,
             ],
             'one-migration-available' => [
                 [
                     $this->createVersion('20150614015627'),
                 ],
-                [
-
-                ],
-                1
+                [],
+                1,
             ],
             'many-migrations-available' => [
                 [
@@ -109,10 +103,8 @@ class UpToDateCommandTest extends \PHPUnit\Framework\TestCase
                     $this->createVersion('20130614015627'),
                     $this->createVersion('20140614015627'),
                 ],
-                [
-                    '20110614015627',
-                ],
-                1
+                ['20110614015627'],
+                1,
             ],
         ];
     }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
@@ -3,15 +3,17 @@ namespace Doctrine\DBAL\Migrations\Tests\Tools\Console;
 
 use Doctrine\DBAL\Migrations\Tools\Console\ConsoleRunner;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 
 /**
  * @covers \Doctrine\DBAL\Migrations\Tools\Console\ConsoleRunner
  */
-class ConsoleRunnerTest extends \PHPUnit\Framework\TestCase
+class ConsoleRunnerTest extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject|EntityManagerHelper */
+    /** @var EntityManagerHelper|MockObject */
     private $entityManagerHelper;
 
     /** @var Application */
@@ -78,9 +80,9 @@ class ConsoleRunnerTest extends \PHPUnit\Framework\TestCase
 
     public function testHasDiffCommand()
     {
-        $this->application->setHelperSet(new HelperSet(array(
+        $this->application->setHelperSet(new HelperSet([
             'em' => $this->entityManagerHelper,
-        )));
+        ]));
 
         ConsoleRunner::addCommands($this->application);
 
@@ -89,9 +91,7 @@ class ConsoleRunnerTest extends \PHPUnit\Framework\TestCase
 
     public function testNotHasDiffCommand()
     {
-        $this->application->setHelperSet(new HelperSet(array(
-
-        )));
+        $this->application->setHelperSet(new HelperSet([]));
 
         ConsoleRunner::addCommands($this->application);
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
@@ -3,50 +3,39 @@ namespace Doctrine\DBAL\Migrations\Tests\Tools\Console\Helper;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Migrations\Configuration\ArrayConfiguration;
+use Doctrine\DBAL\Migrations\Configuration\Configuration as MigrationsConfiguration;
 use Doctrine\DBAL\Migrations\Configuration\JsonConfiguration;
 use Doctrine\DBAL\Migrations\OutputWriter;
 use Doctrine\DBAL\Migrations\Tests\MigrationTestCase;
 use Doctrine\DBAL\Migrations\Tools\Console\Helper\ConfigurationHelper;
 use Doctrine\ORM\Configuration;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigurationHelperTest extends MigrationTestCase
 {
-
-    /**
-     * @var Connection
-     */
+    /** @var Connection */
     private $connection;
 
-    /**
-     * @var Configuration
-     */
+    /** @var Configuration */
     private $configuration;
 
-    /**
-     * @var OutputWriter
-     */
+    /** @var OutputWriter */
     protected $outputWriter;
 
-    /**
-     * @var OutputInterface
-     */
+    /** @var OutputInterface */
     protected $output;
 
-    /**
-     * @var InputInterface|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var InputInterface|MockObject */
     private $input;
 
     protected function setUp()
     {
         $this->configuration = $this->getSqliteConfiguration();
-
-        $this->connection = $this->getSqliteConnection();
-
-        $this->input = $this->getMockBuilder(ArrayInput::class)
+        $this->connection    = $this->getSqliteConnection();
+        $this->input         = $this->getMockBuilder(ArrayInput::class)
             ->setConstructorArgs([[]])
             ->setMethods(['getOption'])
             ->getMock();
@@ -59,7 +48,9 @@ class ConfigurationHelperTest extends MigrationTestCase
         self::assertInstanceOf(ConfigurationHelper::class, $configurationHelper);
     }
 
-    //used in other tests to see if xml or yaml or yml config files are loaded.
+    /**
+     * used in other tests to see if xml or yaml or yml config files are loaded.
+     */
     protected function getConfigurationHelperLoadsASpecificFormat($baseFile, $configFile)
     {
         try {
@@ -77,7 +68,7 @@ class ConfigurationHelperTest extends MigrationTestCase
 
             return trim($this->getOutputStreamContent($this->output));
         } catch (\Exception $e) {
-            unlink($configFile);//i want to be really sure to cleanup this file
+            unlink($configFile); //i want to be really sure to cleanup this file
         }
         return false;
     }
@@ -153,7 +144,6 @@ class ConfigurationHelperTest extends MigrationTestCase
      */
     public function testConfigurationHelperFailsToLoadOtherFormat()
     {
-
         $this->input->method('getOption')
             ->with('configuration')
             ->will($this->returnValue('testconfig.wrong'));
@@ -176,9 +166,9 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        self::assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
+        self::assertInstanceOf(MigrationsConfiguration::class, $migrationConfig);
 
-        self::assertStringMatchesFormat("Loading configuration from the integration code of your framework (setter).", trim($this->getOutputStreamContent($this->output)));
+        self::assertStringMatchesFormat('Loading configuration from the integration code of your framework (setter).', trim($this->getOutputStreamContent($this->output)));
     }
 
     public function testConfigurationHelperWithConfigurationFromSetterAndOverrideFromCommandLine()
@@ -191,8 +181,8 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        self::assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
-        self::assertStringMatchesFormat("Loading configuration from command option: %a", $this->getOutputStreamContent($this->output));
+        self::assertInstanceOf(MigrationsConfiguration::class, $migrationConfig);
+        self::assertStringMatchesFormat('Loading configuration from command option: %a', $this->getOutputStreamContent($this->output));
     }
 
     public function testConfigurationHelperWithoutConfigurationFromSetterAndWithoutOverrideFromCommandLineAndWithoutConfigInPath()
@@ -205,7 +195,7 @@ class ConfigurationHelperTest extends MigrationTestCase
 
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-        self::assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
-        self::assertStringMatchesFormat("", $this->getOutputStreamContent($this->output));
+        self::assertInstanceOf(MigrationsConfiguration::class, $migrationConfig);
+        self::assertStringMatchesFormat('', $this->getOutputStreamContent($this->output));
     }
 }

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/MigrationDirectoryHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/MigrationDirectoryHelperTest.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Migrations\Tools\Console\Helper\MigrationDirectoryHelper;
 
 class MigrationDirectoryHelperTest extends MigrationTestCase
 {
-
     public function testMigrationDirectoryHelper()
     {
         $mirationDirectoryHelper = new MigrationDirectoryHelper($this->getSqliteConfiguration());

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files/config.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files/config.php
@@ -3,5 +3,5 @@ return [
 'name'                 => 'Doctrine Sandbox Migrations',
 'migrations_namespace' => 'DoctrineMigrationsTest',
 'table_name'           => 'doctrine_migration_versions_test',
-'migrations_directory' => 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files'
+'migrations_directory' => 'tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/files',
 ];

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/MigrationsVersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/MigrationsVersionTest.php
@@ -2,10 +2,11 @@
 namespace Doctrine\DBAL\Migrations\Tests\Tools;
 
 use Doctrine\DBAL\Migrations\MigrationsVersion;
+use PHPUnit\Framework\TestCase;
 
-class MigrationsVersionTest extends \PHPUnit\Framework\TestCase
+class MigrationsVersionTest extends TestCase
 {
-
+    /** @var string */
     private $MigrationVersionClass = MigrationsVersion::class;
 
     public function testVersionNumber()

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -36,15 +36,20 @@ use Doctrine\DBAL\Migrations\Tests\Stub\VersionOutputSqlWithParam;
 use Doctrine\DBAL\Migrations\Version;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamFile;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Output\StreamOutput;
 
 require_once __DIR__ . '/realpath.php';
 
 class VersionTest extends MigrationTestCase
 {
+    /** @var Configuration */
     private $config;
 
+    /** @var OutputWriter */
     protected $outputWriter;
 
+    /** @var StreamOutput */
     protected $output;
 
     public function testConstants()
@@ -143,7 +148,7 @@ class VersionTest extends MigrationTestCase
 
     /**
      * Provides states
-     * @return array
+     * @return int[][]
      */
     public function stateProvider()
     {
@@ -174,10 +179,6 @@ class VersionTest extends MigrationTestCase
     }
 
     /**
-     * @param $path
-     * @param $to
-     * @param $getSqlReturn
-     *
      * @dataProvider writeSqlFileProvider
      */
     public function testWriteSqlFile($path, $direction, $getSqlReturn)
@@ -224,6 +225,9 @@ class VersionTest extends MigrationTestCase
         self::assertTrue($version->writeSqlFile($path, $direction));
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function writeSqlFileProvider()
     {
         return [
@@ -316,10 +320,6 @@ class VersionTest extends MigrationTestCase
     }
 
     /**
-     * @param $direction
-     * @param $columnName
-     * @param $tableName
-     *
      * @dataProvider sqlWriteProvider
      */
     public function testWriteSqlWriteToTheCorrectColumnName($direction, $columnName, $tableName)
@@ -343,15 +343,18 @@ class VersionTest extends MigrationTestCase
         foreach ($files as $file) {
             $contents = file_get_contents($file);
             self::assertNotEmpty($contents);
-            if ($direction == Version::DIRECTION_UP) {
-                self::assertContains("INSERT INTO $tableName ($columnName) VALUES ('$versionName');", $contents);
+            if ($direction === Version::DIRECTION_UP) {
+                self::assertContains('INSERT INTO ' . $tableName . ' (' . $columnName . ") VALUES ('" . $versionName . "');", $contents);
             } else {
-                self::assertContains("DELETE FROM $tableName WHERE $columnName = '$versionName'", $contents);
+                self::assertContains('DELETE FROM ' . $tableName . ' WHERE ' . $columnName . " = '" . $versionName . "'", $contents);
             }
             unlink($file);
         }
     }
 
+    /**
+     * @return string[][]
+     */
     public function sqlWriteProvider()
     {
         return [
@@ -368,8 +371,7 @@ class VersionTest extends MigrationTestCase
 
         $connection = $this->getSqliteConnection();
 
-
-        /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject $migration */
+        /** @var Configuration|MockObject $migration */
         $config = $this->getMockBuilder(Configuration::class)
                        ->disableOriginalConstructor()
                        ->setMethods(['getOutputWriter', 'getConnection'])
@@ -380,7 +382,6 @@ class VersionTest extends MigrationTestCase
 
         $config->method('getConnection')
                ->willReturn($connection);
-
 
         /** @var Version|\PHPUnit_Framework_MockObject_MockObject $migration */
         $migration = $this->getMockBuilder(Version::class)
@@ -407,8 +408,8 @@ class VersionTest extends MigrationTestCase
         $ow       = new OutputWriter(function ($msg) use (&$messages) {
             $messages[] = trim($msg);
         });
-        $config  = new Configuration($this->getSqliteConnection(), $ow);
-        $version = new Version(
+        $config   = new Configuration($this->getSqliteConnection(), $ow);
+        $version  = new Version(
             $config,
             '006',
             VersionDryRunWithoutParams::class
@@ -426,8 +427,8 @@ class VersionTest extends MigrationTestCase
         $ow       = new OutputWriter(function ($msg) use (&$messages) {
             $messages[] = trim($msg);
         });
-        $config  = new Configuration($this->getSqliteConnection(), $ow);
-        $version = new Version(
+        $config   = new Configuration($this->getSqliteConnection(), $ow);
+        $version  = new Version(
             $config,
             '006',
             VersionDryRunQuestionMarkParams::class
@@ -446,8 +447,8 @@ class VersionTest extends MigrationTestCase
         $ow       = new OutputWriter(function ($msg) use (&$messages) {
             $messages[] = trim($msg);
         });
-        $config  = new Configuration($this->getSqliteConnection(), $ow);
-        $version = new Version(
+        $config   = new Configuration($this->getSqliteConnection(), $ow);
+        $version  = new Version(
             $config,
             '006',
             VersionDryRunNamedParams::class
@@ -478,8 +479,8 @@ class VersionTest extends MigrationTestCase
         $ow       = new OutputWriter(function ($msg) use (&$messages) {
             $messages[] = trim($msg);
         });
-        $config  = new Configuration($this->getSqliteConnection(), $ow);
-        $version = new Version(
+        $config   = new Configuration($this->getSqliteConnection(), $ow);
+        $version  = new Version(
             $config,
             '006',
             VersionDryRunTypes::class

--- a/tests/Doctrine/DBAL/Migrations/Tests/realpath.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/realpath.php
@@ -7,13 +7,13 @@ namespace Doctrine\DBAL\Migrations;
  *
  * @see https://github.com/mikey179/vfsStream/wiki/Known-Issues
  *
- * @param $path
+ * @param string $path
  *
  * @return string|false
  */
 function realpath($path)
 {
-    if (0 === strpos($path, 'vfs://')) {
+    if (strpos($path, 'vfs://') === 0) {
         return $path;
     }
 


### PR DESCRIPTION
Changes to follow updated Doctrine CS. Most of them are:
- removed annotations
- updated phpDoc: especially array-related (please verify especially those around Migration/Version classes), removed useless types
- `"` -> `'`
- weak to strict comparison (hopefully not breaking anything)
- some other whitespace-related stuff etc.

Should be OK to go to 1.x branch - API stays untouched and strict types are not enabled. That would target 2.0.

~CS is not tagged yet, thus dev-master (WIP).~

Fixes #596.