### PR TITLE
Passing custom AbstractMigration class through CLI --parent

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -71,6 +71,7 @@ abstract class AbstractCommand extends Command
     {
         $this->addOption('configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a migrations configuration file.');
         $this->addOption('db-configuration', null, InputOption::VALUE_OPTIONAL, 'The path to a database connection configuration file.');
+        $this->addOption('parent', null, InputOption::VALUE_OPTIONAL, 'Full namespace path to the abstract migration class.', 'Doctrine\DBAL\Migrations\AbstractMigration');
     }
 
     protected function outputHeader(Configuration $configuration, OutputInterface $output)

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -42,13 +42,13 @@ class GenerateCommand extends AbstractCommand
 
 namespace <namespace>;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
+use <parent_class_full>;
 use Doctrine\DBAL\Schema\Schema;
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version<version> extends AbstractMigration
+class Version<version> extends <parent_class>
 {
     /**
      * @param Schema $schema
@@ -107,17 +107,24 @@ EOT
 
     protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
     {
+
+        $parentClass = $input->getOption('parent');
+
         $placeHolders = [
             '<namespace>',
             '<version>',
             '<up>',
             '<down>',
+            '<parent_class_full>',
+            '<parent_class>'
         ];
         $replacements = [
             $configuration->getMigrationsNamespace(),
             $version,
             $up ? "        " . implode("\n        ", explode("\n", $up)) : null,
-            $down ? "        " . implode("\n        ", explode("\n", $down)) : null
+            $down ? "        " . implode("\n        ", explode("\n", $down)) : null,
+            $parentClass,
+            end( explode('\\', $parentClass ) )
         ];
         $code = str_replace($placeHolders, $replacements, $this->getTemplate());
         $code = preg_replace('/^ +$/m', '', $code);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary
This comment allows passing --parent CLI parameter to migrations:generate.
In this argument you are defining the full name of the class, which will be used as the parent one for all migrations instead of the default one 'Doctrine\DBAL\Migrations\AbstractMigration'.

I'm working with PHP 5.6, hence I did it on the branch based on v1.5.0, but you may want to integrate it to the next release. If you are interested in having it, I could find out how to set the custom class in config files, eg xml. Otherwise I'm happy to leave it as it is for my use.

I created the sample project using this feature in jszoja/multidb-doctrine-migrations.
Thank for your time.


