### PR TITLE
Support multiple versions in ExecuteCommand

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -31,7 +31,7 @@ class ExecuteCommandTest extends TestCase
 
         $input->expects(self::once())
             ->method('getArgument')
-            ->with('version')
+            ->with('versions')
             ->willReturn($versionName);
 
         $input->expects(self::at(3))
@@ -66,7 +66,7 @@ class ExecuteCommandTest extends TestCase
 
         $input->expects(self::once())
             ->method('getArgument')
-            ->with('version')
+            ->with('versions')
             ->willReturn($versionName);
 
         $input->expects(self::at(3))
@@ -101,7 +101,7 @@ class ExecuteCommandTest extends TestCase
 
         $input->expects(self::once())
             ->method('getArgument')
-            ->with('version')
+            ->with('versions')
             ->willReturn($versionName);
 
         $input->expects(self::at(1))
@@ -146,7 +146,7 @@ class ExecuteCommandTest extends TestCase
 
         $input->expects(self::once())
             ->method('getArgument')
-            ->with('version')
+            ->with('versions')
             ->willReturn($versionName);
 
         $input->expects(self::at(1))


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | 

#### Summary

I have a use-case where I need to run many migration versions at once but need to specify them all manually. I can't simply run all until the last migration in the list because some existing migrations might be missing in the list I need to run.

Running them all using the execute command one-by-one is slow because of the overhead of running the command so I'm using a custom command to run multiple specific versions at once. With this PR I could get rid of the customized command in the future.
