### PR TITLE
Set output writer on injected configuration

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/ConfigurationHelper.php
@@ -54,6 +54,8 @@ class ConfigurationHelper extends Helper implements ConfigurationHelperInterface
         if ($this->configuration) {
             $outputWriter->write("Loading configuration from the integration code of your framework (setter).");
 
+            $this->configuration->setOutputWriter($outputWriter);
+
             return $this->configuration;
         }
 

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -109,12 +109,12 @@ class MigrateCommandTest extends CommandTestCase
             ->with(self::VERSION, true, true);
 
         // dry run is set before getting the migrated versions
-        $this->config->expects($this->at(2))
+        $this->config->expects($this->at(3))
             ->method('setIsDryRun')
             ->with(true);
-        $this->config->expects($this->at(3))
-            ->method('getMigratedVersions');
         $this->config->expects($this->at(4))
+            ->method('getMigratedVersions');
+        $this->config->expects($this->at(5))
             ->method('getAvailableVersions');
 
         list($tester, $statusCode) = $this->executeCommand([

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
@@ -73,13 +73,10 @@ class ConfigurationHelperTest extends MigrationTestCase
             $configurationHelper = new ConfigurationHelper($this->getSqliteConnection());
             $configfileLoaded    = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
-            unlink($configFile);
-
             return trim($this->getOutputStreamContent($this->output));
-        } catch (\Exception $e) {
-            unlink($configFile);//i want to be really sure to cleanup this file
+        } finally {
+            unlink($configFile); //i want to be really sure to cleanup this file
         }
-        return false;
     }
 
     public function testConfigurationHelperLoadsXmlFormat()
@@ -153,7 +150,6 @@ class ConfigurationHelperTest extends MigrationTestCase
      */
     public function testConfigurationHelperFailsToLoadOtherFormat()
     {
-
         $this->input->method('getOption')
             ->with('configuration')
             ->will($this->returnValue('testconfig.wrong'));

--- a/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/Tools/Console/Helper/ConfigurationHelperTest.php
@@ -73,6 +73,8 @@ class ConfigurationHelperTest extends MigrationTestCase
             $configurationHelper = new ConfigurationHelper($this->getSqliteConnection());
             $configfileLoaded    = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
+            self::assertAttributeSame($this->getOutputWriter(), 'outputWriter', $configfileLoaded);
+
             return trim($this->getOutputStreamContent($this->output));
         } finally {
             unlink($configFile); //i want to be really sure to cleanup this file
@@ -129,6 +131,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $migrationConfig     = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
         self::assertInstanceOf(ArrayConfiguration::class, $migrationConfig);
+        self::assertAttributeSame($this->getOutputWriter(), 'outputWriter', $migrationConfig);
         self::assertSame('DoctrineMigrationsTest', $migrationConfig->getMigrationsNamespace());
     }
 
@@ -142,6 +145,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $migrationConfig     = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
         self::assertInstanceOf(JsonConfiguration::class, $migrationConfig);
+        self::assertAttributeSame($this->getOutputWriter(), 'outputWriter', $migrationConfig);
         self::assertSame('DoctrineMigrationsTest', $migrationConfig->getMigrationsNamespace());
     }
 
@@ -173,7 +177,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
         self::assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
-
+        self::assertAttributeSame($this->getOutputWriter(), 'outputWriter', $migrationConfig);
         self::assertStringMatchesFormat("Loading configuration from the integration code of your framework (setter).", trim($this->getOutputStreamContent($this->output)));
     }
 
@@ -188,6 +192,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
         self::assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
+        self::assertAttributeSame($this->getOutputWriter(), 'outputWriter', $migrationConfig);
         self::assertStringMatchesFormat("Loading configuration from command option: %a", $this->getOutputStreamContent($this->output));
     }
 
@@ -202,6 +207,7 @@ class ConfigurationHelperTest extends MigrationTestCase
         $migrationConfig = $configurationHelper->getMigrationConfig($this->input, $this->getOutputWriter());
 
         self::assertInstanceOf(\Doctrine\DBAL\Migrations\Configuration\Configuration::class, $migrationConfig);
+        self::assertAttributeSame($this->getOutputWriter(), 'outputWriter', $migrationConfig);
         self::assertStringMatchesFormat("", $this->getOutputStreamContent($this->output));
     }
 }


### PR DESCRIPTION
When injecting the configuration and connection via dependency injection the output writer was not being set, making the internal objects use an output writer that doesn't write to the STDOUT.