### PR TITLE
don't run with 64-bit data on 32-bit build

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Tools/BytesFormatterTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/BytesFormatterTest.php
@@ -14,7 +14,9 @@ class BytesFormatterTest extends TestCase
         self::assertSame('1000', BytesFormatter::formatBytes(1000));
         self::assertSame('97.66K', BytesFormatter::formatBytes(100000));
         self::assertSame('9.54M', BytesFormatter::formatBytes(10000000));
-        self::assertSame('93.13G', BytesFormatter::formatBytes(100000000000));
-        self::assertSame('90.95T', BytesFormatter::formatBytes(100000000000000));
+        if (PHP_INT_SIZE > 4) {
+            self::assertSame('93.13G', BytesFormatter::formatBytes(100000000000));
+            self::assertSame('90.95T', BytesFormatter::formatBytes(100000000000000));
+        }
     }
 }


### PR DESCRIPTION
ON 32-bit computer

```
There was 1 error:
1) Doctrine\Migrations\Tests\Tools\BytesFormatterTest::testFormatBytes
TypeError: Argument 1 passed to Doctrine\Migrations\Tools\BytesFormatter::formatBytes() must be of the type int, float given, called in /builddir/build/BUILD/migrations-0101f5bd7f4e5043bf8630db2930f8fd7da552b6/tests/Doctrine/Migrations/Tests/Tools/BytesFormatterTest.php on line 17
/builddir/build/BUILDROOT/php-doctrine-migrations-2.0.0-1.fc31.noarch/usr/share/php/Doctrine/Migrations/Tools/BytesFormatter.php:20
/builddir/build/BUILD/migrations-0101f5bd7f4e5043bf8630db2930f8fd7da552b6/tests/Doctrine/Migrations/Tests/Tools/BytesFormatterTest.php:17

```