### PR TITLE
Improve DB2 support

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Version.php
+++ b/lib/Doctrine/DBAL/Migrations/Version.php
@@ -149,7 +149,7 @@ class Version
         $this->configuration->createMigrationTable();
         $this->connection->$action(
             $this->configuration->getMigrationsTableName(),
-            [$this->configuration->getMigrationsColumnName() => $this->version]
+            [$this->configuration->getQuotedMigrationsColumnName() => $this->version]
         );
     }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/MigrationTest.php
@@ -194,7 +194,7 @@ class MigrationTest extends MigrationTestCase
         /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject $migration */
         $config = $this->getMockBuilder(Configuration::class)
                        ->disableOriginalConstructor()
-                       ->setMethods(['getCurrentVersion', 'getOutputWriter', 'getLatestVersion'])
+                       ->setMethods(['getCurrentVersion', 'getOutputWriter', 'getLatestVersion', 'getQuotedMigrationsColumnName'])
                        ->getMock();
 
         $config->method('getCurrentVersion')
@@ -202,6 +202,9 @@ class MigrationTest extends MigrationTestCase
 
         $config->method('getOutputWriter')
                ->willReturn($this->getOutputWriter());
+
+         $config->method('getQuotedMigrationsColumnName')
+               ->willReturn('version');
 
         /** @var Migration|\PHPUnit_Framework_MockObject_MockObject $migration */
         $migration = $this->getMockBuilder(Migration::class)

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -372,7 +372,7 @@ class VersionTest extends MigrationTestCase
         /** @var Configuration|\PHPUnit_Framework_MockObject_MockObject $migration */
         $config = $this->getMockBuilder(Configuration::class)
                        ->disableOriginalConstructor()
-                       ->setMethods(['getOutputWriter', 'getConnection'])
+                       ->setMethods(['getOutputWriter', 'getConnection', 'getQuotedMigrationsColumnName'])
                        ->getMock();
 
         $config->method('getOutputWriter')
@@ -380,6 +380,9 @@ class VersionTest extends MigrationTestCase
 
         $config->method('getConnection')
                ->willReturn($connection);
+
+        $config->method('getQuotedMigrationsColumnName')
+                ->willReturn('version');
 
 
         /** @var Version|\PHPUnit_Framework_MockObject_MockObject $migration */


### PR DESCRIPTION
If the migrations column name is a reserved keyword in the used database (e.g. DB2), consistently quote the migrations column name.