### PR TITLE
Show more help text after generating a migration.

### DIFF
--- a/lib/Doctrine/Migrations/MigrationDiffGenerator.php
+++ b/lib/Doctrine/Migrations/MigrationDiffGenerator.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Configuration as DBALConfiguration;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Provider\SchemaProviderInterface;
 use RuntimeException;
 use function preg_match;
@@ -17,9 +16,6 @@ use function substr;
 
 class MigrationDiffGenerator
 {
-    /** @var Configuration */
-    private $configuration;
-
     /** @var DBALConfiguration */
     private $dbalConfiguration;
 
@@ -39,7 +35,6 @@ class MigrationDiffGenerator
     private $migrationSqlGenerator;
 
     public function __construct(
-        Configuration $configuration,
         DBALConfiguration $dbalConfiguration,
         AbstractSchemaManager $schemaManager,
         SchemaProviderInterface $schemaProvider,
@@ -47,7 +42,6 @@ class MigrationDiffGenerator
         MigrationGenerator $migrationGenerator,
         MigrationSqlGenerator $migrationSqlGenerator
     ) {
-        $this->configuration         = $configuration;
         $this->dbalConfiguration     = $dbalConfiguration;
         $this->schemaManager         = $schemaManager;
         $this->schemaProvider        = $schemaProvider;
@@ -57,6 +51,7 @@ class MigrationDiffGenerator
     }
 
     public function generate(
+        string $versionNumber,
         ?string $filterExpression,
         bool $formatted = false,
         int $lineLength = 120
@@ -86,7 +81,7 @@ class MigrationDiffGenerator
         }
 
         return $this->migrationGenerator->generateMigration(
-            $this->configuration->generateVersionNumber(),
+            $versionNumber,
             $up,
             $down
         );

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -89,7 +89,10 @@ EOT
             }
         }
 
+        $versionNumber = $this->configuration->generateVersionNumber();
+
         $path = $this->createMigrationDiffGenerator()->generate(
+            $versionNumber,
             $filterExpression,
             $formatted,
             $lineLength
@@ -101,13 +104,24 @@ EOT
             $this->procOpen($editorCommand, $path);
         }
 
-        $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
+        $output->writeln([
+            sprintf('Generated new migration class to "<info>%s</info>"', $path),
+            '',
+            sprintf(
+                'To run just this migration for testing purposes, you can use <info>migrations:execute --up %s</info>',
+                $versionNumber
+            ),
+            '',
+            sprintf(
+                'To revert the migration you can use <info>migrations:execute --down %s</info>',
+                $versionNumber
+            ),
+        ]);
     }
 
     protected function createMigrationDiffGenerator() : MigrationDiffGenerator
     {
         return new MigrationDiffGenerator(
-            $this->configuration,
             $this->connection->getConfiguration(),
             $this->connection->getSchemaManager(),
             $this->getSchemaProvider(),

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -52,7 +52,19 @@ EOT
             $this->procOpen($editorCommand, $path);
         }
 
-        $output->writeln(sprintf('Generated new migration class to "<info>%s</info>"', $path));
+        $output->writeln([
+            sprintf('Generated new migration class to "<info>%s</info>"', $path),
+            '',
+            sprintf(
+                'To run just this migration for testing purposes, you can use <info>migrations:execute --up %s</info>',
+                $versionNumber
+            ),
+            '',
+            sprintf(
+                'To revert the migration you can use <info>migrations:execute --down %s</info>',
+                $versionNumber
+            ),
+        ]);
     }
 
     protected function procOpen(string $editorCommand, string $path) : void

--- a/tests/Doctrine/Migrations/Tests/MigrationDiffGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationDiffGeneratorTest.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\MigrationDiffGenerator;
 use Doctrine\Migrations\MigrationGenerator;
 use Doctrine\Migrations\MigrationSqlGenerator;
