### PR TITLE
Use DBAL connection defaultTableOptions when creating migrations table

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -98,6 +98,7 @@ class DependencyFactory
     {
         return $this->getDependency(MigrationTable::class, function () : MigrationTable {
             return new MigrationTable(
+                $this->getConnection()->getSchemaManager(),
                 $this->configuration->getMigrationsTableName(),
                 $this->configuration->getMigrationsColumnName(),
                 $this->configuration->getMigrationsColumnLength(),

--- a/lib/Doctrine/Migrations/MigrationTableUpdater.php
+++ b/lib/Doctrine/Migrations/MigrationTableUpdater.php
@@ -75,12 +75,10 @@ class MigrationTableUpdater
     {
         $tableName   = $this->migrationTable->getName();
         $columnNames = $this->migrationTable->getColumnNames();
-        $columnName  = $this->migrationTable->getColumnName();
 
         $currentTable = $this->schemaManager->listTableDetails($tableName);
 
-        $table = new Table($tableName, $currentTable->getColumns());
-        $table->setPrimaryKey([$columnName]);
+        $table = $this->migrationTable->createDBALTable($currentTable->getColumns());
 
         // remove columns from the table definition that we don't care about
         // so we don't try to drop those columns

--- a/tests/Doctrine/Migrations/Tests/MigrationTableUpdaterTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationTableUpdaterTest.php
@@ -46,10 +46,6 @@ class MigrationTableUpdaterTest extends TestCase
                 'executed_at',
             ]);
 
-        $this->migrationTable->expects($this->once())
-            ->method('getColumnName')
-            ->willReturn('version');
-
         $table = $this->createMock(Table::class);
 
         $this->schemaManager->expects($this->once())
@@ -67,7 +63,15 @@ class MigrationTableUpdaterTest extends TestCase
             Type::getType('datetime_immutable')
         );
 
-        $table->expects($this->once())
+        $this->migrationTable->expects($this->once())
+            ->method('createDBALTable')
+            ->with([
+                $versionColumn,
+                $executedAt,
+            ])
+            ->willReturn($table);
+
+        $table->expects($this->any())
             ->method('getColumns')
             ->willReturn([
                 $versionColumn,
@@ -119,10 +123,6 @@ class MigrationTableUpdaterTest extends TestCase
                 'executed_at',
             ]);
 
-        $this->migrationTable->expects($this->once())
-            ->method('getColumnName')
-            ->willReturn('version');
-
         $table = $this->createMock(Table::class);
 
         $this->schemaManager->expects($this->once())
@@ -140,7 +140,15 @@ class MigrationTableUpdaterTest extends TestCase
             Type::getType('datetime_immutable')
         );
 
-        $table->expects($this->once())
+        $this->migrationTable->expects($this->once())
+            ->method('createDBALTable')
+            ->with([
+                $versionColumn,
+                $executedAt,
+            ])
+            ->willReturn($table);
+
+        $table->expects($this->any())
             ->method('getColumns')
             ->willReturn([
                 $versionColumn,


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #555

#### Summary

When creating the migrations table, use the `defaultTableOptions` configured on the DBAL connection.
