### PR TITLE
Commands: allow to reset migrationConfiguration property and reuse the same Command

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -37,7 +37,7 @@ abstract class AbstractCommand extends Command
      * The migrationConfiguration property contains the configuration
      * created taking into account the command line options.
      *
-     * @var Configuration
+     * @var Configuration|null
      */
     private $migrationConfiguration;
 
@@ -71,6 +71,9 @@ abstract class AbstractCommand extends Command
     public function setMigrationConfiguration(Configuration $config)
     {
         $this->configuration = $config;
+
+        // Drop to allow reconfiguring
+        $this->migrationConfiguration = null;
     }
 
     /**


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

After pull request #219 the method setMigrationConfiguration changes nothing when migrationConfiguration was initialized
So we can't reset migrationConfiguration after first run in the same process
This change allows to re-use migration commands whith another configuration on the same PHP process