### PR TITLE
Fix output of the executed SQL query when using parameters

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -401,7 +401,7 @@ class Version
                         $this->outputWriter->write('     <comment>-></comment> ' . $query);
                         $this->connection->executeQuery($query);
                     } else {
-                        $this->outputWriter->write(sprintf('    <comment>-</comment> %s (with parameters)', $query));
+                        $this->outputWriter->write(sprintf('    <comment>-></comment> %s (with parameters)', $query));
                         $this->connection->executeQuery($query, $this->params[$key], $this->types[$key]);
                     }
 


### PR DESCRIPTION
The executed SQL is printed prepended by a `->` in the output when the query does not have parameters, but it only has `-` when adding `with parameters` in the end of the message. This looks like a bug to me (I'm finding it weird each time I read the migration output). So here is the single-char fix.