### PR TITLE
Make minimum PHP requirement reflect reality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         {"name": "Michael Simonson", "email": "contact@mikesimonson.com" }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "doctrine/dbal": "^2.6",
         "ocramius/package-versions": "^1.3",
         "ocramius/proxy-manager": "^2.0.2",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | kinda
| Fixed issues | n/a

#### Summary

Since you're requiring `"ocramius/proxy-manager": "^2.0.2",` new installs will try to use `2.2.0`.

In turn that requires PHP ^7.2 as can be seen [here](https://github.com/Ocramius/ProxyManager/commit/e77558ffaf11499e661d7319c153d68a6a522864) the change was added Jul 2017.

The alternative solution is lower the requirement to "ocramius/proxy-manager": "2.1.1" which only requires PHP ^7.1 as this package has previously.

However, 2.2.0 looks to bring substantial improvements. From the [release notes](https://github.com/Ocramius/ProxyManager/releases/tag/2.2.0):

> This release provides support for the PHP 7.2 object type hint, as well as dramatic (~300%) speed improvement during proxy class generation.
