### PR TITLE
PHPstan 0.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tests/phpunit.xml
 vendor/
 phpunit.xml
 /phpcs.xml
+/phpstan.neon
 /.phpcs-cache
 /box.phar
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ jobs:
     - stage: Code Quality
       env: STATIC_ANALYSIS
       install: travis_retry composer install --prefer-dist
-      script: vendor/bin/phpstan analyse -l 7 -c phpstan.neon lib
+      script: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
         "doctrine/orm": "^2.6",
         "jdorn/sql-formatter": "^1.1",
         "mikey179/vfsStream": "^1.6",
-        "phpstan/phpstan": "^0.9.2",
-        "phpstan/phpstan-phpunit": "^0.9.4",
-        "phpstan/phpstan-strict-rules": "^0.9",
+        "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan-phpunit": "^0.10",
+        "phpstan/phpstan-strict-rules": "^0.10",
         "phpunit/phpunit": "^7.0",
         "symfony/process": "^3.4||^4.0",
         "symfony/yaml": "^3.4||^4.0"

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "jdorn/sql-formatter": "^1.1",
         "mikey179/vfsStream": "^1.6",
         "phpstan/phpstan": "^0.10",
+        "phpstan/phpstan-deprecation-rules": "^0.10",
         "phpstan/phpstan-phpunit": "^0.10",
         "phpstan/phpstan-strict-rules": "^0.10",
         "phpunit/phpunit": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "286c5e9d9c9ecf874c331ded6a55842f",
+    "content-hash": "e66c64c5684f5b95ee05d3aed01f5761",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -2329,6 +2329,52 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2018-06-24T17:49:58+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "ae3a84298c5d93ff82783d2ae8c5a5859dd94c2a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/ae3a84298c5d93ff82783d2ae8c5a5859dd94c2a",
+                "reference": "ae3a84298c5d93ff82783d2ae8c5a5859dd94c2a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "time": "2018-06-24T16:51:04+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8b7ba0a3992d174f990dc1fbdc70194",
+    "content-hash": "286c5e9d9c9ecf874c331ded6a55842f",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -888,6 +888,50 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/xdebug-handler",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "reference": "c919dc6c62e221fc6406f861ea13433c0aa24f08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "time": "2018-04-11T15:42:36+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.4.4",
             "source": {
@@ -1201,16 +1245,16 @@
         },
         {
             "name": "jean85/pretty-package-versions",
-            "version": "1.1",
+            "version": "1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Jean85/pretty-package-versions.git",
-                "reference": "d457344b6a035ef99236bdda4729ad7eeb233f54"
+                "reference": "75c7effcf3f77501d0e0caa75111aff4daa0dd48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/d457344b6a035ef99236bdda4729ad7eeb233f54",
-                "reference": "d457344b6a035ef99236bdda4729ad7eeb233f54",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/75c7effcf3f77501d0e0caa75111aff4daa0dd48",
+                "reference": "75c7effcf3f77501d0e0caa75111aff4daa0dd48",
                 "shasum": ""
             },
             "require": {
@@ -1241,14 +1285,14 @@
                     "email": "alessandro.lai85@gmail.com"
                 }
             ],
-            "description": "A wrapper for ocramius/pretty-package-versions to get pretty versions strings",
+            "description": "A wrapper for ocramius/package-versions to get pretty versions strings",
             "keywords": [
                 "composer",
                 "package",
                 "release",
                 "versions"
             ],
