### PR TITLE
Fix issue with not being able to configure column_length

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/AbstractFileConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/AbstractFileConfiguration.php
@@ -23,6 +23,7 @@ abstract class AbstractFileConfiguration extends Configuration
         'migrations_namespace',
         'table_name',
         'column_name',
+        'column_length',
         'executed_at_column_name',
         'organize_migrations',
         'name',
@@ -86,6 +87,10 @@ abstract class AbstractFileConfiguration extends Configuration
 
         if (isset($config['column_name'])) {
             $this->setMigrationsColumnName($config['column_name']);
+        }
+
+        if (isset($config['column_length'])) {
+            $this->setMigrationsColumnLength($config['column_length']);
         }
 
         if (isset($config['executed_at_column_name'])) {

--- a/lib/Doctrine/Migrations/Configuration/XML/configuration.xsd
+++ b/lib/Doctrine/Migrations/Configuration/XML/configuration.xsd
@@ -12,6 +12,7 @@
                     <xs:complexType>
                         <xs:attribute type="xs:string" name="name"/>
                         <xs:attribute type="xs:string" name="column"/>
+                        <xs:attribute type="xs:string" name="column_length"/>
                         <xs:attribute type="xs:string" name="executed_at_column"/>
                     </xs:complexType>
                 </xs:element>

--- a/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
@@ -45,6 +45,10 @@ class XmlConfiguration extends AbstractFileConfiguration
             $config['column_name'] = (string) $xml->table['column'];
         }
 
+        if (isset($xml->table['column_length'])) {
+            $config['column_length'] = (int) $xml->table['column_length'];
+        }
+
         if (isset($xml->table['executed_at_column'])) {
             $config['executed_at_column_name'] = (string) $xml->table['executed_at_column'];
         }

--- a/tests/Doctrine/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -53,6 +53,12 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
         self::assertEquals('doctrine_migration_column_test', $config->getMigrationsColumnName());
     }
 
