### PR TITLE
Rename Doctrine\Migrations\Migration to Doctrine\Migrations\Migrator

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,6 +10,10 @@ deprecated in the `1.7.1` release to prepare for the BC break.
 
 The `Doctrine\DBAL\Migrations\MigrationsVersion` class is no longer available: please refrain from checking the Migrations version at runtime.
 
+## BC Break: Moved `Doctrine\Migrations\Migration` to `Doctrine\Migrations\Migrator`
+
+To make the name more clear and to differentiate from the `AbstractMigration` class, `Migration` was renamed to `Migrator`.
+
 # Upgrade from 1.0-alpha1 to 1.0.0-alpha3
 
 ## AbstractMigration

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -169,10 +169,10 @@ class DependencyFactory
         });
     }
 
-    public function getMigration() : Migration
+    public function getMigrator() : Migrator
     {
-        return $this->getDependency(Migration::class, function () {
-            return new Migration(
+        return $this->getDependency(Migrator::class, function () {
+            return new Migrator(
                 $this->configuration,
                 $this->getMigrationRepository(),
                 $this->getOutputWriter()

--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -12,7 +12,7 @@ use const COUNT_RECURSIVE;
 use function count;
 use function sprintf;
 
-class Migration
+class Migrator
 {
     /** @var Configuration */
     private $configuration;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
-use Doctrine\Migrations\Migration;
+use Doctrine\Migrations\Migrator;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -95,7 +95,7 @@ EOT
 
     public function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $migration = $this->createMigration();
+        $migrator = $this->createMigrator();
 
         $this->outputHeader($output);
 
@@ -122,16 +122,16 @@ EOT
 
         if ($path !== null) {
             $path = $path === true ? getcwd() : $path;
-            $migration->writeSqlFile($path, $version);
+            $migrator->writeSqlFile($path, $version);
 
             return 0;
         }
 
         $cancelled = false;
 
-        $migration->setNoMigrationException($allowNoMigration);
+        $migrator->setNoMigrationException($allowNoMigration);
 
-        $result = $migration->migrate(
+        $result = $migrator->migrate(
             $version,
             $dryRun,
             $timeAllqueries,
@@ -154,9 +154,9 @@ EOT
         return 0;
     }
 
-    protected function createMigration() : Migration
+    protected function createMigrator() : Migrator
     {
-        return $this->dependencyFactory->getMigration();
+        return $this->dependencyFactory->getMigrator();
     }
 
     private function checkExecutedUnavailableMigrations(

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -14,7 +14,7 @@ use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Exception\MigrationException;
-use Doctrine\Migrations\Migration;
+use Doctrine\Migrations\Migrator;
 use Doctrine\Migrations\OutputWriter;
 use Doctrine\Migrations\QueryWriter;
 use Doctrine\Migrations\Tests\MigrationTestCase;
@@ -134,12 +134,12 @@ class ConfigurationTest extends MigrationTestCase
 
         $dependencyFactory = $configuration->getDependencyFactory();
 
-        $migration = new Migration(
+        $migrator = new Migrator(
             $configuration,
             $dependencyFactory->getMigrationRepository(),
             $dependencyFactory->getOutputWriter()
         );
-        $migration->migrate('3Test');
+        $migrator->migrate('3Test');
 
         $result = call_user_func_array([$configuration, $method], $args);
 

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -126,8 +126,8 @@ class FunctionalTest extends MigrationTestCase
         self::assertInstanceOf(MigrationSkipMigration::class, $migrations['2']->getMigration());
         self::assertInstanceOf(MigrationMigrateFurther::class, $migrations['3']->getMigration());
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate('3');
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate('3');
 
         $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
         self::assertTrue($schema->hasTable('foo'));
@@ -145,8 +145,8 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration('2', MigrationSkipMigration::class);
         $this->config->registerMigration('3', MigrationMigrateFurther::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate();
 
         self::assertEquals(3, $this->config->getCurrentVersion());
         $migrations = $this->config->getMigrations();
@@ -161,8 +161,8 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration('2', MigrationSkipMigration::class);
         $this->config->registerMigration('3', MigrationMigrateFurther::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate('3', true);
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate('3', true);
 
         $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
         self::assertFalse($schema->hasTable('foo'));
@@ -181,10 +181,11 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration('2', MigrationSkipMigration::class);
         $this->config->registerMigration('3', MigrationMigrateFurther::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate('3');
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate('3');
+
         self::assertEquals(3, $this->config->getCurrentVersion());
-        $migration->migrate('0');
+        $migrator->migrate('0');
 
         $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
         self::assertFalse($schema->hasTable('foo'));
@@ -201,8 +202,8 @@ class FunctionalTest extends MigrationTestCase
     {
         $this->config->registerMigration('1', MigrateAddSqlTest::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate('1');
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate('1');
 
         $migrations = $this->config->getMigrations();
         self::assertTrue($migrations['1']->isMigrated());
@@ -213,7 +214,7 @@ class FunctionalTest extends MigrationTestCase
         self::assertNotEmpty($check);
         self::assertEquals('test', $check[0]['test']);
 
-        $migration->migrate('0');
+        $migrator->migrate('0');
         self::assertFalse($migrations['1']->isMigrated());
         $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
         self::assertFalse($schema->hasTable('test_add_sql_table'));
@@ -226,8 +227,8 @@ class FunctionalTest extends MigrationTestCase
 
         $this->config->getConnection()->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (test INT)', $tableName));
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate('1');
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate('1');
 
         $migrations = $this->config->getMigrations();
         self::assertTrue($migrations['1']->isMigrated());
@@ -239,7 +240,7 @@ class FunctionalTest extends MigrationTestCase
         self::assertNotEmpty($check);
         self::assertEquals(3, $check);
 
-        $migration->migrate('0');
+        $migrator->migrate('0');
         self::assertFalse($migrations['1']->isMigrated());
 
         $check = $this->config->getConnection()->fetchColumn(
@@ -257,8 +258,8 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration('1', MigrateAddSqlTest::class);
         $this->config->registerMigration('10', MigrationMigrateFurther::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate();
 
         $config = new Configuration($this->connection);
         $config->setMigrationsNamespace('Doctrine\Migrations\Tests\Functional');
@@ -268,8 +269,8 @@ class FunctionalTest extends MigrationTestCase
         $config->setMigrationsTableName('test_migrations_table');
         $config->setMigrationsColumnName('current_version');
 
-        $migration = $this->createTestMigration($config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($config);
+        $migrator->migrate();
 
         $migrations = $config->getMigrations();
         self::assertTrue($migrations['1']->isMigrated());
@@ -283,8 +284,8 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration('1', MigrateAddSqlTest::class);
         $this->config->registerMigration('3', MigrationMigrateFurther::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate();
 
         $migrations = $this->config->getMigrations();
         self::assertTrue($migrations['1']->isMigrated());
@@ -305,8 +306,8 @@ class FunctionalTest extends MigrationTestCase
         self::assertArrayHasKey(2, $migrations);
         self::assertEquals(2, $migrations['2']->getVersion());
 
-        $migration = $this->createTestMigration($config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($config);
+        $migrator->migrate();
 
         $migrations = $config->getMigrations();
         self::assertTrue($migrations['1']->isMigrated());
@@ -321,10 +322,10 @@ class FunctionalTest extends MigrationTestCase
         $this->config->registerMigration('1', MigrateAddSqlTest::class);
         $this->config->registerMigration('2', MigrationMigrateFurther::class);
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate();
 
-        $sql = $migration->migrate();
+        $sql = $migrator->migrate();
 
         self::assertEquals([], $sql);
     }
@@ -339,9 +340,9 @@ class FunctionalTest extends MigrationTestCase
     public function testMigrateExecutesOlderVersionsThatHaveNetYetBeenMigrated(array $migrations) : void
     {
         foreach ($migrations as $key => $class) {
-            $migration = $this->createTestMigration($this->config);
+            $migrator = $this->createTestMigrator($this->config);
             $this->config->registerMigration((string) $key, $class);
-            $sql = $migration->migrate();
+            $sql = $migrator->migrate();
             self::assertCount(1, $sql, 'should have executed one migration');
         }
     }
@@ -436,8 +437,8 @@ class FunctionalTest extends MigrationTestCase
             $listener = new EventVerificationListener()
         );
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate();
 
         self::assertCount(4, $listener->events);
 
@@ -459,8 +460,8 @@ class FunctionalTest extends MigrationTestCase
             $listener = new EventVerificationListener()
         );
 
-        $migration = $this->createTestMigration($this->config);
-        $migration->migrate();
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate();
 
         self::assertCount(4, $listener->events);
 
@@ -484,12 +485,12 @@ class FunctionalTest extends MigrationTestCase
         $listener            = new AutoCommitListener();
         list($conn, $config) = self::fileConnectionAndConfig();
         $config->registerMigration('1', MigrateWithDataModification::class);
-        $migration = $this->createTestMigration($config);
+        $migrator = $this->createTestMigrator($config);
         $conn->getEventManager()->addEventSubscriber($listener);
         $conn->exec('CREATE TABLE test_data_migration (test INTEGER)');
         $conn->commit();
 
-        $migration->migrate();
+        $migrator->migrate();
 
         self::assertCount(3, $conn->fetchAll('SELECT * FROM test_data_migration'), 'migration did not execute');
         $conn->close();

--- a/tests/Doctrine/Migrations/Tests/MigrationTestCase.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationTestCase.php
@@ -7,7 +7,7 @@ namespace Doctrine\Migrations\Tests;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\Migrations\Configuration\Configuration;
-use Doctrine\Migrations\Migration;
+use Doctrine\Migrations\Migrator;
 use Doctrine\Migrations\OutputWriter;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -106,13 +106,13 @@ abstract class MigrationTestCase extends TestCase
         return [];
     }
 
-    protected function createTestMigration(Configuration $config) : Migration
+    protected function createTestMigrator(Configuration $config) : Migrator
     {
         $dependencyFactory   = $config->getDependencyFactory();
         $migrationRepository = $dependencyFactory->getMigrationRepository();
         $outputWriter        = $dependencyFactory->getOutputWriter();
 
-        return new Migration($config, $migrationRepository, $outputWriter);
+        return new Migrator($config, $migrationRepository, $outputWriter);
     }
 
     /**

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -6,8 +6,8 @@ namespace Doctrine\Migrations\Tests\Tools\Console\Command;
 
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
-use Doctrine\Migrations\Migration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Migrator;
 use Doctrine\Migrations\Tools\Console\Command\MigrateCommand;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -186,10 +186,10 @@ class MigrateCommandTest extends TestCase
         $input  = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
 
-        $migration = $this->createMock(Migration::class);
+        $migration = $this->createMock(Migrator::class);
 
         $this->dependencyFactory->expects($this->once())
-            ->method('getMigration')
+            ->method('getMigrator')
             ->willReturn($migration);
 
         $migration->expects($this->once())
@@ -231,10 +231,10 @@ class MigrateCommandTest extends TestCase
         $input  = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
 
-        $migration = $this->createMock(Migration::class);
+        $migration = $this->createMock(Migrator::class);
 
         $this->dependencyFactory->expects($this->once())
-            ->method('getMigration')
+            ->method('getMigrator')
             ->willReturn($migration);
 
         $input->expects($this->once())


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | change
| BC Break     | yes

#### Summary

Rename the `Doctrine\Migrations\Migration` class to `Doctrine\Migrations\Migrator` to. This name makes more sense for what it is doing and to differentiate between it and `Doctrine\Migrations\AbstractMigration`