-            "time": "2018-01-21T13:54:22+00:00"
+            "time": "2018-06-13T13:22:40+00:00"
         },
         {
             "name": "mikey179/vfsStream",
@@ -1807,24 +1851,24 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v3.1.5",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce"
+                "reference": "35b8caf75e791ba1b2d24fec1552168d72692b12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
-                "reference": "bb87e28e7d7b8d9a7fda231d37457c9210faf6ce",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/35b8caf75e791ba1b2d24fec1552168d72692b12",
+                "reference": "35b8caf75e791ba1b2d24fec1552168d72692b12",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.5"
+                "php": ">=7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0"
+                "phpunit/phpunit": "^6.5 || ^7.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -1832,7 +1876,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1854,7 +1898,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2018-02-28T20:30:58+00:00"
+            "time": "2018-06-03T11:33:10+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2175,33 +2219,34 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.2",
+            "version": "0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "02f909f134fe06f0cd4790d8627ee24efbe84d6a"
+                "reference": "ed3223362174b8067729930439e139794e9e514a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/02f909f134fe06f0cd4790d8627ee24efbe84d6a",
-                "reference": "02f909f134fe06f0cd4790d8627ee24efbe84d6a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/ed3223362174b8067729930439e139794e9e514a",
+                "reference": "ed3223362174b8067729930439e139794e9e514a",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.0"
+                "php": "~7.1"
             },
             "require-dev": {
                 "consistence/coding-standard": "^2.0.0",
                 "jakub-onderka/php-parallel-lint": "^0.9.2",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan": "^0.9",
+                "phpstan/phpstan": "^0.10@dev",
                 "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^3.3.0"
+                "slevomat/coding-standard": "^3.3.0",
+                "symfony/process": "^3.4 || ^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.1-dev"
+                    "dev-master": "0.3-dev"
                 }
             },
             "autoload": {
@@ -2216,46 +2261,50 @@
                 "MIT"
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2018-01-13T18:19:41+00:00"
+            "time": "2018-06-20T17:48:01+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.9.2",
+            "version": "0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e59541bcc7cac9b35ca54db6365bf377baf4a488"
+                "reference": "86b9f9a4421d282f3c18e0d4d1426f330c1ef21d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e59541bcc7cac9b35ca54db6365bf377baf4a488",
-                "reference": "e59541bcc7cac9b35ca54db6365bf377baf4a488",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/86b9f9a4421d282f3c18e0d4d1426f330c1ef21d",
+                "reference": "86b9f9a4421d282f3c18e0d4d1426f330c1ef21d",
                 "shasum": ""
             },
             "require": {
+                "composer/xdebug-handler": "^1.0",
                 "jean85/pretty-package-versions": "^1.0.3",
                 "nette/bootstrap": "^2.4 || ^3.0",
                 "nette/di": "^2.4.7 || ^3.0",
                 "nette/robot-loader": "^3.0.1",
                 "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "^3.1",
-                "php": "~7.0",
-                "phpstan/phpdoc-parser": "^0.2",
+                "nikic/php-parser": "^4.0.2",
+                "php": "~7.1",
+                "phpstan/phpdoc-parser": "^0.3",
                 "symfony/console": "~3.2 || ~4.0",
                 "symfony/finder": "~3.2 || ~4.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "2.2.1",
+                "brianium/paratest": "^2.0",
+                "consistence/coding-standard": "^3.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
                 "ext-gd": "*",
                 "ext-intl": "*",
                 "ext-mysqli": "*",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "ext-zip": "*",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-php-parser": "^0.9",
-                "phpstan/phpstan-phpunit": "^0.9.3",
-                "phpstan/phpstan-strict-rules": "^0.9",
-                "phpunit/phpunit": "^6.5.4",
-                "slevomat/coding-standard": "4.0.0"
+                "phpstan/phpstan-php-parser": "^0.10",
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpstan/phpstan-strict-rules": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.6.2"
             },
             "bin": [
                 "bin/phpstan"
@@ -2263,7 +2312,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9-dev"
+                    "dev-master": "0.10-dev"
                 }
             },
             "autoload": {
@@ -2279,39 +2328,44 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2018-01-28T13:22:19+00:00"
+            "time": "2018-06-24T17:49:58+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "0.9.4",
+            "version": "0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "852411f841a37aeca2fa5af0002b0272c485c9bf"
+                "reference": "6feecc7faae187daa6be44140cd0f1ba210e6aa0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/852411f841a37aeca2fa5af0002b0272c485c9bf",
-                "reference": "852411f841a37aeca2fa5af0002b0272c485c9bf",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6feecc7faae187daa6be44140cd0f1ba210e6aa0",
+                "reference": "6feecc7faae187daa6be44140cd0f1ba210e6aa0",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.0",
-                "phpstan/phpstan": "^0.9.1",
-                "phpunit/phpunit": "^6.3 || ~7.0"
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^2.0",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-strict-rules": "^0.9",
+                "phpstan/phpstan-strict-rules": "^0.10",
+                "phpunit/phpunit": "^7.0",
                 "satooshi/php-coveralls": "^1.0",
-                "slevomat/coding-standard": "^3.3.0"
+                "slevomat/coding-standard": "^4.5.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9-dev"
+                    "dev-master": "0.10-dev"
                 }
             },
             "autoload": {
@@ -2324,38 +2378,40 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
-            "time": "2018-02-02T09:45:47+00:00"
+            "time": "2018-06-22T18:12:17+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "0.9",
+            "version": "0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "15be9090622c6b85c079922308f831018d8d9e23"
+                "reference": "bffdf03fc70602833936dccf6c2eb3be58ed78d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/15be9090622c6b85c079922308f831018d8d9e23",
-                "reference": "15be9090622c6b85c079922308f831018d8d9e23",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/bffdf03fc70602833936dccf6c2eb3be58ed78d6",
+                "reference": "bffdf03fc70602833936dccf6c2eb3be58ed78d6",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.0",
-                "phpstan/phpstan": "^0.9"
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.10"
             },
             "require-dev": {
-                "consistence/coding-standard": "^2.0.0",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-phpunit": "^0.9",
-                "phpunit/phpunit": "^6.4",
-                "slevomat/coding-standard": "^3.3.0"
+                "phpstan/phpstan-phpunit": "^0.10",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.9-dev"
+                    "dev-master": "0.10-dev"
                 }
             },
             "autoload": {
@@ -2368,7 +2424,7 @@
                 "MIT"
             ],
             "description": "Extra strict and opinionated rules for PHPStan",
