### PR TITLE
Mark classes as internal that nobody should be depending on.

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/AbstractFileConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/AbstractFileConfiguration.php
@@ -16,6 +16,9 @@ use function in_array;
 use function realpath;
 use function strcasecmp;
 
+/**
+ * @internal
+ */
 abstract class AbstractFileConfiguration extends Configuration
 {
     /** @var array */

--- a/lib/Doctrine/Migrations/Configuration/ArrayConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/ArrayConfiguration.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Configuration;
 
+/**
+ * @internal
+ */
 class ArrayConfiguration extends AbstractFileConfiguration
 {
     /** @inheritdoc */

--- a/lib/Doctrine/Migrations/Configuration/Connection/ConnectionLoaderInterface.php
+++ b/lib/Doctrine/Migrations/Configuration/Connection/ConnectionLoaderInterface.php
@@ -6,6 +6,9 @@ namespace Doctrine\Migrations\Configuration\Connection;
 
 use Doctrine\DBAL\Connection;
 
+/**
+ * @internal
+ */
 interface ConnectionLoaderInterface
 {
     /**

--- a/lib/Doctrine/Migrations/Configuration/Connection/Loader/ArrayConnectionConfigurationLoader.php
+++ b/lib/Doctrine/Migrations/Configuration/Connection/Loader/ArrayConnectionConfigurationLoader.php
@@ -11,6 +11,9 @@ use InvalidArgumentException;
 use function file_exists;
 use function is_array;
 
+/**
+ * @internal
+ */
 class ArrayConnectionConfigurationLoader implements ConnectionLoaderInterface
 {
     /** @var null|string */

--- a/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionConfigurationChainLoader.php
+++ b/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionConfigurationChainLoader.php
@@ -7,6 +7,9 @@ namespace Doctrine\Migrations\Configuration\Connection\Loader;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Connection\ConnectionLoaderInterface;
 
+/**
+ * @internal
+ */
 final class ConnectionConfigurationChainLoader implements ConnectionLoaderInterface
 {
     /** @var ConnectionLoaderInterface[] */

--- a/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionConfigurationLoader.php
+++ b/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionConfigurationLoader.php
@@ -8,6 +8,9 @@ use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Connection\ConnectionLoaderInterface;
 
+/**
+ * @internal
+ */
 class ConnectionConfigurationLoader implements ConnectionLoaderInterface
 {
     /** @var null|Configuration */

--- a/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionHelperLoader.php
+++ b/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionHelperLoader.php
@@ -9,6 +9,9 @@ use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\Migrations\Configuration\Connection\ConnectionLoaderInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 
+/**
+ * @internal
+ */
 class ConnectionHelperLoader implements ConnectionLoaderInterface
 {
     /** @var string */

--- a/lib/Doctrine/Migrations/Configuration/JsonConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/JsonConfiguration.php
@@ -8,6 +8,9 @@ use Doctrine\Migrations\Configuration\Exception\JsonNotValid;
 use function file_get_contents;
 use function json_decode;
 
+/**
+ * @internal
+ */
 class JsonConfiguration extends AbstractFileConfiguration
 {
     /** @inheritdoc */

--- a/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
@@ -13,6 +13,9 @@ use function libxml_clear_errors;
 use function libxml_use_internal_errors;
 use function simplexml_load_file;
 
+/**
+ * @internal
+ */
 class XmlConfiguration extends AbstractFileConfiguration
 {
     /** @inheritdoc */

--- a/lib/Doctrine/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/YamlConfiguration.php
@@ -11,6 +11,9 @@ use function class_exists;
 use function file_get_contents;
 use function is_array;
 
+/**
+ * @internal
+ */
 class YamlConfiguration extends AbstractFileConfiguration
 {
     /**

--- a/lib/Doctrine/Migrations/Event/Listeners/AutoCommitListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/AutoCommitListener.php
@@ -11,6 +11,8 @@ use Doctrine\Migrations\Events;
 /**
  * Listens for `onMigrationsMigrated` and, if the connection has autocommit
  * makes sure to do the final commit to ensure changes stick around.
+ *
+ * @internal
  */
 final class AutoCommitListener implements EventSubscriber
 {

--- a/lib/Doctrine/Migrations/FileQueryWriter.php
+++ b/lib/Doctrine/Migrations/FileQueryWriter.php
@@ -11,6 +11,9 @@ use function file_put_contents;
 use function is_dir;
 use function sprintf;
 
+/**
+ * @internal
+ */
 final class FileQueryWriter implements QueryWriter
 {
     /** @var null|OutputWriter */

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -16,6 +16,9 @@ use function realpath;
 use function sprintf;
 use function substr;
 
+/**
+ * @internal
+ */
 abstract class Finder implements MigrationFinder
 {
     protected static function requireOnce(string $path) : void

--- a/lib/Doctrine/Migrations/Finder/GlobFinder.php
+++ b/lib/Doctrine/Migrations/Finder/GlobFinder.php
@@ -7,6 +7,9 @@ namespace Doctrine\Migrations\Finder;
 use function glob;
 use function rtrim;
 
+/**
+ * @internal
+ */
 final class GlobFinder extends Finder
 {
     /**

--- a/lib/Doctrine/Migrations/Finder/MigrationDeepFinder.php
+++ b/lib/Doctrine/Migrations/Finder/MigrationDeepFinder.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Finder;
 
+/**
+ * @internal
+ */
 interface MigrationDeepFinder extends MigrationFinder
 {
 }

--- a/lib/Doctrine/Migrations/Finder/RecursiveRegexFinder.php
+++ b/lib/Doctrine/Migrations/Finder/RecursiveRegexFinder.php
@@ -11,6 +11,9 @@ use RegexIterator;
 use const DIRECTORY_SEPARATOR;
 use function sprintf;
 
+/**
+ * @internal
+ */
 final class RecursiveRegexFinder extends Finder implements MigrationDeepFinder
 {
     /**

--- a/lib/Doctrine/Migrations/Generator/DiffGenerator.php
+++ b/lib/Doctrine/Migrations/Generator/DiffGenerator.php
@@ -14,6 +14,9 @@ use function preg_match;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 class DiffGenerator
 {
     /** @var DBALConfiguration */

--- a/lib/Doctrine/Migrations/Generator/Generator.php
+++ b/lib/Doctrine/Migrations/Generator/Generator.php
@@ -18,6 +18,9 @@ use function sprintf;
 use function str_replace;
 use function trim;
 
+/**
+ * @internal
+ */
 class Generator
 {
     private const MIGRATION_TEMPLATE = <<<'TEMPLATE'

--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -17,6 +17,9 @@ use const COUNT_RECURSIVE;
 use function count;
 use function sprintf;
 
+/**
+ * @internal
+ */
 class Migrator
 {
     /** @var Configuration */

--- a/lib/Doctrine/Migrations/MigratorConfiguration.php
+++ b/lib/Doctrine/Migrations/MigratorConfiguration.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+/**
+ * @internal
+ */
 class MigratorConfiguration
 {
     /** @var bool */

--- a/lib/Doctrine/Migrations/OutputWriter.php
+++ b/lib/Doctrine/Migrations/OutputWriter.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+/**
+ * @internal
+ */
 class OutputWriter
 {
     /** @var callable */

--- a/lib/Doctrine/Migrations/Provider/LazySchemaDiffProvider.php
+++ b/lib/Doctrine/Migrations/Provider/LazySchemaDiffProvider.php
@@ -10,6 +10,9 @@ use ProxyManager\Factory\LazyLoadingValueHolderFactory;
 use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
 use ProxyManager\Proxy\LazyLoadingInterface;
 
+/**
+ * @internal
+ */
 class LazySchemaDiffProvider implements SchemaDiffProviderInterface
 {
     /** @var LazyLoadingValueHolderFactory */

--- a/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
@@ -10,6 +10,9 @@ use Doctrine\ORM\Tools\SchemaTool;
 use UnexpectedValueException;
 use function count;
 
+/**
+ * @internal
+ */
 final class OrmSchemaProvider implements SchemaProviderInterface
 {
     /** @var EntityManagerInterface */

--- a/lib/Doctrine/Migrations/Provider/SchemaDiffProvider.php
+++ b/lib/Doctrine/Migrations/Provider/SchemaDiffProvider.php
@@ -8,6 +8,9 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 
+/**
+ * @internal
+ */
 class SchemaDiffProvider implements SchemaDiffProviderInterface
 {
     /** @var AbstractPlatform */

--- a/lib/Doctrine/Migrations/Provider/SchemaDiffProviderInterface.php
+++ b/lib/Doctrine/Migrations/Provider/SchemaDiffProviderInterface.php
@@ -6,6 +6,9 @@ namespace Doctrine\Migrations\Provider;
 
 use Doctrine\DBAL\Schema\Schema;
 
+/**
+ * @internal
+ */
 interface SchemaDiffProviderInterface
 {
     public function createFromSchema() : Schema;

--- a/lib/Doctrine/Migrations/QueryWriter.php
+++ b/lib/Doctrine/Migrations/QueryWriter.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+/**
+ * @internal
+ */
 interface QueryWriter
 {
     /**

--- a/lib/Doctrine/Migrations/Rollup.php
+++ b/lib/Doctrine/Migrations/Rollup.php
@@ -12,6 +12,9 @@ use function count;
 use function current;
 use function sprintf;
 
+/**
+ * @internal
+ */
 class Rollup
 {
     /** @var Configuration */

--- a/lib/Doctrine/Migrations/SchemaDumper.php
+++ b/lib/Doctrine/Migrations/SchemaDumper.php
@@ -12,6 +12,9 @@ use RuntimeException;
 use function count;
 use function implode;
 
+/**
+ * @internal
+ */
 class SchemaDumper
 {
     /** @var AbstractPlatform */

--- a/lib/Doctrine/Migrations/Stopwatch.php
+++ b/lib/Doctrine/Migrations/Stopwatch.php
@@ -7,6 +7,9 @@ namespace Doctrine\Migrations;
 use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
+/**
+ * @internal
+ */
 class Stopwatch
 {
     /** @var SymfonyStopwatch */

--- a/lib/Doctrine/Migrations/Tools/BooleanStringFormatter.php
+++ b/lib/Doctrine/Migrations/Tools/BooleanStringFormatter.php
@@ -6,6 +6,9 @@ namespace Doctrine\Migrations\Tools;
 
 use function strtolower;
 
+/**
+ * @internal
+ */
 class BooleanStringFormatter
 {
     public static function toBoolean(string $value, bool $default) : bool

--- a/lib/Doctrine/Migrations/Tools/BytesFormatter.php
+++ b/lib/Doctrine/Migrations/Tools/BytesFormatter.php
@@ -9,6 +9,9 @@ use function log;
 use function pow;
 use function round;
 
+/**
+ * @internal
+ */
 final class BytesFormatter
 {
     public static function formatBytes(int $size, int $precision = 2) : string

--- a/lib/Doctrine/Migrations/Tools/Console/ConnectionLoader.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConnectionLoader.php
@@ -15,6 +15,9 @@ use InvalidArgumentException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 
+/**
+ * @internal
+ */
 class ConnectionLoader
 {
     /** @var Configuration|null */

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
@@ -19,6 +19,9 @@ use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 
+/**
+ * @internal
+ */
 class ConsoleRunner
 {
     /** @param AbstractCommand[] $commands */

--- a/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationDirectoryHelper.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationDirectoryHelper.php
@@ -6,7 +6,6 @@ namespace Doctrine\Migrations\Tools\Console\Helper;
 
 use Doctrine\Migrations\Configuration\Configuration;
 use InvalidArgumentException;
-use Symfony\Component\Console\Helper\Helper;
 use const DIRECTORY_SEPARATOR;
 use function date;
 use function file_exists;
@@ -15,7 +14,10 @@ use function mkdir;
 use function rtrim;
 use function sprintf;
 
-class MigrationDirectoryHelper extends Helper
+/**
+ * @internal
+ */
+class MigrationDirectoryHelper
 {
     /** @var Configuration */
     private $configuration;

--- a/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
@@ -10,6 +10,9 @@ use Doctrine\Migrations\MigrationRepository;
 use function count;
 use function sprintf;
 
+/**
+ * @internal
+ */
 class MigrationStatusInfosHelper
 {
     /** @var Configuration  */

--- a/lib/Doctrine/Migrations/Tracking/TableDefinition.php
+++ b/lib/Doctrine/Migrations/Tracking/TableDefinition.php
@@ -9,6 +9,9 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\Type;
 
+/**
+ * @internal
+ */
 class TableDefinition
 {
     public const MIGRATION_COLUMN_TYPE             = 'string';

--- a/lib/Doctrine/Migrations/Tracking/TableStatus.php
+++ b/lib/Doctrine/Migrations/Tracking/TableStatus.php
@@ -6,6 +6,9 @@ namespace Doctrine\Migrations\Tracking;
 
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 
+/**
+ * @internal
+ */
 class TableStatus
 {
     /** @var AbstractSchemaManager */

--- a/lib/Doctrine/Migrations/Tracking/TableUpdater.php
+++ b/lib/Doctrine/Migrations/Tracking/TableUpdater.php
@@ -12,6 +12,9 @@ use Doctrine\DBAL\Schema\Table;
 use Throwable;
 use function in_array;
 
+/**
+ * @internal
+ */
 class TableUpdater
 {
     /** @var Connection */

--- a/lib/Doctrine/Migrations/Version/Direction.php
+++ b/lib/Doctrine/Migrations/Version/Direction.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Version;
 
+/**
+ * @internal
+ */
 final class Direction
 {
     public const UP   = 'up';

--- a/lib/Doctrine/Migrations/Version/State.php
+++ b/lib/Doctrine/Migrations/Version/State.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Version;
 
+/**
+ * @internal
+ */
 final class State
 {
     public const NONE = 0;

--- a/lib/Doctrine/Migrations/Version/Version.php
+++ b/lib/Doctrine/Migrations/Version/Version.php
@@ -20,6 +20,9 @@ use function date_default_timezone_get;
 use function in_array;
 use function str_replace;
 
+/**
+ * @internal
+ */
 class Version implements VersionInterface
 {
     /** @var Configuration */

--- a/lib/Doctrine/Migrations/Version/VersionInterface.php
+++ b/lib/Doctrine/Migrations/Version/VersionInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Version;
 
+/**
+ * @internal
+ */
 interface VersionInterface
 {
     public function getVersion() : string;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #710

#### Summary

Mark classes as internal that nobody should be depending on. The only thing I see that people should be depending on are:

- Doctrine\Migrations\Configuration\Configuration
- Doctrine\Migrations\Events
- Doctrine\Migrations\Finder\MigrationFinder
- Doctrine\Migrations\Provider\SchemaProviderInterface
- Doctrine\Migrations\Provider\StubSchemaProvider
- Doctrine\Migrations\AbstractMigration
   - isTransactional
   - getDescription
   - warnIf
   - abortIf
   - skipIf
   - preUp
   - postUp
   - preDown
   - postDown
   - up
   - down
   - addSql
   - write
   - throwIrreversibleMigrationException
- Doctrine\Migrations\Tools\Console\Command\AbstractCommand
- Doctrine\Migrations\Tools\Console\Command\DiffCommand
- Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand
- Doctrine\Migrations\Tools\Console\Command\ExecuteCommand
- Doctrine\Migrations\Tools\Console\Command\GenerateCommand
- Doctrine\Migrations\Tools\Console\Command\LatestCommand
- Doctrine\Migrations\Tools\Console\Command\MigrateCommand
- Doctrine\Migrations\Tools\Console\Command\RollupCommand
- Doctrine\Migrations\Tools\Console\Command\StatusCommand
- Doctrine\Migrations\Tools\Console\Command\UpToDateCommand
- Doctrine\Migrations\Tools\Console\Command\VersionCommand
