### PR TITLE
Fix --write-sql option so it can accept a path to write the sql file to.

### DIFF
--- a/docs/en/reference/managing_migrations.rst
+++ b/docs/en/reference/managing_migrations.rst
@@ -227,6 +227,26 @@ executed SQL outputted in a nice format:
     # Version 20100416130422
     CREATE TABLE addresses (id INT NOT NULL, street VARCHAR(255) NOT NULL, PRIMARY KEY(id)) ENGINE = InnoDB;
 
+The ``--write-sql`` option also accepts an optional value for where to write the sql file.
+
+It can be a relative path to a file that will write to the current working directory:
+
+.. code-block:: bash
+
+    $ ./doctrine migrations:migrate --write-sql=migration.sql
+
+Or it can be an absolute path to the file:
+
+.. code-block:: bash
+
+    $ ./doctrine migrations:migrate --write-sql=/path/to/migration.sql
+
+Or it can be a directory and it will generate the filename to write to that directory:
+
+.. code-block:: bash
+
+    $ ./doctrine migrations:migrate --write-sql=/path/to/directory
+
 .. _managing-versions-table:
 
 Managing the Version Table

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use function getcwd;
-use function is_bool;
 
 class ExecuteCommand extends AbstractCommand
 {
@@ -30,8 +29,9 @@ class ExecuteCommand extends AbstractCommand
             ->addOption(
                 'write-sql',
                 null,
-                InputOption::VALUE_NONE,
-                'The path to output the migration SQL file instead of executing it.'
+                InputOption::VALUE_OPTIONAL,
+                'The path to output the migration SQL file instead of executing it. Defaults to current working directory.',
+                false
             )
             ->addOption(
                 'dry-run',
@@ -96,7 +96,7 @@ EOT
         $version = $this->migrationRepository->getVersion($version);
 
         if ($path !== false) {
-            $path = is_bool($path) ? getcwd() : $path;
+            $path = $path === null ? getcwd() : $path;
 
             $version->writeSqlFile($path, $direction);
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -34,7 +34,8 @@ class MigrateCommand extends AbstractCommand
                 'write-sql',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The path to output the migration SQL file instead of executing it. Default to current working directory.'
+                'The path to output the migration SQL file instead of executing it. Defaults to current working directory.',
+                false
             )
             ->addOption(
                 'dry-run',
@@ -120,8 +121,9 @@ EOT
             return 1;
         }
 
-        if ($path !== null) {
-            $path = $path === true ? getcwd() : $path;
+        if ($path !== false) {
+            $path = $path === null ? getcwd() : $path;
+
             $migrator->writeSqlFile($path, $version);
 
             return 0;

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -10,6 +10,7 @@ use Doctrine\Migrations\Version;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use function getcwd;
 
 class ExecuteCommandTest extends TestCase
 {
@@ -19,7 +20,7 @@ class ExecuteCommandTest extends TestCase
     /** @var ExecuteCommand */
     private $executeCommand;
 
-    public function testWriteSql() : void
+    public function testWriteSqlCustomPath() : void
     {
         $versionName = '1';
 
@@ -50,6 +51,41 @@ class ExecuteCommandTest extends TestCase
         $version->expects($this->once())
             ->method('writeSqlFile')
             ->with('/path', 'down');
+
+        self::assertEquals(0, $this->executeCommand->execute($input, $output));
+    }
+
+    public function testWriteSqlCurrentWorkingDirectory() : void
+    {
+        $versionName = '1';
+
+        $input   = $this->createMock(InputInterface::class);
+        $output  = $this->createMock(OutputInterface::class);
+        $version = $this->createMock(Version::class);
+
+        $input->expects($this->once())
+            ->method('getArgument')
+            ->with('version')
+            ->willReturn($versionName);
+
+        $input->expects($this->at(3))
+            ->method('getOption')
+            ->with('write-sql')
+            ->willReturn(null);
+
+        $input->expects($this->at(4))
+            ->method('getOption')
+            ->with('down')
+            ->willReturn(true);
+
+        $this->migrationRepository->expects($this->once())
+            ->method('getVersion')
+            ->with($versionName)
+            ->willReturn($version);
+
+        $version->expects($this->once())
+            ->method('writeSqlFile')
+            ->with(getcwd(), 'down');
 
         self::assertEquals(0, $this->executeCommand->execute($input, $output));
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #606

#### Summary

Allows the `--write-sql` to accept a value to write the sql file to. If you don't specify a value, it writes the file to the current working directory.