### PR TITLE
bin/ entrypoint refresh

### DIFF
--- a/bin/doctrine-migrations
+++ b/bin/doctrine-migrations
@@ -3,4 +3,6 @@
 
 declare(strict_types=1);
 
-include('doctrine-migrations.php');
+namespace Doctrine\Migrations;
+
+require __DIR__ . '/doctrine-migrations.php';

--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -2,72 +2,88 @@
 
 declare(strict_types=1);
 
+namespace Doctrine\Migrations;
+
 use Doctrine\Migrations\Tools\Console\ConsoleRunner;
-use Symfony\Component\Console\Helper\DialogHelper;
+use Phar;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
+use const DIRECTORY_SEPARATOR;
+use const E_USER_ERROR;
+use const PHP_EOL;
+use function extension_loaded;
+use function file_exists;
+use function getcwd;
+use function is_readable;
+use function trigger_error;
 
 $autoloadFiles = [
     __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/../../../autoload.php'
+    __DIR__ . '/../../../autoload.php',
 ];
 
-$autoloader = false;
+$autoloaderFound = false;
 
 foreach ($autoloadFiles as $autoloadFile) {
-    if (file_exists($autoloadFile)) {
-        require_once $autoloadFile;
-        $autoloader = true;
+    if (! file_exists($autoloadFile)) {
+        continue;
     }
+
+    require_once $autoloadFile;
+    $autoloaderFound = true;
 }
 
-if (!$autoloader) {
-    if (extension_loaded('phar') && ($uri = Phar::running())) {
-        echo 'The phar has been built without dependencies' . PHP_EOL;
+if (! $autoloaderFound) {
+    if (extension_loaded('phar') && Phar::running() !== '') {
+        echo 'The PHAR was built without dependencies!' . PHP_EOL;
+        exit(1);
     }
 
-    die('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
+    echo 'vendor/autoload.php could not be found. Did you run `composer install`?', PHP_EOL;
+    exit(1);
 }
 
 // Support for using the Doctrine ORM convention of providing a `cli-config.php` file.
-$directories = [getcwd(), getcwd() . DIRECTORY_SEPARATOR . 'config'];
+$configurationDirectories = [
+    getcwd(),
+    getcwd() . DIRECTORY_SEPARATOR . 'config',
+];
 
-$configFile = null;
-foreach ($directories as $directory) {
-    $configFile = $directory . DIRECTORY_SEPARATOR . 'cli-config.php';
+$configurationFile = null;
+foreach ($configurationDirectories as $configurationDirectory) {
+    $configurationFilePath = $configurationDirectory . DIRECTORY_SEPARATOR . 'cli-config.php';
 
-    if (file_exists($configFile)) {
-        break;
+    if (! file_exists($configurationFilePath)) {
+        continue;
     }
+
+    $configurationFile = $configurationFilePath;
+    break;
 }
 
 $helperSet = null;
-if (file_exists($configFile)) {
-    if ( ! is_readable($configFile)) {
-        trigger_error(
-            'Configuration file [' . $configFile . '] does not have read permission.', E_USER_ERROR
-        );
+if ($configurationFile !== null) {
+    if (! is_readable($configurationFile)) {
+        trigger_error('Configuration file [' . $configurationFile . '] does not have read permission.', E_USER_ERROR);
+        exit(1);
     }
 
-    $helperSet = require $configFile;
+    $helperSet = require $configurationFile;
 
-    if ( ! ($helperSet instanceof HelperSet)) {
+    if (! $helperSet instanceof HelperSet) {
         foreach ($GLOBALS as $helperSetCandidate) {
-            if ($helperSetCandidate instanceof HelperSet) {
-                $helperSet = $helperSetCandidate;
-                break;
+            if (! $helperSetCandidate instanceof HelperSet) {
+                continue;
             }
+
+            $helperSet = $helperSetCandidate;
+            break;
         }
     }
 }
 
-$helperSet = ($helperSet) ?: new HelperSet();
-
-if(class_exists('\Symfony\Component\Console\Helper\QuestionHelper')) {
-    $helperSet->set(new QuestionHelper(), 'question');
-} else {
-    $helperSet->set(new DialogHelper(), 'dialog');
-}
+$helperSet = $helperSet ?? new HelperSet();
+$helperSet->set(new QuestionHelper(), 'question');
 
 $commands = [];
 

--- a/bin/doctrine-migrations.php
+++ b/bin/doctrine-migrations.php
@@ -17,74 +17,76 @@ use function getcwd;
 use function is_readable;
 use function trigger_error;
 
-$autoloadFiles = [
-    __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/../../../autoload.php',
-];
+(function () : void {
+    $autoloadFiles = [
+        __DIR__ . '/../vendor/autoload.php',
+        __DIR__ . '/../../../autoload.php',
+    ];
 
-$autoloaderFound = false;
+    $autoloaderFound = false;
 
-foreach ($autoloadFiles as $autoloadFile) {
-    if (! file_exists($autoloadFile)) {
-        continue;
+    foreach ($autoloadFiles as $autoloadFile) {
+        if (! file_exists($autoloadFile)) {
+            continue;
+        }
+
+        require_once $autoloadFile;
+        $autoloaderFound = true;
     }
 
-    require_once $autoloadFile;
-    $autoloaderFound = true;
-}
+    if (! $autoloaderFound) {
+        if (extension_loaded('phar') && Phar::running() !== '') {
+            echo 'The PHAR was built without dependencies!' . PHP_EOL;
+            exit(1);
+        }
 
-if (! $autoloaderFound) {
-    if (extension_loaded('phar') && Phar::running() !== '') {
-        echo 'The PHAR was built without dependencies!' . PHP_EOL;
+        echo 'vendor/autoload.php could not be found. Did you run `composer install`?', PHP_EOL;
         exit(1);
     }
 
-    echo 'vendor/autoload.php could not be found. Did you run `composer install`?', PHP_EOL;
-    exit(1);
-}
+    // Support for using the Doctrine ORM convention of providing a `cli-config.php` file.
+    $configurationDirectories = [
+        getcwd(),
+        getcwd() . DIRECTORY_SEPARATOR . 'config',
+    ];
 
-// Support for using the Doctrine ORM convention of providing a `cli-config.php` file.
-$configurationDirectories = [
-    getcwd(),
-    getcwd() . DIRECTORY_SEPARATOR . 'config',
-];
+    $configurationFile = null;
+    foreach ($configurationDirectories as $configurationDirectory) {
+        $configurationFilePath = $configurationDirectory . DIRECTORY_SEPARATOR . 'cli-config.php';
 
-$configurationFile = null;
-foreach ($configurationDirectories as $configurationDirectory) {
-    $configurationFilePath = $configurationDirectory . DIRECTORY_SEPARATOR . 'cli-config.php';
+        if (! file_exists($configurationFilePath)) {
+            continue;
+        }
 
-    if (! file_exists($configurationFilePath)) {
-        continue;
+        $configurationFile = $configurationFilePath;
+        break;
     }
 
-    $configurationFile = $configurationFilePath;
-    break;
-}
+    $helperSet = null;
+    if ($configurationFile !== null) {
+        if (! is_readable($configurationFile)) {
+            trigger_error('Configuration file [' . $configurationFile . '] does not have read permission.', E_USER_ERROR);
+            exit(1);
+        }
 
-$helperSet = null;
-if ($configurationFile !== null) {
-    if (! is_readable($configurationFile)) {
-        trigger_error('Configuration file [' . $configurationFile . '] does not have read permission.', E_USER_ERROR);
-        exit(1);
-    }
+        $helperSet = require $configurationFile;
 
-    $helperSet = require $configurationFile;
+        if (! $helperSet instanceof HelperSet) {
+            foreach ($GLOBALS as $helperSetCandidate) {
+                if (! $helperSetCandidate instanceof HelperSet) {
+                    continue;
+                }
 
-    if (! $helperSet instanceof HelperSet) {
-        foreach ($GLOBALS as $helperSetCandidate) {
-            if (! $helperSetCandidate instanceof HelperSet) {
-                continue;
+                $helperSet = $helperSetCandidate;
+                break;
             }
-
-            $helperSet = $helperSetCandidate;
-            break;
         }
     }
-}
 
-$helperSet = $helperSet ?? new HelperSet();
-$helperSet->set(new QuestionHelper(), 'question');
+    $helperSet = $helperSet ?? new HelperSet();
+    $helperSet->set(new QuestionHelper(), 'question');
 
-$commands = [];
+    $commands = [];
 
-ConsoleRunner::run($helperSet, $commands);
+    ConsoleRunner::run($helperSet, $commands);
+})();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,11 +4,12 @@
     <arg name="extensions" value="php"/>
     <arg name="parallel" value="80"/>
     <arg name="cache" value=".phpcs-cache"/>
-    <arg name="colors" />
+    <arg name="colors"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
+    <file>bin</file>
     <file>lib</file>
     <file>tests</file>
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes-ish (non-zero exit code)

#### Summary

Update bin/ to our CS, add namespace and clean up some statements.
Legacy symfony/console fallback removed.
Also exit code 1 is now used in case of error.

_Review each commit separately or with `?w=1` to avoid noisy whitespace changes._