### PR TITLE
Fix: No need to update composer itself twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ cache:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
-  - travis_retry composer self-update
 
 install:
   - rm composer.lock


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

This PR

* [x] removes a redundant run of `composer self-update` on Travis

💁‍♂️ For reference, see

* https://travis-ci.org/doctrine/migrations/jobs/396429439#L473-L476
* https://travis-ci.org/doctrine/migrations/jobs/396429439#L501-L502