### PR TITLE
Add shorter console command aliases to improve developer experience.

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -34,6 +34,7 @@ class DiffCommand extends AbstractCommand
 
         $this
             ->setName('migrations:diff')
+            ->setAliases(['diff'])
             ->setDescription('Generate a migration by comparing your current database to your mapping information.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command generates a migration by comparing your current database to your mapping information:

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -17,6 +17,7 @@ class ExecuteCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:execute')
+            ->setAliases(['execute'])
             ->setDescription(
                 'Execute a single migration version up or down manually.'
             )

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -17,6 +17,7 @@ class GenerateCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:generate')
+            ->setAliases(['generate'])
             ->setDescription('Generate a blank migration class.')
             ->addOption(
                 'editor-cmd',

--- a/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
@@ -14,6 +14,7 @@ class LatestCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:latest')
+            ->setAliases(['latest'])
             ->setDescription('Outputs the latest version number')
         ;
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -21,6 +21,7 @@ class MigrateCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:migrate')
+            ->setAliases(['migrate'])
             ->setDescription(
                 'Execute a migration to a specified version or the latest available version.'
             )

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -21,6 +21,7 @@ class StatusCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:status')
+            ->setAliases(['status'])
             ->setDescription('View the status of a set of migrations.')
             ->addOption(
                 'show-versions',

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -15,6 +15,7 @@ class UpToDateCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:up-to-date')
+            ->setAliases(['up-to-date'])
             ->setDescription('Tells you if your schema is up-to-date.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command tells you if your schema is up-to-date:

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -21,6 +21,7 @@ class VersionCommand extends AbstractCommand
     {
         $this
             ->setName('migrations:version')
+            ->setAliases(['version'])
             ->setDescription('Manually add and delete migration versions from the version table.')
             ->addArgument(
                 'version',


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Add shorter console command aliases to improve the developer experience.

Before:

    $ ./migrations migrations:generate

After:

    $ ./migrations generate
