### PR TITLE
CS on return types

### DIFF
--- a/lib/Doctrine/Migrations/MigrationGenerator.php
+++ b/lib/Doctrine/Migrations/MigrationGenerator.php
@@ -35,18 +35,18 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version<version> extends AbstractMigration
 {
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return '';
     }
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
 <up>
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
 <down>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | /

#### Summary

This PR only removes an extra space before semicolons on generated return types.

https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#45-method-and-function-arguments
> When you have a return type declaration present there MUST be one space after the colon followed by the type declaration. The colon and declaration MUST be on the same line as the argument list closing parentheses with no spaces between the two characters.
