### PR TITLE
Remove unused input and output extension points from bin/doctrine-mig…

### DIFF
--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -69,14 +69,6 @@ if(class_exists('\Symfony\Component\Console\Helper\QuestionHelper')) {
     $helperSet->set(new DialogHelper(), 'dialog');
 }
 
-$input = file_exists('migrations-input.php')
-    ? include 'migrations-input.php'
-    : null;
-
-$output = file_exists('migrations-output.php')
-    ? include 'migrations-output.php'
-    : null;
-
 $commands = [];
 
 ConsoleRunner::run($helperSet, $commands);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/doctrine/migrations/pull/685/files#r189024397

#### Summary

Removes unused input and output extension points in bin/doctrine-migrations.php