@@ -18,9 +17,6 @@ use PHPUnit\Framework\TestCase;
 
 class MigrationDiffGeneratorTest extends TestCase
 {
-    /** @var Configuration */
-    private $configuration;
-
     /** @var DBALConfiguration */
     private $dbalConfiguration;
 
@@ -110,21 +106,16 @@ class MigrationDiffGeneratorTest extends TestCase
             ->with(['UPDATE table SET value = 1'], true, 80)
             ->willReturn('test2');
 
-        $this->configuration->expects($this->once())
-            ->method('generateVersionNumber')
-            ->willReturn('1234');
-
         $this->migrationGenerator->expects($this->once())
             ->method('generateMigration')
             ->with('1234', 'test1', 'test2')
             ->willReturn('path');
 
-        self::assertEquals('path', $this->migrationDiffGenerator->generate('/table_name1/', true, 80));
+        self::assertEquals('path', $this->migrationDiffGenerator->generate('1234', '/table_name1/', true, 80));
     }
 
     protected function setUp() : void
     {
-        $this->configuration          = $this->createMock(Configuration::class);
         $this->dbalConfiguration      = $this->createMock(DBALConfiguration::class);
         $this->schemaManager          = $this->createMock(AbstractSchemaManager::class);
         $this->schemaProvider         = $this->createMock(SchemaProviderInterface::class);
@@ -134,7 +125,6 @@ class MigrationDiffGeneratorTest extends TestCase
         $this->migrationDiffGenerator = $this->createMock(MigrationDiffGenerator::class);
 
         $this->migrationDiffGenerator = new MigrationDiffGenerator(
-            $this->configuration,
             $this->dbalConfiguration,
             $this->schemaManager,
             $this->schemaProvider,

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests\Tools\Console\Command;
 
+use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\MigrationDiffGenerator;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use PHPUnit\Framework\TestCase;
@@ -15,6 +16,9 @@ final class DiffCommandTest extends TestCase
     /** @var MigrationDiffGenerator */
     private $migrationDiffGenerator;
 
+    /** @var Configuration */
+    private $configuration;
+
     /** @var DiffCommand */
     private $diffCommand;
 
@@ -22,6 +26,10 @@ final class DiffCommandTest extends TestCase
     {
         $input  = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
+
+        $this->configuration->expects($this->once())
+            ->method('generateVersionNumber')
+            ->willReturn('1234');
 
         $input->expects($this->at(0))
             ->method('getOption')
@@ -43,9 +51,13 @@ final class DiffCommandTest extends TestCase
             ->with('editor-cmd')
             ->willReturn('mate');
 
+        $this->configuration->expects($this->once())
+            ->method('generateVersionNumber')
+            ->willReturn('1234');
+
         $this->migrationDiffGenerator->expects($this->once())
             ->method('generate')
-            ->with('filter expression', true, 80)
+            ->with('1234', 'filter expression', true, 80)
             ->willReturn('/path/to/migration.php');
 
         $this->diffCommand->expects($this->once())
@@ -54,7 +66,13 @@ final class DiffCommandTest extends TestCase
 
         $output->expects($this->once())
             ->method('writeln')
-            ->with('Generated new migration class to "<info>/path/to/migration.php</info>"');
+            ->with([
+                'Generated new migration class to "<info>/path/to/migration.php</info>"',
+                '',
+                'To run just this migration for testing purposes, you can use <info>migrations:execute --up 1234</info>',
+                '',
+                'To revert the migration you can use <info>migrations:execute --down 1234</info>',
+            ]);
 
         $this->diffCommand->execute($input, $output);
     }
@@ -62,10 +80,13 @@ final class DiffCommandTest extends TestCase
     protected function setUp() : void
     {
         $this->migrationDiffGenerator = $this->createMock(MigrationDiffGenerator::class);
+        $this->configuration          = $this->createMock(Configuration::class);
 
         $this->diffCommand = $this->getMockBuilder(DiffCommand::class)
             ->setMethods(['createMigrationDiffGenerator', 'procOpen'])
             ->getMock();
+
+        $this->diffCommand->setMigrationConfiguration($this->configuration);
 
         $this->diffCommand->expects($this->once())
             ->method('createMigrationDiffGenerator')

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -51,7 +51,13 @@ final class GenerateCommandTest extends TestCase
 
         $output->expects($this->once())
             ->method('writeln')
-            ->with('Generated new migration class to "<info>/path/to/migration.php</info>"');
+            ->with([
+                'Generated new migration class to "<info>/path/to/migration.php</info>"',
+                '',
+                'To run just this migration for testing purposes, you can use <info>migrations:execute --up 1234</info>',
+                '',
+                'To revert the migration you can use <info>migrations:execute --down 1234</info>',
+            ]);
 
         $this->generateCommand->execute($input, $output);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #173

#### Summary

Improve the developer experience by showing more help text after generating a new migration.

cc @weaverryan 

#### Output

```
$ ./migrations migrations:generate
Generated new migration class to "/data/doctrine/migration-test/lib/Doctrine/Test/Migrations/Version20180512034732.php"

To run just this migration for testing purposes, you can use migrations:execute --up 20180512034732

To revert the migration you can use migrations:execute --down 20180512034732
```