### PR TITLE
workaround for libXML bug - https://bugs.php.net/bug.php?id=62577

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
@@ -11,9 +11,10 @@ use SimpleXMLElement;
 use const DIRECTORY_SEPARATOR;
 use const LIBXML_NOCDATA;
 use function assert;
+use function file_get_contents;
 use function libxml_clear_errors;
 use function libxml_use_internal_errors;
-use function simplexml_load_file;
+use function simplexml_load_string;
 
 /**
  * The XmlConfiguration class is responsible for loading migration configuration information from a XML file.
@@ -41,8 +42,10 @@ class XmlConfiguration extends AbstractFileConfiguration
             throw XmlNotValid::failedValidation();
         }
 
-        $xml = simplexml_load_file($file, SimpleXMLElement::class, LIBXML_NOCDATA);
+        $rawXML = file_get_contents($file);
+        assert($rawXML !== false);
 
+        $xml = simplexml_load_string($rawXML, SimpleXMLElement::class, LIBXML_NOCDATA);
         assert($xml !== false);
 
         $config = [];


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

If libxml_disable_entity_loader(true), simplexml_load_file() fails;
this avoids the limitation by avoiding file operations in libXML.

The only difference here is that the file operations are done via file_get_contents() and the resulting string is passed to simplexml_load_string() from PHP, instead of simplexml_load_file() doing these two things internally.

