### PR TITLE
allow "float" in formatBytes to work on 32-bit computers

### DIFF
--- a/lib/Doctrine/Migrations/Tools/BytesFormatter.php
+++ b/lib/Doctrine/Migrations/Tools/BytesFormatter.php
@@ -17,7 +17,7 @@ use function round;
  */
 final class BytesFormatter
 {
-    public static function formatBytes(int $size, int $precision = 2) : string
+    public static function formatBytes(float $size, int $precision = 2) : string
     {
         $base     = log($size, 1024);
         $suffixes = ['', 'K', 'M', 'G', 'T'];


### PR DESCRIPTION
Alternative to pr #802 which could be better.

As float also allow int, I don't think this is a BC break, especially as the class is final