### PR TITLE
Use $strict param in functions that have it

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -652,7 +652,7 @@ class Configuration
 
         $versions = array_map('strval', array_keys($this->migrations));
         array_unshift($versions, '0');
-        $offset = array_search((string) $version, $versions);
+        $offset = array_search((string) $version, $versions, true);
         if ($offset === false || ! isset($versions[$offset + $delta])) {
             // Unknown version or delta out of bounds.
             return null;
@@ -948,7 +948,7 @@ class Configuration
     private function shouldExecuteMigration($direction, Version $version, $to, $migrated)
     {
         if ($direction === Version::DIRECTION_DOWN) {
-            if ( ! in_array($version->getVersion(), $migrated)) {
+            if ( ! in_array($version->getVersion(), $migrated, true)) {
                 return false;
             }
 
@@ -956,7 +956,7 @@ class Configuration
         }
 
         if ($direction === Version::DIRECTION_UP) {
-            if (in_array($version->getVersion(), $migrated)) {
+            if (in_array($version->getVersion(), $migrated, true)) {
                 return false;
             }
 

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/StatusCommand.php
@@ -82,7 +82,7 @@ EOT
         $migratedVersions = $configuration->getMigratedVersions();
 
         foreach ($migrations as $version) {
-            $isMigrated = in_array($version->getVersion(), $migratedVersions);
+            $isMigrated = in_array($version->getVersion(), $migratedVersions, true);
             $status     = $isMigrated ? '<info>migrated</info>' : '<error>not migrated</error>';
 
             $migrationDescription = $version->getMigration()->getDescription()


### PR DESCRIPTION
Some functions, e.g. `in_array`, have a third param to enable strict comparison :shield: