### PR TITLE
Fix stopwatch so it uses a single symfony stopwatch instance.

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -11,6 +11,7 @@ use Doctrine\Migrations\Provider\LazySchemaDiffProvider;
 use Doctrine\Migrations\Provider\SchemaDiffProvider;
 use Doctrine\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\Migrations\Tools\Console\Helper\MigrationStatusInfosHelper;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 
 /**
  * @internal
@@ -225,7 +226,9 @@ class DependencyFactory
     public function getStopwatch() : Stopwatch
     {
         return $this->getDependency(Stopwatch::class, function () : Stopwatch {
-            return new Stopwatch();
+            $symfonyStopwatch = new SymfonyStopwatch(true);
+
+            return new Stopwatch($symfonyStopwatch);
         });
     }
 

--- a/lib/Doctrine/Migrations/Stopwatch.php
+++ b/lib/Doctrine/Migrations/Stopwatch.php
@@ -9,10 +9,16 @@ use Symfony\Component\Stopwatch\StopwatchEvent;
 
 class Stopwatch
 {
+    /** @var SymfonyStopwatch */
+    private $symfonyStopwatch;
+
+    public function __construct(SymfonyStopwatch $symfonyStopwatch)
+    {
+        $this->symfonyStopwatch = $symfonyStopwatch;
+    }
+
     public function start(string $section) : StopwatchEvent
     {
-        $stopwatch = new SymfonyStopwatch(true);
-
-        return $stopwatch->start($section);
+        return $this->symfonyStopwatch->start($section);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -23,6 +23,7 @@ use Doctrine\Migrations\Stopwatch;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tests\Stub\Configuration\AutoloadVersions\Version1Test;
 use Doctrine\Migrations\Version;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use function array_keys;
 use function call_user_func_array;
 use function sprintf;
@@ -138,7 +139,8 @@ class ConfigurationTest extends MigrationTestCase
 
         $dependencyFactory = $configuration->getDependencyFactory();
 
-        $stopwatch = new Stopwatch();
+        $symfonyStopwatch = new SymfonyStopwatch(true);
+        $stopwatch        = new Stopwatch($symfonyStopwatch);
 
         $migrator = new Migrator(
             $configuration,

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -29,6 +29,7 @@ use Doctrine\Migrations\Tests\Stub\Functional\MigrationSkipMigration;
 use Doctrine\Migrations\Version;
 use Doctrine\Migrations\VersionExecutor;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use function file_exists;
 use function get_class_methods;
 use function in_array;
@@ -564,7 +565,8 @@ class FunctionalTest extends MigrationTestCase
 
         $parameterFormatter = new ParameterFormatter($this->connection);
 
-        $stopwatch = new Stopwatch();
+        $symfonyStopwatch = new SymfonyStopwatch();
+        $stopwatch        = new Stopwatch($symfonyStopwatch);
 
         $versionExecutor = new VersionExecutor(
             $this->config,

--- a/tests/Doctrine/Migrations/Tests/MigrationTestCase.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationTestCase.php
@@ -14,6 +14,7 @@ use Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use function fopen;
 use function fwrite;
 use function glob;
@@ -112,7 +113,8 @@ abstract class MigrationTestCase extends TestCase
         $dependencyFactory   = $config->getDependencyFactory();
         $migrationRepository = $dependencyFactory->getMigrationRepository();
         $outputWriter        = $dependencyFactory->getOutputWriter();
-        $stopwatch           = new Stopwatch();
+        $symfonyStopwatch    = new SymfonyStopwatch();
+        $stopwatch           = new Stopwatch($symfonyStopwatch);
 
         return new Migrator($config, $migrationRepository, $outputWriter, $stopwatch);
     }
@@ -125,7 +127,8 @@ abstract class MigrationTestCase extends TestCase
         $dependencyFactory   = $config->getDependencyFactory();
         $migrationRepository = $dependencyFactory->getMigrationRepository();
         $outputWriter        = $dependencyFactory->getOutputWriter();
-        $stopwatch           = new Stopwatch();
+        $symfonyStopwatch    = new SymfonyStopwatch();
+        $stopwatch           = new Stopwatch($symfonyStopwatch);
 
         return [$config, $migrationRepository, $outputWriter, $stopwatch];
     }

--- a/tests/Doctrine/Migrations/Tests/StopwatchTest.php
+++ b/tests/Doctrine/Migrations/Tests/StopwatchTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests;
 
 use Doctrine\Migrations\Stopwatch;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
 class StopwatchTest extends TestCase
@@ -27,6 +28,8 @@ class StopwatchTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->stopwatch = new Stopwatch();
+        $symfonyStopwatch = new SymfonyStopwatch();
+
+        $this->stopwatch = new Stopwatch($symfonyStopwatch);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/Migrations/Tests/VersionTest.php
@@ -36,6 +36,7 @@ use PDO;
 use ReflectionClass;
 use stdClass;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use Throwable;
 use const DIRECTORY_SEPARATOR;
 use function current;
@@ -603,7 +604,8 @@ class VersionTest extends MigrationTestCase
 
         $parameterFormatter = new ParameterFormatter($configuration->getConnection());
 
-        $stopwatch = new Stopwatch();
+        $symfonyStopwatch = new SymfonyStopwatch();
+        $stopwatch        = new Stopwatch($symfonyStopwatch);
 
         $versionExecutor = new VersionExecutor(
             $configuration,
@@ -626,7 +628,8 @@ class VersionTest extends MigrationTestCase
 
         $parameterFormatter = new ParameterFormatter($configuration->getConnection());
 
-        $stopwatch = new Stopwatch();
+        $symfonyStopwatch = new SymfonyStopwatch();
+        $stopwatch        = new Stopwatch($symfonyStopwatch);
 
         $versionExecutor = new VersionExecutor(
             $configuration,


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/doctrine/migrations/pull/681#discussion_r189052882

#### Summary

Based on a comment from @stof we can use a single Symfony Stopwatch instance.