+    public function testMigrationsColumnLength() : void
+    {
+        $config = $this->loadConfiguration();
+        self::assertEquals(200, $config->getMigrationsColumnLength());
+    }
+
     public function testMigrationsExecutedAtColumnName() : void
     {
         $config = $this->loadConfiguration();

--- a/tests/Doctrine/Migrations/Tests/Configuration/AbstractFileConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/AbstractFileConfigurationTest.php
@@ -41,6 +41,7 @@ class AbstractFileConfigurationTest extends TestCase
             'setMigrationsNamespace',
             'setMigrationsTableName',
             'setMigrationsColumnName',
+            'setMigrationsColumnLength',
             'setMigrationsExecutedAtColumnName',
             'setMigrationsAreOrganizedByYearAndMonth',
             'setName',
@@ -61,6 +62,10 @@ class AbstractFileConfigurationTest extends TestCase
         $fileConfiguration->expects($this->once())
             ->method('setMigrationsColumnName')
             ->with('version_number');
+
+        $fileConfiguration->expects($this->once())
+            ->method('setMigrationsColumnLength')
+            ->with(200);
 
         $fileConfiguration->expects($this->once())
             ->method('setMigrationsExecutedAtColumnName')
@@ -90,17 +95,18 @@ class AbstractFileConfigurationTest extends TestCase
             ->with('custom_template');
 
         $fileConfiguration->setTestConfiguration([
-            'migrations_namespace' => 'Doctrine',
-            'table_name' => 'migration_version',
-            'column_name' => 'version_number',
-            'executed_at_column_name' => 'executed_at',
-            'organize_migrations' => 'year_and_month',
-            'name' => 'Migrations Test',
-            'migrations_directory' => 'migrations_directory',
-            'migrations' => [
+            'migrations_namespace'      => 'Doctrine',
+            'table_name'                => 'migration_version',
+            'column_name'               => 'version_number',
+            'column_length'             => 200,
+            'executed_at_column_name'   => 'executed_at',
+            'organize_migrations'       => 'year_and_month',
+            'name'                      => 'Migrations Test',
+            'migrations_directory'      => 'migrations_directory',
+            'migrations'                => [
                 [
                     'version' => '001',
-                    'class' => 'Test',
+                    'class'   => 'Test',
                 ],
             ],
             'custom_template' => 'custom_template',

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config.json
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config.json
@@ -3,6 +3,7 @@
   "migrations_namespace"      : "DoctrineMigrationsTest",
   "table_name"                : "doctrine_migration_versions_test",
   "column_name"               : "doctrine_migration_column_test",
+  "column_length"             : 200,
   "executed_at_column_name"   : "doctrine_migration_executed_at_column_test",
   "migrations_directory"      : ".",
   "migrations"                : []

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config.php
@@ -3,11 +3,12 @@
 declare(strict_types=1);
 
 return [
-'name'                      => 'Doctrine Sandbox Migrations',
-'migrations_namespace'      => 'DoctrineMigrationsTest',
-'table_name'                => 'doctrine_migration_versions_test',
-'column_name'               => 'doctrine_migration_column_test',
-'executed_at_column_name'   => 'doctrine_migration_executed_at_column_test',
-'migrations_directory'      => '.',
-'migrations'                => [],
+    'name'                      => 'Doctrine Sandbox Migrations',
+    'migrations_namespace'      => 'DoctrineMigrationsTest',
+    'table_name'                => 'doctrine_migration_versions_test',
+    'column_name'               => 'doctrine_migration_column_test',
+    'column_length'             => 200,
+    'executed_at_column_name'   => 'doctrine_migration_executed_at_column_test',
+    'migrations_directory'      => '.',
+    'migrations'                => [],
 ];

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config.xml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config.xml
@@ -6,7 +6,7 @@
 
     <name>Doctrine Sandbox Migrations</name>
     <migrations-namespace>DoctrineMigrationsTest</migrations-namespace>
-    <table name="doctrine_migration_versions_test" column="doctrine_migration_column_test" executed_at_column="doctrine_migration_executed_at_column_test" />
+    <table name="doctrine_migration_versions_test" column="doctrine_migration_column_test" column_length="200" executed_at_column="doctrine_migration_executed_at_column_test" />
     <migrations-directory>.</migrations-directory>
 
 </doctrine-migrations>

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config.yml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config.yml
@@ -3,6 +3,7 @@ name: Doctrine Sandbox Migrations
 migrations_namespace: DoctrineMigrationsTest
 table_name: doctrine_migration_versions_test
 column_name: doctrine_migration_column_test
+column_length: 200
 executed_at_column_name: doctrine_migration_executed_at_column_test
 migrations_directory: .
 migrations: []

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_migrations_list.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_migrations_list.php
@@ -3,20 +3,20 @@
 declare(strict_types=1);
 
 return [
-'name'                 => 'Doctrine Sandbox Migrations',
-'table_name'           => 'doctrine_migration_versions_test',
-'migrations'           => [
-    [
-        'class' => 'Doctrine\\Migrations\\Tests\\Stub\\Version1Test',
-        'version' => 'Version1Test',
+    'name'                 => 'Doctrine Sandbox Migrations',
+    'table_name'           => 'doctrine_migration_versions_test',
+    'migrations'           => [
+        [
+            'class'   => 'Doctrine\\Migrations\\Tests\\Stub\\Version1Test',
+            'version' => 'Version1Test',
+        ],
+        [
+            'class'   => 'Doctrine\\Migrations\\Tests\\Stub\\Version2Test',
+            'version' => 'Version2Test',
+        ],
+        [
+            'class'   => 'Doctrine\\Migrations\\Tests\\Stub\\Version3Test',
+            'version' => 'Version3Test',
+        ],
     ],
-    [
-        'class' => 'Doctrine\\Migrations\\Tests\\Stub\\Version2Test',
-        'version' => 'Version2Test',
-    ],
-    [
-        'class' => 'Doctrine\\Migrations\\Tests\\Stub\\Version3Test',
-        'version' => 'Version3Test',
-    ],
-],
 ];

--- a/tests/Doctrine/Migrations/Tests/Functional/MigrationTableManipulatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/MigrationTableManipulatorTest.php
@@ -34,6 +34,7 @@ class MigrationTableManipulatorTest extends MigrationTestCase
 
         self::assertTrue($table->hasColumn('version'));
         self::assertTrue($table->getColumn('version')->getNotnull());
+        self::assertEquals(200, $table->getColumn('version')->getLength());
 
         self::assertTrue($table->hasColumn('executed_at'));
         self::assertTrue($table->getColumn('executed_at')->getNotnull());
@@ -42,7 +43,7 @@ class MigrationTableManipulatorTest extends MigrationTestCase
     public function testUpdateMigrationTable() : void
     {
         $createTablesSql = [
-            'CREATE TABLE doctrine_migration_versions (version varchar(255) NOT NULL, test varchar(255) DEFAULT NULL, PRIMARY KEY (version))',
+            'CREATE TABLE doctrine_migration_versions (version varchar(200) NOT NULL, test varchar(255) DEFAULT NULL, PRIMARY KEY (version))',
             'CREATE TABLE test (test varchar(255) NOT NULL)',
         ];
 
@@ -73,7 +74,9 @@ class MigrationTableManipulatorTest extends MigrationTestCase
 
     protected function setUp() : void
     {
-        $configuration     = $this->getSqliteConfiguration();
+        $configuration = $this->getSqliteConfiguration();
+        $configuration->setMigrationsColumnLength(200);
+
         $dependencyFactory = $configuration->getDependencyFactory();
 
         $this->migrationTableManipulator = $dependencyFactory->getMigrationTableManipulator();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #678

#### Summary

Fix issue with not being able to configure the migrations table version column length from configuration files.
