### PR TITLE
Refactor monster Configuration class.

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Finder\RecursiveRegexFinder;
+use Doctrine\Migrations\Provider\LazySchemaDiffProvider;
+use Doctrine\Migrations\Provider\SchemaDiffProvider;
+use Doctrine\Migrations\Provider\SchemaDiffProviderInterface;
+
+/**
+ * @internal
+ */
+final class DependencyFactory
+{
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var object[] */
+    private $dependencies = [];
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function getEventDispatcher() : EventDispatcher
+    {
+        return $this->getDependency(EventDispatcher::class, function () {
+            return new EventDispatcher(
+                $this->configuration,
+                $this->getConnection()->getEventManager()
+            );
+        });
+    }
+
+    public function getSchemaDiffProvider() : SchemaDiffProviderInterface
+    {
+        return $this->getDependency(SchemaDiffProviderInterface::class, function () {
+            return LazySchemaDiffProvider::fromDefaultProxyFactoryConfiguration(
+                new SchemaDiffProvider(
+                    $this->getConnection()->getSchemaManager(),
+                    $this->getConnection()->getDatabasePlatform()
+                )
+            );
+        });
+    }
+
+    public function getMigrationFileBuilder() : MigrationFileBuilder
+    {
+        return $this->getDependency(MigrationFileBuilder::class, function () {
+            return new MigrationFileBuilder(
+                $this->configuration->getMigrationsTableName(),
+                $this->configuration->getQuotedMigrationsColumnName()
+            );
+        });
+    }
+
+    public function getParameterFormatter() : ParameterFormatterInterface
+    {
+        return $this->getDependency(ParameterFormatter::class, function () {
+            return new ParameterFormatter($this->getConnection());
+        });
+    }
+
+    public function getMigrationRepository() : MigrationRepository
+    {
+        return $this->getDependency(MigrationRepository::class, function () {
+            return new MigrationRepository(
+                $this->configuration,
+                $this->getConnection(),
+                $this->configuration->getMigrationsFinder(),
+                new VersionFactory($this->configuration, $this->getVersionExecutor())
+            );
+        });
+    }
+
+    public function getMigrationTableCreator() : MigrationTableCreator
+    {
+        return $this->getDependency(MigrationTableCreator::class, function () {
+            return new MigrationTableCreator(
+                $this->configuration,
+                $this->getConnection()->getSchemaManager()
+            );
+        });
+    }
+
+    public function getVersionExecutor() : VersionExecutor
+    {
+        return $this->getDependency(VersionExecutor::class, function () {
+            return new VersionExecutor(
+                $this->configuration,
+                $this->getConnection(),
+                $this->getSchemaDiffProvider(),
+                $this->getOutputWriter(),
+                $this->getParameterFormatter()
+            );
+        });
+    }
+
+    public function getQueryWriter() : FileQueryWriter
+    {
+        return $this->getDependency(FileQueryWriter::class, function () {
+            return new FileQueryWriter(
+                $this->getOutputWriter(),
+                $this->getMigrationFileBuilder()
+            );
+        });
+    }
+
+    public function getOutputWriter() : OutputWriter
+    {
+        return $this->getDependency(OutputWriter::class, function () {
+            return new OutputWriter();
+        });
+    }
+
+    public function getVersionAliasResolver() : VersionAliasResolver
+    {
+        return $this->getDependency(VersionAliasResolver::class, function () {
+            return new VersionAliasResolver(
+                $this->getMigrationRepository()
+            );
+        });
+    }
+
+    public function getMigrationPlanCalculator() : MigrationPlanCalculator
+    {
+        return $this->getDependency(MigrationPlanCalculator::class, function () {
+            return new MigrationPlanCalculator($this->getMigrationRepository());
+        });
+    }
+
+    public function getRecursiveRegexFinder() : RecursiveRegexFinder
+    {
+        return $this->getDependency(RecursiveRegexFinder::class, function () {
+            return new RecursiveRegexFinder();
+        });
+    }
+
+    /**
+     * @return mixed
+     */
+    private function getDependency(string $className, callable $callback)
+    {
+        if (! isset($this->dependencies[$className])) {
+            $this->dependencies[$className] = $callback();
+        }
+
+        return $this->dependencies[$className];
+    }
+
+    private function getConnection() : Connection
+    {
+        return $this->configuration->getConnection();
+    }
+}

