### PR TITLE
Fix command return type hints so they are consistent and match what S…

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -79,7 +79,7 @@ EOT
     public function execute(
         InputInterface $input,
         OutputInterface $output
-    ) : void {
+    ) : ?int {
         $filterExpression = $input->getOption('filter-expression') ?? null;
         $formatted        = (bool) $input->getOption('formatted');
         $lineLength       = (int) $input->getOption('line-length');
@@ -120,6 +120,8 @@ EOT
                 $versionNumber
             ),
         ]);
+
+        return 0;
     }
 
     protected function createMigrationDiffGenerator() : DiffGenerator

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -60,7 +60,7 @@ EOT
     public function execute(
         InputInterface $input,
         OutputInterface $output
-    ) : void {
+    ) : ?int {
         $formatted  = (bool) $input->getOption('formatted');
         $lineLength = (int) $input->getOption('line-length');
 
@@ -100,5 +100,7 @@ EOT
             '',
             'To use this as a rollup migration you can use the <info>migrations:rollup</info> command.',
         ]);
+
+        return 0;
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -40,7 +40,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : void
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $versionNumber = $this->configuration->generateVersionNumber();
 
@@ -67,5 +67,7 @@ EOT
                 $versionNumber
             ),
         ]);
+
+        return 0;
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
@@ -24,7 +24,7 @@ class LatestCommand extends AbstractCommand
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : void
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $latestVersion = $this->migrationRepository->getLatestVersion();
         $version       = $this->migrationRepository->getVersion($latestVersion);
@@ -35,5 +35,7 @@ class LatestCommand extends AbstractCommand
             $latestVersion,
             $description !== '' ? ' - ' . $description : ''
         ));
+
+        return 0;
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -109,7 +109,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : int
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $this->outputHeader($output);
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
@@ -37,7 +37,7 @@ EOT
     public function execute(
         InputInterface $input,
         OutputInterface $output
-    ) : void {
+    ) : ?int {
         $version = $this->dependencyFactory
             ->getRollup()->rollup();
 
@@ -45,5 +45,7 @@ EOT
             'Rolled up migrations to version <info>%s</info>',
             $version->getVersion()
         ));
+
+        return 0;
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -47,7 +47,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : void
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $output->writeln("\n <info>==</info> Configuration\n");
 
@@ -68,7 +68,7 @@ EOT
         }
 
         if ($input->getOption('show-versions') === false) {
-            return;
+            return 0;
         }
 
         $versions                      = $this->migrationRepository->getMigrations();
@@ -81,7 +81,7 @@ EOT
         }
 
         if (count($executedUnavailableMigrations) === 0) {
-            return;
+            return 0;
         }
 
         $output->writeln(
@@ -97,6 +97,8 @@ EOT
                 )
             );
         }
+
+        return 0;
     }
 
     private function writeStatusInfosLineAligned(OutputInterface $output, string $title, ?string $value) : void

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -31,7 +31,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : int
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $migrations          = count($this->migrationRepository->getMigrations());
         $migratedVersions    = count($this->migrationRepository->getMigratedVersions());

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -90,7 +90,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : void
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         if ($input->getOption('add') === false && $input->getOption('delete') === false) {
             throw new InvalidArgumentException(
@@ -113,6 +113,8 @@ EOT
         } else {
             $this->markVersions($input, $output);
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Working on updating DoctrineMigrationsBundle and I noticed the return type hints for the commands were not consistent and inline with what the Symfony console return type is defined as.
