### PR TITLE
CI: Test against PHP 7.4snapshot instead of nightly (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - nightly
+  - 7.4snapshot
 
 cache:
   directories:
@@ -24,7 +24,7 @@ script:
 
 jobs:
   allow_failures:
-    - php: nightly
+    - php: 7.4snapshot
 
   include:
     - stage: Test


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement

#### Summary

Since PHP 7.4 was branched off recently, `nightly` is now PHP 8.0-dev and PHP 7.4 is not tested against.
This way we get rid of unreachable PHP 8.0 target and get the code tested against PHP 7.4-dev instead.