--- a/lib/Doctrine/Migrations/MigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/MigrationPlanCalculator.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use function array_filter;
+use function array_reverse;
+use function count;
+use function in_array;
+
+/**
+ * @internal
+ */
+final class MigrationPlanCalculator
+{
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    public function __construct(MigrationRepository $migrationRepository)
+    {
+        $this->migrationRepository = $migrationRepository;
+    }
+
+    /** @return Version[] */
+    public function getMigrationsToExecute(string $direction, string $to) : array
+    {
+        $allVersions = $this->migrationRepository->getMigrations();
+
+        if ($direction === Version::DIRECTION_DOWN && count($allVersions) !== 0) {
+            $allVersions = array_reverse($allVersions);
+        }
+
+        $migrated = $this->migrationRepository->getMigratedVersions();
+
+        return array_filter($allVersions, function (VersionInterface $version) use (
+            $migrated,
+            $direction,
+            $to
+        ) {
+            return $this->shouldExecuteMigration($direction, $version, $to, $migrated);
+        });
+    }
+
+    /** @param string[] $migrated */
+    private function shouldExecuteMigration(
+        string $direction,
+        VersionInterface $version,
+        string $to,
+        array $migrated
+    ) : bool {
+        $to = (int) $to;
+
+        if ($direction === Version::DIRECTION_DOWN) {
+            if (! in_array($version->getVersion(), $migrated, true)) {
+                return false;
+            }
+
+            return (int) $version->getVersion() > $to;
+        }
+
+        if ($direction === Version::DIRECTION_UP) {
+            if (in_array($version->getVersion(), $migrated, true)) {
+                return false;
+            }
+
+            return (int) $version->getVersion() <= $to;
+        }
+
+        return false;
+    }
+}

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Exception\DuplicateMigrationVersion;
+use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Exception\UnknownMigrationVersion;
+use Doctrine\Migrations\Finder\MigrationFinder;
+use const SORT_STRING;
+use function array_keys;
+use function array_map;
+use function array_search;
+use function array_unshift;
+use function class_exists;
+use function count;
+use function end;
+use function get_class;
+use function implode;
+use function ksort;
+use function sprintf;
+use function substr;
+
+/**
+ * @internal
+ */
+class MigrationRepository
+{
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var Connection */
+    private $connection;
+
+    /** @var MigrationFinder */
+    private $migrationFinder;
+
+    /** @var VersionFactory */
+    private $versionFactory;
+
+    /** @var Version[] */
+    private $migrations = [];
+
+    public function __construct(
+        Configuration $configuration,
+        Connection $connection,
+        MigrationFinder $migrationFinder,
+        VersionFactory $versionFactory
+    ) {
+        $this->configuration   = $configuration;
+        $this->connection      = $connection;
+        $this->migrationFinder = $migrationFinder;
+        $this->versionFactory  = $versionFactory;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findMigrations(string $path) : array
+    {
+        return $this->migrationFinder->findMigrations($path, $this->configuration->getMigrationsNamespace());
+    }
+
+    /** @return Version[] */
+    public function registerMigrationsFromDirectory(string $path) : array
+    {
+        return $this->registerMigrations($this->findMigrations($path));
+    }
+
+    /** @throws MigrationException */
+    public function registerMigration(string $version, string $migrationClassName) : Version
+    {
+        $this->ensureMigrationClassExists($migrationClassName);
+
+        if (isset($this->migrations[$version])) {
+            throw DuplicateMigrationVersion::new(
+                $version,
+                get_class($this->migrations[$version])
+            );
+        }
+
+        $version = $this->versionFactory->createVersion($version, $migrationClassName);
+
+        $this->migrations[$version->getVersion()] = $version;
+
+        ksort($this->migrations, SORT_STRING);
+
+        return $version;
+    }
+
+    /**
+     * @param string[] $migrations
+     *
+     * @return Version[]
+     */
+    public function registerMigrations(array $migrations) : array
+    {
+        $versions = [];
+
+        foreach ($migrations as $version => $class) {
+            $versions[] = $this->registerMigration((string) $version, $class);
+        }
+
+        return $versions;
+    }
+
+    public function getCurrentVersion() : string
+    {
+        $this->configuration->createMigrationTable();
+
+        if (! $this->configuration->isMigrationTableCreated() && $this->configuration->isDryRun()) {
+            return '0';
+        }
+
+        $this->configuration->connect();
+
+        $this->loadMigrationsFromDirectory();
+
+        $where = null;
+
+        if (! empty($this->migrations)) {
+            $migratedVersions = [];
+
+            foreach ($this->migrations as $migration) {
+                $migratedVersions[] = sprintf("'%s'", $migration->getVersion());
+            }
+
+            $where = sprintf(
+                ' WHERE %s IN (%s)',
+                $this->configuration->getQuotedMigrationsColumnName(),
+                implode(', ', $migratedVersions)
+            );
+        }
+
+        $sql = sprintf(
+            'SELECT %s FROM %s%s ORDER BY %s DESC',
+            $this->configuration->getQuotedMigrationsColumnName(),
+            $this->configuration->getMigrationsTableName(),
+            $where,
+            $this->configuration->getQuotedMigrationsColumnName()
+        );
+
+        $sql    = $this->connection->getDatabasePlatform()->modifyLimitQuery($sql, 1);
+        $result = $this->connection->fetchColumn($sql);
+
+        return $result !== false ? (string) $result : '0';
+    }
+
+    public function getVersion(string $version) : Version
+    {
+        $this->loadMigrationsFromDirectory();
+
+        if (! isset($this->migrations[$version])) {
+            throw UnknownMigrationVersion::new($version);
+        }
+
+        return $this->migrations[$version];
+    }
+
+    public function hasVersion(string $version) : bool
+    {
+        $this->loadMigrationsFromDirectory();
+
+        return isset($this->migrations[$version]);
+    }
+
+    public function hasVersionMigrated(Version $version) : bool
+    {
+        $this->configuration->connect();
+        $this->configuration->createMigrationTable();
+
+        $sql = sprintf(
+            'SELECT %s FROM %s WHERE %s = ?',
+            $this->configuration->getQuotedMigrationsColumnName(),
+            $this->configuration->getMigrationsTableName(),
+            $this->configuration->getQuotedMigrationsColumnName()
+        );
+
+        $version = $this->connection->fetchColumn($sql, [$version->getVersion()]);
+
+        return $version !== false;
+    }
+
+    /**
+     * @return Version[]
+     */
+    public function getMigrations() : array
+    {
+        $this->loadMigrationsFromDirectory();
+
+        return $this->migrations;
+    }
+
+    /** @return string[] */
+    public function getAvailableVersions() : array
+    {
+        $availableVersions = [];
+
+        $this->loadMigrationsFromDirectory();
+
+        foreach ($this->migrations as $migration) {
+            $availableVersions[] = $migration->getVersion();
+        }
+
+        return $availableVersions;
+    }
+
+    /** @return string[] */
+    public function getMigratedVersions() : array
+    {
+        $this->configuration->createMigrationTable();
+
+        if (! $this->configuration->isMigrationTableCreated() && $this->configuration->isDryRun()) {
+            return [];
+        }
+
+        $this->configuration->connect();
+
+        $sql = sprintf(
+            'SELECT %s FROM %s',
+            $this->configuration->getQuotedMigrationsColumnName(),
+            $this->configuration->getMigrationsTableName()
+        );
+
+        $result = $this->connection->fetchAll($sql);
+
+        return array_map('current', $result);
+    }
+
+    public function getNumberOfAvailableMigrations() : int
+    {
+        $this->loadMigrationsFromDirectory();
+
+        return count($this->migrations);
+    }
+
+    public function getLatestVersion() : string
+    {
+        $this->loadMigrationsFromDirectory();
+
+        $versions = array_keys($this->migrations);
+        $latest   = end($versions);
+
+        return $latest !== false ? (string) $latest : '0';
+    }
+
+    public function getNumberOfExecutedMigrations() : int
+    {
+        $this->configuration->connect();
+        $this->configuration->createMigrationTable();
+
+        $sql = sprintf(
+            'SELECT COUNT(%s) FROM %s',
+            $this->configuration->getQuotedMigrationsColumnName(),
+            $this->configuration->getMigrationsTableName()
+        );
+
+        $result = $this->connection->fetchColumn($sql);
+
+        return $result !== false ? (int) $result : 0;
+    }
+
+    public function getRelativeVersion(string $version, int $delta) : ?string
+    {
+        $this->loadMigrationsFromDirectory();
+
+        $versions = array_map('strval', array_keys($this->migrations));
+
+        array_unshift($versions, '0');
+
+        $offset = array_search($version, $versions, true);
+
+        if ($offset === false || ! isset($versions[$offset + $delta])) {
+            // Unknown version or delta out of bounds.
+            return null;
+        }
+
+        return $versions[$offset + $delta];
+    }
+
+    public function getDeltaVersion(string $delta) : ?string
+    {
+        $symbol = substr($delta, 0, 1);
+        $number = (int) substr($delta, 1);
+
+        if ($number <= 0) {
+            return null;
+        }
+
+        if ($symbol === '+' || $symbol === '-') {
+            return $this->getRelativeVersion($this->getCurrentVersion(), (int) $delta);
+        }
+
+        return null;
+    }
+
+    public function getPrevVersion() : ?string
+    {
+        return $this->getRelativeVersion($this->getCurrentVersion(), -1);
+    }
+
+    public function getNextVersion() : ?string
+    {
+        return $this->getRelativeVersion($this->getCurrentVersion(), 1);
+    }
+
+    private function loadMigrationsFromDirectory() : void
+    {
+        $migrationsDirectory = $this->configuration->getMigrationsDirectory();
+
+        if (count($this->migrations) !== 0 || $migrationsDirectory === null) {
+            return;
+        }
+
+        $this->registerMigrationsFromDirectory($migrationsDirectory);
+    }
+
+    /** @throws MigrationException */
+    private function ensureMigrationClassExists(string $class) : void
+    {
+        if (! class_exists($class)) {
+            throw MigrationClassNotFound::new(
+                $class,
+                $this->configuration->getMigrationsNamespace()
+            );
+        }
+    }
+}

--- a/lib/Doctrine/Migrations/MigrationTableCreator.php
+++ b/lib/Doctrine/Migrations/MigrationTableCreator.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\Configuration\Configuration;
+
+/**
+ * @internal
+ */
+final class MigrationTableCreator
+{
+    private const MIGRATION_COLUMN_TYPE   = 'string';
+    private const MIGRATION_COLUMN_LENGTH = 255;
+
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var AbstractSchemaManager */
+    private $schemaManager;
+
+    /** @var bool|null */
+    private $migrationTableCreated;
+
+    public function __construct(Configuration $configuration, AbstractSchemaManager $schemaManager)
+    {
+        $this->configuration = $configuration;
+        $this->schemaManager = $schemaManager;
+    }
+
+    public function isMigrationTableCreated() : bool
+    {
+        if ($this->migrationTableCreated === null) {
+            $this->configuration->connect();
+
+            $migrationsTableName = $this->configuration->getMigrationsTableName();
+
+            if ($this->schemaManager->tablesExist([$migrationsTableName])) {
+                $this->migrationTableCreated = true;
+            } else {
+                $this->migrationTableCreated = false;
+            }
+        }
+
+        return $this->migrationTableCreated;
+    }
+
+    public function createMigrationTable() : bool
+    {
+        $this->configuration->validate();
+
+        if ($this->configuration->isDryRun()) {
+            return false;
+        }
+
+        if ($this->isMigrationTableCreated()) {
+            return false;
+        }
+
+        $migrationsTableName  = $this->configuration->getMigrationsTableName();
+        $migrationsColumnName = $this->configuration->getMigrationsColumnName();
+
+        $columns = [
+            $migrationsColumnName => $this->getMigrationsColumn(),
+        ];
+
+        $table = new Table($migrationsTableName, $columns);
+        $table->setPrimaryKey([$migrationsColumnName]);
+
+        $this->schemaManager->createTable($table);
+
+        $this->migrationTableCreated = true;
+
+        return true;
+    }
+
+    public function getMigrationsColumn() : Column
+    {
+        return new Column(
+            $this->configuration->getMigrationsColumnName(),
+            Type::getType(self::MIGRATION_COLUMN_TYPE),
+            ['length' => self::MIGRATION_COLUMN_LENGTH]
+        );
+    }
+}

--- a/lib/Doctrine/Migrations/ParameterFormatterInterface.php
+++ b/lib/Doctrine/Migrations/ParameterFormatterInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+/**
+ * @internal
+ */
 interface ParameterFormatterInterface
 {
     /**

--- a/lib/Doctrine/Migrations/Version.php
+++ b/lib/Doctrine/Migrations/Version.php
@@ -11,7 +11,7 @@ use function assert;
 use function count;
 use function in_array;
 
-class Version
+class Version implements VersionInterface
 {
     public const STATE_NONE = 0;
     public const STATE_PRE  = 1;

--- a/lib/Doctrine/Migrations/VersionAliasResolver.php
+++ b/lib/Doctrine/Migrations/VersionAliasResolver.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use function substr;
+
+/**
+ * @internal
+ */
+final class VersionAliasResolver
+{
+    private const ALIAS_FIRST   = 'first';
+    private const ALIAS_CURRENT = 'current';
+    private const ALIAS_PREV    = 'prev';
+    private const ALIAS_NEXT    = 'next';
+    private const ALIAS_LATEST  = 'latest';
+
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    public function __construct(MigrationRepository $migrationRepository)
+    {
+        $this->migrationRepository = $migrationRepository;
+    }
+
+    /**
+     * Returns the version number from an alias.
+     *
+     * Supported aliases are:
+     *
+     * - first: The very first version before any migrations have been run.
+     * - current: The current version.
+     * - prev: The version prior to the current version.
+     * - next: The version following the current version.
+     * - latest: The latest available version.
+     *
+     * If an existing version number is specified, it is returned verbatimly.
+     */
+    public function resolveVersionAlias(string $alias) : ?string
+    {
+        if ($this->migrationRepository->hasVersion($alias)) {
+            return $alias;
+        }
+
+        switch ($alias) {
+            case self::ALIAS_FIRST:
+                return '0';
+
+            case self::ALIAS_CURRENT:
+                return $this->migrationRepository->getCurrentVersion();
+
+            case self::ALIAS_PREV:
+                return $this->migrationRepository->getPrevVersion();
+
+            case self::ALIAS_NEXT:
+                return $this->migrationRepository->getNextVersion();
+
+            case self::ALIAS_LATEST:
+                return $this->migrationRepository->getLatestVersion();
+
+            default:
+                if (substr($alias, 0, 7) === self::ALIAS_CURRENT) {
+                    return $this->migrationRepository->getDeltaVersion(substr($alias, 7));
+                }
+
+                return null;
+        }
+    }
+}

--- a/lib/Doctrine/Migrations/VersionExecutor.php
+++ b/lib/Doctrine/Migrations/VersionExecutor.php
@@ -16,6 +16,9 @@ use function rtrim;
 use function sprintf;
 use function ucfirst;
 
+/**
+ * @internal
+ */
 final class VersionExecutor implements VersionExecutorInterface
 {
     /** @var Configuration */

--- a/lib/Doctrine/Migrations/VersionExecutorInterface.php
+++ b/lib/Doctrine/Migrations/VersionExecutorInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+/**
+ * @internal
+ */
 interface VersionExecutorInterface
 {
     /**

--- a/lib/Doctrine/Migrations/VersionFactory.php
+++ b/lib/Doctrine/Migrations/VersionFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use Doctrine\Migrations\Configuration\Configuration;
+
+/**
+ * @var internal
+ */
+final class VersionFactory
+{
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var VersionExecutorInterface */
+    private $versionExecutor;
+
+    public function __construct(Configuration $configuration, VersionExecutorInterface $versionExecutor)
+    {
+        $this->configuration   = $configuration;
+        $this->versionExecutor = $versionExecutor;
+    }
+
+    public function createVersion(string $version, string $migrationClassName) : Version
+    {
+        return new Version(
+            $this->configuration,
+            $version,
+            $migrationClassName,
+            $this->versionExecutor
+        );
+    }
+}

--- a/lib/Doctrine/Migrations/VersionInterface.php
+++ b/lib/Doctrine/Migrations/VersionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+interface VersionInterface
+{
+    public function getVersion() : string;
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -57,5 +57,6 @@
         <exclude-pattern>lib/Doctrine/Migrations/Finder/MigrationDeepFinderInterface.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/Migrations/VersionExecutorInterface.php</exclude-pattern>
         <exclude-pattern>lib/Doctrine/Migrations/ParameterFormatterInterface.php</exclude-pattern>
+        <exclude-pattern>lib/Doctrine/Migrations/VersionInterface.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -59,7 +59,20 @@ class ConfigurationTest extends MigrationTestCase
     {
         $migrationsDir = __DIR__ . '/ConfigurationTestSource/Migrations';
 
-        $configuration = new Configuration($this->getConnectionMock());
+        $connection = $this->getConnectionMock();
+
+        $platform      = $this->createMock(AbstractPlatform::class);
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+
+        $connection->expects($this->once())
+            ->method('getDatabasePlatform')
+            ->willReturn($platform);
+
+        $connection->expects($this->once())
+            ->method('getSchemaManager')
+            ->willReturn($schemaManager);
+
+        $configuration = new Configuration($connection);
         $configuration->setMigrationsNamespace('Migrations');
         $configuration->setMigrationsDirectory($migrationsDir);
 
@@ -264,11 +277,19 @@ class ConfigurationTest extends MigrationTestCase
     public function testGetQueryWriterCreatesAnInstanceIfItWasNotConfigured() : void
     {
         $dp = $this->getMockForAbstractClass(AbstractPlatform::class, [], '', false, true, true, ['getReservedKeywordsClass']);
+
         $dp->method('getReservedKeywordsClass')
             ->willReturn(EmptyKeywordList::class);
+
         $conn = $this->getConnectionMock();
         $conn->method('getDatabasePlatform')
             ->willReturn($dp);
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+
+        $conn->expects($this->once())
+            ->method('getSchemaManager')
+            ->willReturn($schemaManager);
 
         $configuration = new Configuration($conn);
         $queryWriter   = $configuration->getQueryWriter();

--- a/tests/Doctrine/Migrations/Tests/MigrationPlanCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationPlanCalculatorTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests;
+
+use Doctrine\Migrations\MigrationPlanCalculator;
+use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version;
+use Doctrine\Migrations\VersionInterface;
+use PHPUnit\Framework\TestCase;
+
+final class MigrationPlanCalculatorTest extends TestCase
+{
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    /** @var MigrationPlanCalculator */
+    private $migrationPlanCalculator;
+
+    public function testGetMigrationsToExecuteUp() : void
+    {
+        $version1 = $this->createMock(VersionInterface::class);
+        $version1->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('01');
+
+        $version2 = $this->createMock(VersionInterface::class);
+        $version2->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('02');
+
+        $version3 = $this->createMock(VersionInterface::class);
+        $version3->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('03');
+
+        $version4 = $this->createMock(VersionInterface::class);
+        $version4->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('04');
+
+        $this->migrationRepository->expects($this->once())
+            ->method('getMigrations')
+            ->willReturn([
+                '01' => $version1,
+                '02' => $version2,
+                '03' => $version3,
+                '04' => $version4,
+            ]);
+
+        $this->migrationRepository->expects($this->once())
+            ->method('getMigratedVersions')
+            ->willReturn([
+                '02',
+                '03',
+            ]);
+
+        $expected = [
+            '01' => $version1,
+            '04' => $version4,
+        ];
+
+        $migrationsToExecute = $this->migrationPlanCalculator->getMigrationsToExecute(
+            Version::DIRECTION_UP,
+            '04'
+        );
+
+        $this->assertEquals($expected, $migrationsToExecute);
+    }
+
+    public function testGetMigrationsToExecuteDown() : void
+    {
+        $version1 = $this->createMock(VersionInterface::class);
+        $version1->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('01');
+
+        $version2 = $this->createMock(VersionInterface::class);
+        $version2->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('02');
+
+        $version3 = $this->createMock(VersionInterface::class);
+        $version3->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('03');
+
+        $version4 = $this->createMock(VersionInterface::class);
+        $version4->expects($this->any())
+            ->method('getVersion')
+            ->willReturn('04');
+
+        $this->migrationRepository->expects($this->once())
+            ->method('getMigrations')
+            ->willReturn([
+                '01' => $version1,
+                '02' => $version2,
+                '03' => $version3,
+                '04' => $version4,
+            ]);
+
+        $this->migrationRepository->expects($this->once())
+            ->method('getMigratedVersions')
+            ->willReturn([
+                '02',
+                '03',
+            ]);
+
+        $expected = [
+            '03' => $version1,
+            '02' => $version4,
+        ];
+
+        $migrationsToExecute = $this->migrationPlanCalculator->getMigrationsToExecute(
+            Version::DIRECTION_DOWN,
+            '01'
+        );
+
+        $this->assertEquals($expected, $migrationsToExecute);
+    }
+
+
+    protected function setUp() : void
+    {
+        $this->migrationRepository = $this->createMock(MigrationRepository::class);
+
+        $this->migrationPlanCalculator = new MigrationPlanCalculator($this->migrationRepository);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/MigrationTableCreatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationTableCreatorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests;
+
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\MigrationTableCreator;
+use PHPUnit\Framework\TestCase;
+
+class MigrationTableCreatorTest extends TestCase
+{
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var SchemaManager */
+    private $schemaManager;
+
+    /** @var MigrationTableCreator */
+    private $migrationTableCreator;
+
+    public function testIsMigrationTableCreated() : void
+    {
+        $this->configuration->expects($this->once())
+            ->method('connect');
+
+        $this->configuration->expects($this->once())
+            ->method('getMigrationsTableName')
+            ->willReturn('table_name');
+
+        $this->schemaManager->expects($this->once())
+            ->method('tablesExist')
+            ->with(['table_name'])
+            ->willReturn(true);
+
+        $this->assertTrue($this->migrationTableCreator->isMigrationTableCreated());
+    }
+
+    public function testDreateMigrationTableAlreadyCreated() : void
+    {
+        $this->configuration->expects($this->once())
+            ->method('validate');
+
+        $this->configuration->expects($this->once())
+            ->method('connect');
+
+        $this->configuration->expects($this->once())
+            ->method('getMigrationsTableName')
+            ->willReturn('table_name');
+
+        $this->schemaManager->expects($this->once())
+            ->method('tablesExist')
+            ->with(['table_name'])
+            ->willReturn(true);
+
+        $this->assertFalse($this->migrationTableCreator->createMigrationTable());
+    }
+
+    public function testCreateMigrationTable() : void
+    {
+        $this->configuration->expects($this->once())
+            ->method('validate');
+
+        $this->configuration->expects($this->once())
+            ->method('connect');
+
+        $this->configuration->expects($this->exactly(2))
+            ->method('getMigrationsTableName')
+            ->willReturn('table_name');
+
+        $this->schemaManager->expects($this->once())
+            ->method('tablesExist')
+            ->with(['table_name'])
+            ->willReturn(false);
+
+        $this->configuration->expects($this->once())
+            ->method('isDryRun')
+            ->willReturn(false);
+
+        $this->configuration->expects($this->exactly(2))
+            ->method('getMigrationsTableName')
+            ->willReturn('table_name');
+
+        $this->configuration->expects($this->exactly(2))
+            ->method('getMigrationsColumnName')
+            ->willReturn('column_name');
+
+        $this->schemaManager->expects($this->once())
+            ->method('createTable');
+
+        $this->assertTrue($this->migrationTableCreator->createMigrationTable());
+    }
+
+    protected function setUp() : void
+    {
+        $this->configuration = $this->createMock(Configuration::class);
+        $this->schemaManager = $this->createMock(AbstractSchemaManager::class);
+
+        $this->migrationTableCreator = new MigrationTableCreator(
+            $this->configuration,
+            $this->schemaManager
+        );
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/VersionAliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/VersionAliasResolverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests;
+
+use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\VersionAliasResolver;
+use PHPUnit\Framework\TestCase;
+
+final class VersionAliasResolverTest extends TestCase
+{
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    /** @var VersionAliasResolver */
+    private $versionAliasResolver;
+
+    /**
+     * @dataProvider getAliases
+     */
+    public function testResolveVersionAlias(
+        string $alias,
+        ?string $expectedVersion,
+        ?string $expectedMethod,
+        ?string $expectedArgument
+    ) : void {
+        $this->migrationRepository->expects($this->once())
+            ->method('hasVersion')
+            ->with($alias)
+            ->willReturn(false);
+
+        if ($expectedMethod !== null) {
+            $expectation = $this->migrationRepository->expects($this->once())
+                ->method($expectedMethod)
+                ->willReturn($expectedVersion);
+
+            if ($expectedArgument) {
+                $expectation->with($expectedArgument);
+            }
+        }
+
+        $this->assertEquals($expectedVersion, $this->versionAliasResolver->resolveVersionAlias($alias));
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function getAliases() : array
+    {
+        return [
+            ['first', '0', null, null],
+            ['current', '5', 'getCurrentVersion', null],
+            ['prev', '4', 'getPrevVersion', null],
+            ['next', '6', 'getNextVersion', null],
+            ['latest', '7', 'getLatestVersion', null],
+            ['current-5', '2', 'getDeltaVersion', -5],
+            ['test-5', null, null, null],
+        ];
+    }
+
+    public function testResolveVersionAliasHasVersion() : void
+    {
+        $this->migrationRepository->expects($this->once())
+            ->method('hasVersion')
+            ->with('test')
+            ->willReturn(true);
+
+        $this->assertEquals('test', $this->versionAliasResolver->resolveVersionAlias('test'));
+    }
+
+    protected function setUp() : void
+    {
+        $this->migrationRepository = $this->createMock(MigrationRepository::class);
+
+        $this->versionAliasResolver = new VersionAliasResolver($this->migrationRepository);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/VersionFactoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/VersionFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Version;
+use Doctrine\Migrations\VersionExecutorInterface;
+use Doctrine\Migrations\VersionFactory;
+use PHPUnit\Framework\TestCase;
+
+final class VersionFactoryTest extends TestCase
+{
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var VersionExecutor */
+    private $versionExecutor;
+
+    /** @var VersionFactory */
+    private $versionFactory;
+
+    public function testCreateVersion() : void
+    {
+        $version = $this->versionFactory->createVersion(
+            '001',
+            VersionFactoryTestMigration::class
+        );
+
+        $this->assertInstanceOf(Version::class, $version);
+        $this->assertSame($this->configuration, $version->getConfiguration());
+        $this->assertInstanceOf(VersionFactoryTestMigration::class, $version->getMigration());
+    }
+
+    protected function setUp() : void
+    {
+        $this->configuration   = $this->createMock(Configuration::class);
+        $this->versionExecutor = $this->createMock(VersionExecutorInterface::class);
+
+        $this->versionFactory = new VersionFactory(
+            $this->configuration,
+            $this->versionExecutor
+        );
+    }
+}
+
+class VersionFactoryTestMigration extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+    }
+
+    public function down(Schema $schema) : void
+    {
+    }
+}


### PR DESCRIPTION
Fixes #544

- [x] Extract functionality out of Configuration in to separate classes and proxy to the new classes initially.
- [x] Extract MigrationRepository::getMigrationsToExecute method to a MigrationPlanCalculator class.
- [x] Move resolveVersionAlias to VersionAliasResolver class.
- [x] We need some kind of dependency/object factory. Right now all our objects and dependencies are in Configuration class and it is being used as a sort of service locator.