-            "time": "2017-11-26T20:12:30+00:00"
+            "time": "2018-06-22T18:09:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2754,6 +2810,53 @@
                 "xunit"
             ],
             "time": "2018-04-11T04:50:36+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3410,16 +3513,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.0.9",
+            "version": "v4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ca27c02b7a3fef4828c998c2ff9ba7aae1641c49"
+                "reference": "087e2ee0d74464a4c6baac4e90417db7477dc238"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ca27c02b7a3fef4828c998c2ff9ba7aae1641c49",
-                "reference": "ca27c02b7a3fef4828c998c2ff9ba7aae1641c49",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/087e2ee0d74464a4c6baac4e90417db7477dc238",
+                "reference": "087e2ee0d74464a4c6baac4e90417db7477dc238",
                 "shasum": ""
             },
             "require": {
@@ -3428,7 +3531,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -3455,7 +3558,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-04-04T05:10:37+00:00"
+            "time": "2018-05-16T14:33:22+00:00"
         },
         {
             "name": "symfony/process",

--- a/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionConfigurationChainLoader.php
+++ b/lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionConfigurationChainLoader.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Configuration\Connection\Loader;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Connection\ConnectionLoaderInterface;
+use Doctrine\Migrations\Configuration\Connection\Loader\Exception\InvalidConfiguration;
 
 /**
  * The ConnectionConfigurationChainLoader class is responsible for loading a Doctrine\DBAL\Connection from an array of
@@ -30,7 +31,7 @@ final class ConnectionConfigurationChainLoader implements ConnectionLoaderInterf
      * Read the input and return a Configuration, returns null if the config
      * is not supported.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidConfiguration
      */
     public function chosen() : ?Connection
     {

--- a/lib/Doctrine/Migrations/Configuration/Exception/XmlNotValid.php
+++ b/lib/Doctrine/Migrations/Configuration/Exception/XmlNotValid.php
@@ -8,7 +8,12 @@ use LogicException;
 
 final class XmlNotValid extends LogicException implements ConfigurationException
 {
-    public static function new() : self
+    public static function malformed() : self
+    {
+        return new self('The XML configuration is malformed.');
+    }
+
+    public static function failedValidation() : self
     {
         return new self('XML configuration did not pass the validation test.', 10);
     }

--- a/lib/Doctrine/Migrations/Configuration/Exception/YamlNotValid.php
+++ b/lib/Doctrine/Migrations/Configuration/Exception/YamlNotValid.php
@@ -8,7 +8,12 @@ use LogicException;
 
 final class YamlNotValid extends LogicException implements ConfigurationException
 {
-    public static function new() : self
+    public static function malformed() : self
+    {
+        return new self('The YAML configuration is malformed.');
+    }
+
+    public static function invalid() : self
     {
         return new self('Configuration is not valid YAML.', 10);
     }

--- a/lib/Doctrine/Migrations/Configuration/JsonConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/JsonConfiguration.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Configuration;
 
 use Doctrine\Migrations\Configuration\Exception\JsonNotValid;
+use const JSON_ERROR_NONE;
+use function assert;
 use function file_get_contents;
 use function json_decode;
+use function json_last_error;
 
 /**
  * The YamlConfiguration class is responsible for loading migration configuration information from a JSON file.
@@ -18,9 +21,13 @@ class JsonConfiguration extends AbstractFileConfiguration
     /** @inheritdoc */
     protected function doLoad(string $file) : void
     {
-        $config = json_decode(file_get_contents($file), true);
+        $contents = file_get_contents($file);
 
-        if ($config === false) {
+        assert($contents !== false);
+
+        $config = json_decode($contents, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
             throw JsonNotValid::new();
         }
 

--- a/lib/Doctrine/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/YamlConfiguration.php
@@ -8,6 +8,7 @@ use Doctrine\Migrations\Configuration\Exception\YamlNotAvailable;
 use Doctrine\Migrations\Configuration\Exception\YamlNotValid;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
+use function assert;
 use function class_exists;
 use function file_get_contents;
 use function is_array;
@@ -28,8 +29,12 @@ class YamlConfiguration extends AbstractFileConfiguration
             throw YamlNotAvailable::new();
         }
 
+        $content = file_get_contents($file);
+
+        assert($content !== false);
+
         try {
-            $config = Yaml::parse(file_get_contents($file));
+            $config = Yaml::parse($content);
         } catch (ParseException $e) {
             throw YamlNotValid::malformed();
         }

--- a/lib/Doctrine/Migrations/Configuration/YamlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/YamlConfiguration.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Configuration;
 
 use Doctrine\Migrations\Configuration\Exception\YamlNotAvailable;
 use Doctrine\Migrations\Configuration\Exception\YamlNotValid;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use function class_exists;
 use function file_get_contents;
@@ -27,10 +28,14 @@ class YamlConfiguration extends AbstractFileConfiguration
             throw YamlNotAvailable::new();
         }
 
-        $config = Yaml::parse(file_get_contents($file));
+        try {
+            $config = Yaml::parse(file_get_contents($file));
+        } catch (ParseException $e) {
+            throw YamlNotValid::malformed();
+        }
 
         if (! is_array($config)) {
-            throw YamlNotValid::new();
+            throw YamlNotValid::invalid();
         }
 
         if (isset($config['migrations_directory'])) {

--- a/lib/Doctrine/Migrations/Finder/Finder.php
+++ b/lib/Doctrine/Migrations/Finder/Finder.php
@@ -8,6 +8,7 @@ use Doctrine\Migrations\Finder\Exception\InvalidDirectory;
 use Doctrine\Migrations\Finder\Exception\NameIsReserved;
 use ReflectionClass;
 use const SORT_STRING;
+use function assert;
 use function get_declared_classes;
 use function in_array;
 use function is_dir;
@@ -53,7 +54,11 @@ abstract class Finder implements MigrationFinder
         $includedFiles = [];
         foreach ($files as $file) {
             static::requireOnce($file);
-            $includedFiles[] = realpath($file);
+
+            $realFile = realpath($file);
+            assert($realFile !== false);
+
+            $includedFiles[] = $realFile;
         }
 
         $classes  = $this->loadMigrationClasses($includedFiles, $namespace);

--- a/lib/Doctrine/Migrations/Generator/DiffGenerator.php
+++ b/lib/Doctrine/Migrations/Generator/DiffGenerator.php
@@ -111,7 +111,7 @@ class DiffGenerator
             foreach ($toSchema->getTables() as $table) {
                 $tableName = $table->getName();
 
-                if (preg_match($filterExpression, $this->resolveTableName($tableName))) {
+                if (preg_match($filterExpression, $this->resolveTableName($tableName)) === 1) {
                     continue;
                 }
 

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -19,12 +19,14 @@ use function array_keys;
 use function array_map;
 use function array_search;
 use function array_unshift;
+use function assert;
 use function class_exists;
 use function count;
 use function end;
 use function get_class;
 use function implode;
 use function is_array;
+use function is_int;
 use function ksort;
 use function sprintf;
 use function substr;
@@ -342,6 +344,8 @@ class MigrationRepository
         array_unshift($versions, '0');
 
         $offset = array_search($version, $versions, true);
+
+        assert($offset === false || is_int($offset));
 
         if ($offset === false || ! isset($versions[$offset + $delta])) {
             // Unknown version or delta out of bounds.

--- a/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -129,7 +129,7 @@ abstract class AbstractCommand extends Command
             );
         }
 
-        if ($this->migrationConfiguration === null && $this->configuration instanceof Configuration) {
+        if ($this->migrationConfiguration === null && $this->configuration !== null) {
             $this->migrationConfiguration = $this->configuration;
         }
 
@@ -174,9 +174,10 @@ abstract class AbstractCommand extends Command
 
     private function hasConfigurationHelper() : bool
     {
+        /** @var HelperSet|null $helperSet */
         $helperSet = $this->getHelperSet();
 
-        if (! $helperSet instanceof HelperSet) {
+        if ($helperSet === null) {
             return false;
         }
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -9,7 +9,9 @@ use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function assert;
 use function count;
+use function is_string;
 use function max;
 use function sprintf;
 use function str_repeat;
@@ -54,6 +56,8 @@ EOT
         $infos = $this->dependencyFactory->getMigrationStatusInfosHelper();
 
         foreach ($infos->getMigrationsInfos() as $name => $value) {
+            assert(is_string($name));
+
             $string = (string) $value;
 
             if ($name === 'New Migrations') {

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -136,7 +136,7 @@ EOT
             );
         }
 
-        if ($rangeFromOption !== null ^ $rangeToOption !== null) {
+        if ($rangeFromOption !== null xor $rangeToOption !== null) {
             throw InvalidOptionUsage::new(
                 'Options --range-to and --range-from should be used together.'
             );

--- a/lib/Doctrine/Migrations/Tools/Console/Exception/VersionAlreadyExists.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Exception/VersionAlreadyExists.php
@@ -12,6 +12,6 @@ final class VersionAlreadyExists extends InvalidArgumentException implements Con
 {
     public static function new(Version $version) : self
     {
-        return new self(sprintf('The version "%s" already exists in the version table.', $version));
+        return new self(sprintf('The version "%s" already exists in the version table.', $version->getVersion()));
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Exception/VersionDoesNotExist.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Exception/VersionDoesNotExist.php
@@ -12,6 +12,6 @@ final class VersionDoesNotExist extends InvalidArgumentException implements Cons
 {
     public static function new(Version $version) : self
     {
-        return new self(sprintf('The version "%s" does not exist in the version table.', $version));
+        return new self(sprintf('The version "%s" does not exist in the version table.', $version->getVersion()));
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationDirectoryHelper.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationDirectoryHelper.php
@@ -7,6 +7,7 @@ namespace Doctrine\Migrations\Tools\Console\Helper;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Tools\Console\Exception\DirectoryDoesNotExist;
 use const DIRECTORY_SEPARATOR;
+use function assert;
 use function date;
 use function file_exists;
 use function getcwd;
@@ -35,6 +36,9 @@ class MigrationDirectoryHelper
     {
         $dir = $this->configuration->getMigrationsDirectory();
         $dir = $dir ?? getcwd();
+
+        assert($dir !== false, 'Unable to determine current working directory.');
+
         $dir = rtrim($dir, '/');
 
         if (! file_exists($dir)) {

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -197,9 +197,9 @@ final class Executor implements ExecutorInterface
         $migration->{'pre' . ucfirst($direction)}($fromSchema);
 
         if ($direction === Direction::UP) {
-            $this->outputWriter->write("\n" . sprintf('  <info>++</info> migrating <comment>%s</comment>', $version) . "\n");
+            $this->outputWriter->write("\n" . sprintf('  <info>++</info> migrating <comment>%s</comment>', $version->getVersion()) . "\n");
         } else {
-            $this->outputWriter->write("\n" . sprintf('  <info>--</info> reverting <comment>%s</comment>', $version) . "\n");
+            $this->outputWriter->write("\n" . sprintf('  <info>--</info> reverting <comment>%s</comment>', $version->getVersion()) . "\n");
         }
 
         $version->setState(State::EXEC);
@@ -223,7 +223,7 @@ final class Executor implements ExecutorInterface
         } else {
             $this->outputWriter->write(sprintf(
                 '<error>Migration %s was executed but did not result in any SQL statements.</error>',
-                $version
+                $version->getVersion()
             ));
         }
 
@@ -306,7 +306,7 @@ final class Executor implements ExecutorInterface
     {
         $this->outputWriter->write(sprintf(
             '<error>Migration %s failed during %s. Error %s</error>',
-            $version,
+            $version->getVersion(),
             $version->getExecutionState(),
             $e->getMessage()
         ));

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,0 @@
-parameters:
-    ignoreErrors:
-        # Ignore proxy manager magic
-        - '#ProxyManager\\Proxy\\VirtualProxyInterface#'
-
-includes:
-    - vendor/phpstan/phpstan-phpunit/extension.neon
-    - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,6 @@ parameters:
 #'
 
 includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,13 @@
+parameters:
+    level: 7
+    paths:
+        - %currentWorkingDirectory%/lib
+    ignoreErrors:
+        # Ignore proxy manager magic
+        - '~ProxyManager\\Proxy\\VirtualProxyInterface~'
+        - '~Parameter #1 \$files of method Doctrine\\Migrations\\Finder\\Finder::loadMigrationClasses\(\) expects array<string>, array<int, string\|false> given~'
+#'
+
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/tests/Doctrine/Migrations/Tests/Configuration/JsonConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/JsonConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Configuration;
 
 use Doctrine\Migrations\Configuration\AbstractFileConfiguration;
+use Doctrine\Migrations\Configuration\Exception\JsonNotValid;
 use Doctrine\Migrations\Configuration\JsonConfiguration;
 use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\OutputWriter;
@@ -41,5 +42,12 @@ class JsonConfigurationTest extends AbstractConfigurationTest
         $this->expectExceptionMessage('Given config file does not exist');
 
         $config->load(__DIR__ . '/_files/none.json');
+    }
+
+    public function testInvalid() : void
+    {
+        $this->expectException(JsonNotValid::class);
+
+        $this->loadConfiguration('malformed');
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/XmlConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/XmlConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Configuration;
 
 use Doctrine\Migrations\Configuration\AbstractFileConfiguration;
+use Doctrine\Migrations\Configuration\Exception\XmlNotValid;
 use Doctrine\Migrations\Configuration\XmlConfiguration;
 use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\OutputWriter;
@@ -26,5 +27,12 @@ class XmlConfigurationTest extends AbstractConfigurationTest
         $configFileSuffix->load(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile);
 
         return $configFileSuffix;
+    }
+
+    public function testInvalid() : void
+    {
+        $this->expectException(XmlNotValid::class);
+
+        $this->loadConfiguration('malformed');
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/YamlConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/YamlConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Configuration;
 
 use Doctrine\Migrations\Configuration\AbstractFileConfiguration;
+use Doctrine\Migrations\Configuration\Exception\YamlNotValid;
 use Doctrine\Migrations\Configuration\YamlConfiguration;
 use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\OutputWriter;
@@ -26,5 +27,12 @@ class YamlConfigurationTest extends AbstractConfigurationTest
         $configFileSuffix->load(__DIR__ . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . $configFile);
 
         return $configFileSuffix;
+    }
+
+    public function testInvalid() : void
+    {
+        $this->expectException(YamlNotValid::class);
+
+        $this->loadConfiguration('malformed');
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_malformed.json
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_malformed.json
@@ -1,0 +1,1 @@
+{invalid json}

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_malformed.xml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_malformed.xml
@@ -1,0 +1,1 @@
+invalid xml

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_malformed.yml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_malformed.yml
@@ -1,0 +1,3 @@
+invalid:
+    - a
+  - b


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Update to PHPStan 0.10.

Slightly improved error handling in configuration loaders.

Added phpstan-deprecations-rules.
There are no errors currenty, but with symfony/symfony#27647, it will start reporting:
```
 ------ ------------------------------------------------------------------------------------ 
  Line   lib/Doctrine/Migrations/Configuration/Connection/Loader/ConnectionHelperLoader.php  
 ------ ------------------------------------------------------------------------------------ 
  30     Instantiation of deprecated class Symfony\Component\Console\Helper\HelperSet.       
 ------ ------------------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php                             
 ------ ---------------------------------------------------------------------------------------------- 
  115    Call to deprecated method getHelperSet() of class Symfony\Component\Console\Command\Command.  
  144    Call to deprecated method getHelper() of class Symfony\Component\Console\Command\Command.     
  178    Call to deprecated method getHelperSet() of class Symfony\Component\Console\Command\Command.  
  195    Call to deprecated method getHelperSet() of class Symfony\Component\Console\Command\Command.  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php                              
 ------ ------------------------------------------------------------------------------------------- 
  146    Call to deprecated method getHelper() of class Symfony\Component\Console\Command\Command.  
 ------ ------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------ 
  Line   lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php                                   
 ------ ------------------------------------------------------------------------------------------ 
  43     Call to deprecated method setHelperSet() of class Symfony\Component\Console\Application.  
  64     Call to deprecated method getHelperSet() of class Symfony\Component\Console\Application.  
 ------ ------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
  Line   lib/Doctrine/Migrations/Tools/Console/Helper/ConfigurationHelper.php                                                                  
 ------ -------------------------------------------------------------------------------------------------------------------------------------- 
  23     Class Doctrine\Migrations\Tools\Console\Helper\ConfigurationHelper extends deprecated class Symfony\Component\Console\Helper\Helper.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 9 errors
```