### PR TITLE
Allow Migration Classes to be in Multiple Namespaces

### DIFF
--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Finder;
 
 use InvalidArgumentException;
+use ReflectionClass;
 use const PHP_EOL;
 use const SORT_STRING;
-use function basename;
+use function get_declared_classes;
+use function in_array;
 use function is_dir;
+use function ksort;
 use function realpath;
 use function sprintf;
 use function substr;
-use function uasort;
 
 abstract class Finder implements MigrationFinder
 {
@@ -50,7 +52,7 @@ abstract class Finder implements MigrationFinder
             $includedFiles[] = realpath($file);
         }
 
-        $classes = $this->loadMigrationClasses($includedFiles);
+        $classes  = $this->loadMigrationClasses($includedFiles);
         $versions = [];
         foreach ($classes as $class) {
             $version = substr($class->getShortName(), 7);
@@ -69,11 +71,18 @@ abstract class Finder implements MigrationFinder
         return $versions;
     }
 
+    /**
+     * Look up all declared classes and find those classes contained
+     * in the give `$files` array.
+     *
+     * @param string[] $files The set of files that were `required`
+     * @return ReflectionClass[] the classes in `$files`
+     */
     protected function loadMigrationClasses(array $files) : array
     {
         $classes = [];
         foreach (get_declared_classes() as $class) {
-            $ref = new \ReflectionClass($class);
+            $ref = new ReflectionClass($class);
             if (in_array($ref->getFileName(), $files)) {
                 $classes[] = $ref;
             }

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -71,7 +71,7 @@ abstract class Finder implements MigrationFinder
 
     /**
      * Look up all declared classes and find those classes contained
-     * in the give `$files` array.
+     * in the given `$files` array.
      *
      * @param string[] $files The set of files that were `required`
      * @param string|null $namespace If not null only classes in this namespace will be returned

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -81,16 +81,16 @@ abstract class Finder implements MigrationFinder
     {
         $classes = [];
         foreach (get_declared_classes() as $class) {
-            $ref = new ReflectionClass($class);
-            if (! in_array($ref->getFileName(), $files, true)) {
+            $reflectionClass = new ReflectionClass($class);
+            if (! in_array($reflectionClass->getFileName(), $files, true)) {
                 continue;
             }
 
-            if (null !== $namespace && $namespace !== $ref->getNamespaceName()) {
+            if (null !== $namespace && $namespace !== $reflectionClass->getNamespaceName()) {
                 continue;
             }
 
-            $classes[] = $ref;
+            $classes[] = $reflectionClass;
         }
 
         return $classes;

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -40,7 +40,7 @@ abstract class Finder implements MigrationFinder
      *
      * @return string[]
      */
-    protected function loadMigrations(array $files, ?string $namespace) : array
+    protected function loadMigrations(array $files) : array
     {
         $migrations = [];
 

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -44,8 +44,6 @@ abstract class Finder implements MigrationFinder
      */
     protected function loadMigrations(array $files) : array
     {
-        $migrations = [];
-
         $includedFiles = [];
         foreach ($files as $file) {
             static::requireOnce($file);

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -81,9 +81,11 @@ abstract class Finder implements MigrationFinder
         $classes = [];
         foreach (get_declared_classes() as $class) {
             $ref = new ReflectionClass($class);
-            if (in_array($ref->getFileName(), $files, true)) {
-                $classes[] = $ref;
+            if (! in_array($ref->getFileName(), $files, true)) {
+                continue;
             }
+
+            $classes[] = $ref;
         }
 
         return $classes;

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -73,7 +73,7 @@ abstract class Finder implements MigrationFinder
      * Look up all declared classes and find those classes contained
      * in the given `$files` array.
      *
-     * @param string[] $files The set of files that were `required`
+     * @param string[]    $files     The set of files that were `required`
      * @param string|null $namespace If not null only classes in this namespace will be returned
      * @return ReflectionClass[] the classes in `$files`
      */
@@ -86,7 +86,7 @@ abstract class Finder implements MigrationFinder
                 continue;
             }
 
-            if (null !== $namespace && $namespace !== $reflectionClass->getNamespaceName()) {
+            if ($namespace !== null && $namespace !== $reflectionClass->getNamespaceName()) {
                 continue;
             }
 

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -81,7 +81,7 @@ abstract class Finder implements MigrationFinder
         $classes = [];
         foreach (get_declared_classes() as $class) {
             $ref = new ReflectionClass($class);
-            if (in_array($ref->getFileName(), $files)) {
+            if (in_array($ref->getFileName(), $files, true)) {
                 $classes[] = $ref;
             }
         }

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -42,7 +42,7 @@ abstract class Finder implements MigrationFinder
      *
      * @return string[]
      */
-    protected function loadMigrations(array $files) : array
+    protected function loadMigrations(array $files, ?string $namespace) : array
     {
         $includedFiles = [];
         foreach ($files as $file) {
@@ -50,7 +50,7 @@ abstract class Finder implements MigrationFinder
             $includedFiles[] = realpath($file);
         }
 
-        $classes  = $this->loadMigrationClasses($includedFiles);
+        $classes  = $this->loadMigrationClasses($includedFiles, $namespace);
         $versions = [];
         foreach ($classes as $class) {
             $version = substr($class->getShortName(), 7);
@@ -74,14 +74,19 @@ abstract class Finder implements MigrationFinder
      * in the give `$files` array.
      *
      * @param string[] $files The set of files that were `required`
+     * @param string|null $namespace If not null only classes in this namespace will be returned
      * @return ReflectionClass[] the classes in `$files`
      */
-    protected function loadMigrationClasses(array $files) : array
+    protected function loadMigrationClasses(array $files, ?string $namespace) : array
     {
         $classes = [];
         foreach (get_declared_classes() as $class) {
             $ref = new ReflectionClass($class);
             if (! in_array($ref->getFileName(), $files, true)) {
+                continue;
+            }
+
+            if (null !== $namespace && $namespace !== $ref->getNamespaceName()) {
                 continue;
             }
 

--- a/lib/Doctrine/Migrations/Finder/GlobFinder.php
+++ b/lib/Doctrine/Migrations/Finder/GlobFinder.php
@@ -12,12 +12,12 @@ final class GlobFinder extends Finder
     /**
      * @return string[]
      */
-    public function findMigrations(string $directory, ?string $namespace = null) : array
+    public function findMigrations(string $directory) : array
     {
         $dir = $this->getRealPath($directory);
 
         $files = glob(rtrim($dir, '/') . '/Version*.php');
 
-        return $this->loadMigrations($files, $namespace);
+        return $this->loadMigrations($files);
     }
 }

--- a/lib/Doctrine/Migrations/Finder/GlobFinder.php
+++ b/lib/Doctrine/Migrations/Finder/GlobFinder.php
@@ -12,12 +12,12 @@ final class GlobFinder extends Finder
     /**
      * @return string[]
      */
-    public function findMigrations(string $directory) : array
+    public function findMigrations(string $directory, ?string $namespace = null) : array
     {
         $dir = $this->getRealPath($directory);
 
         $files = glob(rtrim($dir, '/') . '/Version*.php');
 
-        return $this->loadMigrations($files);
+        return $this->loadMigrations($files, $namespace);
     }
 }

--- a/lib/Doctrine/Migrations/Finder/MigrationFinder.php
+++ b/lib/Doctrine/Migrations/Finder/MigrationFinder.php
@@ -8,7 +8,7 @@ interface MigrationFinder
 {
     /**
      * @param string $directory The directory which the finder should search
-     * @param string|null $namespace If not null only classes in this namespace will be allowed
+     * @param string|null $namespace If not null only classes in this namespace will be returned
      * @return string[]
      */
     public function findMigrations(string $directory, ?string $namespace = null) : array;

--- a/lib/Doctrine/Migrations/Finder/MigrationFinder.php
+++ b/lib/Doctrine/Migrations/Finder/MigrationFinder.php
@@ -6,6 +6,10 @@ namespace Doctrine\Migrations\Finder;
 
 interface MigrationFinder
 {
-    /** @return string[] */
-    public function findMigrations(string $directory) : array;
+    /**
+     * @param string $directory The directory which the finder should search
+     * @param string|null $namespace If not null only classes in this namespace will be allowed
+     * @return string[]
+     */
+    public function findMigrations(string $directory, ?string $namespace = null) : array;
 }

--- a/lib/Doctrine/Migrations/Finder/MigrationFinder.php
+++ b/lib/Doctrine/Migrations/Finder/MigrationFinder.php
@@ -7,7 +7,7 @@ namespace Doctrine\Migrations\Finder;
 interface MigrationFinder
 {
     /**
-     * @param string $directory The directory which the finder should search
+     * @param string      $directory The directory which the finder should search
      * @param string|null $namespace If not null only classes in this namespace will be returned
      * @return string[]
      */

--- a/lib/Doctrine/Migrations/Finder/MigrationFinder.php
+++ b/lib/Doctrine/Migrations/Finder/MigrationFinder.php
@@ -7,5 +7,5 @@ namespace Doctrine\Migrations\Finder;
 interface MigrationFinder
 {
     /** @return string[] */
-    public function findMigrations(string $directory, ?string $namespace = null) : array;
+    public function findMigrations(string $directory) : array;
 }

--- a/lib/Doctrine/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/Migrations/Finder/RecursiveRegexFinder.php
@@ -16,11 +16,14 @@ final class RecursiveRegexFinder extends Finder implements MigrationDeepFinder
     /**
      * @return string[]
      */
-    public function findMigrations(string $directory) : array
+    public function findMigrations(string $directory, ?string $namespace = null) : array
     {
         $dir = $this->getRealPath($directory);
 
-        return $this->loadMigrations($this->getMatches($this->createIterator($dir)));
+        return $this->loadMigrations(
+            $this->getMatches($this->createIterator($dir)),
+            $namespace
+        );
     }
 
     private function createIterator(string $dir) : RegexIterator

--- a/lib/Doctrine/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/Migrations/Finder/RecursiveRegexFinder.php
@@ -16,11 +16,11 @@ final class RecursiveRegexFinder extends Finder implements MigrationDeepFinder
     /**
      * @return string[]
      */
-    public function findMigrations(string $directory, ?string $namespace = null) : array
+    public function findMigrations(string $directory) : array
     {
         $dir = $this->getRealPath($directory);
 
-        return $this->loadMigrations($this->getMatches($this->createIterator($dir)), $namespace);
+        return $this->loadMigrations($this->getMatches($this->createIterator($dir)));
     }
 
     private function createIterator(string $dir) : RegexIterator

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -64,7 +64,7 @@ class MigrationRepository
      */
     public function findMigrations(string $path) : array
     {
-        return $this->migrationFinder->findMigrations($path, $this->configuration->getMigrationsNamespace());
+        return $this->migrationFinder->findMigrations($path);
     }
 
     /** @return Version[] */

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -64,7 +64,10 @@ class MigrationRepository
      */
     public function findMigrations(string $path) : array
     {
-        return $this->migrationFinder->findMigrations($path);
+        return $this->migrationFinder->findMigrations(
+            $path,
+            $this->configuration->getMigrationsNamespace()
+        );
     }
 
     /** @return Version[] */

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -14,7 +14,6 @@ use Doctrine\DBAL\Platforms\Keywords\KeywordList;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
-use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Migrator;
 use Doctrine\Migrations\OutputWriter;

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -60,34 +60,6 @@ class ConfigurationTest extends MigrationTestCase
         self::assertSame($outputWriter, $configuration->getOutputWriter());
     }
 
-    public function testRegisterMigrationsClassExistCheck() : void
-    {
-        $migrationsDir = __DIR__ . '/ConfigurationTestSource/Migrations';
-
-        $connection = $this->getConnectionMock();
-
-        $platform      = $this->createMock(AbstractPlatform::class);
-        $schemaManager = $this->createMock(AbstractSchemaManager::class);
-
-        $connection->expects($this->once())
-            ->method('getDatabasePlatform')
-            ->willReturn($platform);
-
-        $connection->expects($this->once())
-            ->method('getSchemaManager')
-            ->willReturn($schemaManager);
-
-        $configuration = new Configuration($connection);
-        $configuration->setMigrationsNamespace('Migrations');
-        $configuration->setMigrationsDirectory($migrationsDir);
-
-        $this->expectException(
-            MigrationException::class,
-            'Migration class "Migrations\Version123" was not found. Is it placed in "Migrations" namespace?'
-        );
-        $configuration->registerMigrationsFromDirectory($migrationsDir);
-    }
-
     public function testGetSetMigrationsColumnName() : void
     {
         $configuration = new Configuration($this->getConnectionMock());

--- a/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
@@ -21,4 +21,16 @@ abstract class FinderTestCase extends MigrationTestCase
             '0002' => 'TestMigrations\\TestOther\\Version0002',
         ], $versions);
     }
+
+    public function testOnlyClassesInTheProvidedNamespaceAreLoadedWhenNamespaceIsProvided() : void
+    {
+        $versions = $this->finder->findMigrations(
+            __DIR__ . '/_features/MultiNamespace',
+            'TestMigrations\\Test'
+        );
+
+        $this->assertEquals([
+            '0001' => 'TestMigrations\\Test\\Version0001',
+        ], $versions);
+    }
 }

--- a/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
@@ -12,9 +12,9 @@ abstract class FinderTestCase extends MigrationTestCase
     /** @var MigrationFinder */
     protected $finder;
 
-    public function testClassesInMultipleNamespacesCanBeLoadedByTheFinder()
+    public function testClassesInMultipleNamespacesCanBeLoadedByTheFinder() : void
     {
-        $versions = $this->finder->findMigrations(__DIR__.'/_features/MultiNamespace');
+        $versions = $this->finder->findMigrations(__DIR__ . '/_features/MultiNamespace');
 
         $this->assertEquals([
             '0001' => 'TestMigrations\\Test\\Version0001',

--- a/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
@@ -29,8 +29,6 @@ abstract class FinderTestCase extends MigrationTestCase
             'TestMigrations\\Test'
         );
 
-        $this->assertEquals([
-            '0001' => 'TestMigrations\\Test\\Version0001',
-        ], $versions);
+        $this->assertEquals(['0001' => 'TestMigrations\\Test\\Version0001'], $versions);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/FinderTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Finder;
+
+use Doctrine\Migrations\Finder\MigrationFinder;
+use Doctrine\Migrations\Tests\MigrationTestCase;
+
+abstract class FinderTestCase extends MigrationTestCase
+{
+    /** @var MigrationFinder */
+    protected $finder;
+
+    public function testClassesInMultipleNamespacesCanBeLoadedByTheFinder()
+    {
+        $versions = $this->finder->findMigrations(__DIR__.'/_features/MultiNamespace');
+
+        $this->assertEquals([
+            '0001' => 'TestMigrations\\Test\\Version0001',
+            '0002' => 'TestMigrations\\TestOther\\Version0002',
+        ], $versions);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/GlobFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/GlobFinderTest.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Finder;
 
 use Doctrine\Migrations\Finder\GlobFinder;
-use Doctrine\Migrations\Tests\MigrationTestCase;
 use InvalidArgumentException;
 
-class GlobFinderTest extends MigrationTestCase
+class GlobFinderTest extends finderTestCase
 {
-    /** @var GlobFinder */
-    private $finder;
-
     public function testBadFilenameCausesErrorWhenFindingMigrations() : void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Doctrine/Migrations/Tests/Finder/GlobFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/GlobFinderTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Migrations\Tests\Finder;
 use Doctrine\Migrations\Finder\GlobFinder;
 use InvalidArgumentException;
 
-class GlobFinderTest extends finderTestCase
+class GlobFinderTest extends FinderTestCase
 {
     public function testBadFilenameCausesErrorWhenFindingMigrations() : void
     {

--- a/tests/Doctrine/Migrations/Tests/Finder/GlobFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/GlobFinderTest.php
@@ -25,7 +25,7 @@ class GlobFinderTest extends finderTestCase
 
     public function testFindMigrationsReturnsTheExpectedFilesFromDirectory() : void
     {
-        $migrations = $this->finder->findMigrations(__DIR__ . '/_files', 'TestMigrations');
+        $migrations = $this->finder->findMigrations(__DIR__ . '/_files');
 
         self::assertArrayHasKey('20150502000000', $migrations);
         self::assertEquals('TestMigrations\\Version20150502000000', $migrations['20150502000000']);

--- a/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -43,8 +43,8 @@ class RecursiveRegexFinderTest extends FinderTestCase
             '20150502000003' => 'TestMigrations\\Version20150502000003',
             '20150502000004' => 'TestMigrations\\Version20150502000004',
             '20150502000005' => 'TestMigrations\\Version20150502000005',
-            '1_reset_versions' => 'TestMigrations\\Version1_reset_versions',
-            '1_symlinked_file' => 'TestMigrations\\Version1_symlinked_file',
+            '1ResetVersions' => 'TestMigrations\\Version1ResetVersions',
+            '1SymlinkedFile' => 'TestMigrations\\Version1SymlinkedFile',
         ];
         foreach ($tests as $version => $namespace) {
             self::assertArrayHasKey($version, $migrations);
@@ -63,9 +63,9 @@ class RecursiveRegexFinderTest extends FinderTestCase
         self::assertArrayNotHasKey('ARandomClass', $migrations);
     }
 
-    public function testFindMigrationsCanLocateClassesInNestedNamespacesAndDirectories()
+    public function testFindMigrationsCanLocateClassesInNestedNamespacesAndDirectories() : void
     {
-        $versions = $this->finder->findMigrations(__DIR__.'/_features/MultiNamespaceNested');
+        $versions = $this->finder->findMigrations(__DIR__ . '/_features/MultiNamespaceNested');
 
         $this->assertEquals([
             '0001' => 'TestMigrations\\MultiNested\\Version0001',

--- a/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -33,7 +33,7 @@ class RecursiveRegexFinderTest extends FinderTestCase
 
     public function testFindMigrationsReturnsTheExpectedFilesFromDirectory() : void
     {
-        $migrations = $this->finder->findMigrations(__DIR__ . '/_files', 'TestMigrations');
+        $migrations = $this->finder->findMigrations(__DIR__ . '/_files');
 
         self::assertCount(7, $migrations);
 

--- a/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -80,9 +80,7 @@ class RecursiveRegexFinderTest extends FinderTestCase
             'TestMigrations\\MultiNested'
         );
 
-        $this->assertEquals([
-            '0001' => 'TestMigrations\\MultiNested\\Version0001',
-        ], $versions);
+        $this->assertEquals(['0001' => 'TestMigrations\\MultiNested\\Version0001'], $versions);
     }
 
     protected function setUp() : void

--- a/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -73,6 +73,18 @@ class RecursiveRegexFinderTest extends FinderTestCase
         ], $versions);
     }
 
+    public function testOnlyMigrationsInTheProvidedNamespacesAreLoadedIfNamespaceIsProvided() : void
+    {
+        $versions = $this->finder->findMigrations(
+            __DIR__ . '/_features/MultiNamespaceNested',
+            'TestMigrations\\MultiNested'
+        );
+
+        $this->assertEquals([
+            '0001' => 'TestMigrations\\MultiNested\\Version0001',
+        ], $versions);
+    }
+
     protected function setUp() : void
     {
         $this->finder = new RecursiveRegexFinder();

--- a/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -5,15 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Finder;
 
 use Doctrine\Migrations\Finder\RecursiveRegexFinder;
-use Doctrine\Migrations\Tests\MigrationTestCase;
 use InvalidArgumentException;
 use function asort;
 
-class RecursiveRegexFinderTest extends MigrationTestCase
+class RecursiveRegexFinderTest extends FinderTestCase
 {
-    /** @var RecursiveRegexFinder */
-    private $finder;
-
     public function testVersionNameCausesErrorWhen0() : void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -65,6 +61,16 @@ class RecursiveRegexFinderTest extends MigrationTestCase
         self::assertArrayNotHasKey('ADeeperRandomClass', $migrations);
         self::assertArrayNotHasKey('AnotherRandomClassNotStartingWithVersion', $migrations);
         self::assertArrayNotHasKey('ARandomClass', $migrations);
+    }
+
+    public function testFindMigrationsCanLocateClassesInNestedNamespacesAndDirectories()
+    {
+        $versions = $this->finder->findMigrations(__DIR__.'/_features/MultiNamespaceNested');
+
+        $this->assertEquals([
+            '0001' => 'TestMigrations\\MultiNested\\Version0001',
+            '0002' => 'TestMigrations\\MultiNested\\Deep\\Version0002',
+        ], $versions);
     }
 
     protected function setUp() : void

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0001.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0001.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations\Test;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0001.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0001.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations\Test;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version0001 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0002.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0002.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations\TestOther;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0002.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespace/Version0002.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations\TestOther;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version0002 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Deep/Version0002.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Deep/Version0002.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations\MultiNested\Deep;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Deep/Version0002.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Deep/Version0002.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations\MultiNested\Deep;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version0002 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Version0001.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Version0001.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations\MultiNested;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Version0001.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_features/MultiNamespaceNested/Version0001.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations\MultiNested;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version0001 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000000.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000000.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20150502000000 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000000.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000000.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000001.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000001.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000001.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/Version20150502000001.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20150502000001 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version1ResetVersions.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version1ResetVersions.php
@@ -7,7 +7,7 @@ namespace TestMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-class Version1ResetVversions extends AbstractMigration
+class Version1ResetVersions extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version1ResetVersions.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version1ResetVersions.php
@@ -1,13 +1,13 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-class Version1_symlinked_file extends AbstractMigration
+class Version1ResetVversions extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version1_reset_versions.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version1_reset_versions.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version1_reset_versions extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20150502000003 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003/Version20150502000005.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003/Version20150502000005.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20150502000005 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003/Version20150502000005.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/Version20150502000003/Version20150502000005.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/deeper/Version20150502000004.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/deeper/Version20150502000004.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_files/deep/deeper/Version20150502000004.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_files/deep/deeper/Version20150502000004.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20150502000004 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_regression/NoVersionNamed0/Version0.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_regression/NoVersionNamed0/Version0.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Doctrine\Migrations\Tests\Finder\Regression\NoVersionNamed0;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version0 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Finder/_regression/NoVersionNamed0/Version0.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_regression/NoVersionNamed0/Version0.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests\Finder\Regression\NoVersionNamed0;
 

--- a/tests/Doctrine/Migrations/Tests/Finder/_symlinked_files/Version1SymlinkedFile.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_symlinked_files/Version1SymlinkedFile.php
@@ -1,13 +1,13 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace TestMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-class Version1_reset_versions extends AbstractMigration
+class Version1SymlinkedFile extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {

--- a/tests/Doctrine/Migrations/Tests/Finder/_symlinked_files/Version1_symlinked_file.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/_symlinked_files/Version1_symlinked_file.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace TestMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version1_symlinked_file extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // ignored
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // ignored
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Functional/CliTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/CliTest.php
@@ -281,13 +281,12 @@ class CliTest extends MigrationTestCase
     /**
      * @return array|\string[]
      */
-    private function findMigrations(string $namespace = 'TestMigrations') : array
+    private function findMigrations() : array
     {
         $finder = new RecursiveRegexFinder();
 
         return $finder->findMigrations(
-            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'migrations',
-            $namespace
+            __DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'migrations'
         );
     }
 

--- a/tests/Doctrine/Migrations/Tests/MigrationRepositoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationRepositoryTest.php
@@ -65,7 +65,7 @@ class MigrationRepositoryTest extends TestCase
         self::assertEquals($versionData, $this->migrationRepository->getVersionData($version));
     }
 
-    public function testRegisterMigrationWithNonExistentClassCausesError()
+    public function testRegisterMigrationWithNonExistentClassCausesError() : void
     {
         $this->expectException(MigrationClassNotFound::class);
 

--- a/tests/Doctrine/Migrations/Tests/MigrationRepositoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Exception\MigrationClassNotFound;
 use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Version;
@@ -62,6 +63,13 @@ class MigrationRepositoryTest extends TestCase
             ->willReturn($versionData);
 
         self::assertEquals($versionData, $this->migrationRepository->getVersionData($version));
+    }
+
+    public function testRegisterMigrationWithNonExistentClassCausesError()
+    {
+        $this->expectException(MigrationClassNotFound::class);
+
+        $this->migrationRepository->registerMigration('123', DoesNotExistAtAll::class);
     }
 
     protected function setUp() : void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | Improvement
| BC Break     | yes
| Fixed issues | #348

#### Summary

This changes the various `MigrationFinder` implementations to use reflection and `get_declared_classes` to load the various migration classes. The code is similar to the [doctrine persistence stuff](https://github.com/doctrine/common/blob/de19a0b00b7a3e5f8820141f11ddf26ee0a7d26e/lib/Doctrine/Common/Persistence/Mapping/Driver/AnnotationDriver.php#L175-L237)

The end result is that all the code for loading migrations no longer cares about the namespace in the configuration -- it's only for generating new migrations now. Users can nest namespaces as they wish.
