### PR TITLE
Support Symfony 3.4 in Doctrine Migration 2.0 as 3.4 is a LTS release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.1",
         "doctrine/dbal": "^2.6",
         "ocramius/proxy-manager": "^2.0.2",
-        "symfony/console": "^4.0"
+        "symfony/console": "^3.4||^4.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f4b84a2773f4f6394d9a3b70d05ff9c",
+    "content-hash": "f2132d3a673d899aea95d84e0fedb334",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
Fixes #651