### PR TITLE
Fix for referencing tables created during a dry run

### DIFF
--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -179,6 +179,13 @@ class Migrator
             foreach ($migrationsToExecute as $version) {
                 $versionExecutionResult = $version->execute($direction, $migratorConfiguration);
 
+                // capture the to Schema for the migration so we have the ability to use
+                // it as the from Schema for the next migration when we are running a dry run
+                // $toSchema may be null in the case of skipped migrations
+                if (! $versionExecutionResult->isSkipped()) {
+                    $migratorConfiguration->setFromSchema($versionExecutionResult->getToSchema());
+                }
+
                 $sql[$version->getVersion()] = $versionExecutionResult->getSql();
                 $time                       += $versionExecutionResult->getTime();
             }

--- a/lib/Doctrine/Migrations/MigratorConfiguration.php
+++ b/lib/Doctrine/Migrations/MigratorConfiguration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+use Doctrine\DBAL\Schema\Schema;
+
 /**
  * The MigratorConfiguration class is responsible for defining the configuration for a migration.
  *
@@ -25,6 +27,9 @@ class MigratorConfiguration
 
     /** @var bool */
     private $allOrNothing = false;
+
+    /** @var Schema|null */
+    private $fromSchema;
 
     public function isDryRun() : bool
     {
@@ -70,6 +75,18 @@ class MigratorConfiguration
     public function setAllOrNothing(bool $allOrNothing) : self
     {
         $this->allOrNothing = $allOrNothing;
+
+        return $this;
+    }
+
+    public function getFromSchema() : ?Schema
+    {
+        return $this->fromSchema;
+    }
+
+    public function setFromSchema(Schema $fromSchema) : self
+    {
+        $this->fromSchema = $fromSchema;
 
         return $this;
     }

--- a/lib/Doctrine/Migrations/Version/ExecutionResult.php
+++ b/lib/Doctrine/Migrations/Version/ExecutionResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Version;
 
+use Doctrine\DBAL\Schema\Schema;
+use RuntimeException;
 use Throwable;
 use function count;
 
@@ -37,6 +39,9 @@ class ExecutionResult
 
     /** @var Throwable|null */
     private $exception;
+
+    /** @var Schema|null */
+    private $toSchema;
 
     /**
      * @param string[] $sql
@@ -151,5 +156,19 @@ class ExecutionResult
     public function getException() : ?Throwable
     {
         return $this->exception;
+    }
+
+    public function setToSchema(Schema $toSchema) : void
+    {
+        $this->toSchema = $toSchema;
+    }
+
+    public function getToSchema() : Schema
+    {
+        if ($this->toSchema === null) {
+            throw new RuntimeException('Cannot call getToSchema() when toSchema is null.');
+        }
+
+        return $this->toSchema;
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -200,7 +200,13 @@ class FunctionalTest extends MigrationTestCase
         $migrator = $this->createTestMigrator($this->config);
         $migrator->migrate('2', $migratorConfiguration);
 
-        $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
+        $schema = $migratorConfiguration->getFromSchema();
+
+        self::assertInstanceOf(Schema::class, $schema);
+        self::assertTrue($schema->hasTable('foo'));
+
+        $table = $schema->getTable('foo');
+        self::assertTrue($table->hasColumn('bar'));
     }
 
     public function testMigrateDownSeveralSteps() : void

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -19,6 +19,8 @@ use Doctrine\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\Migrations\Stopwatch;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tests\Stub\EventVerificationListener;
+use Doctrine\Migrations\Tests\Stub\Functional\DryRun\DryRun1;
+use Doctrine\Migrations\Tests\Stub\Functional\DryRun\DryRun2;
 use Doctrine\Migrations\Tests\Stub\Functional\MigrateAddSqlPostAndPreUpAndDownTest;
 use Doctrine\Migrations\Tests\Stub\Functional\MigrateAddSqlTest;
 use Doctrine\Migrations\Tests\Stub\Functional\MigrateNotTouchingTheSchema;
@@ -185,6 +187,20 @@ class FunctionalTest extends MigrationTestCase
         self::assertFalse($migrations['1']->isMigrated());
         self::assertFalse($migrations['2']->isMigrated());
         self::assertFalse($migrations['3']->isMigrated());
+    }
+
+    public function testDryRunWithTableCreatedWithSchemaInFirstMigration() : void
+    {
+        $this->config->registerMigration('1', DryRun1::class);
+        $this->config->registerMigration('2', DryRun2::class);
+
+        $migratorConfiguration = (new MigratorConfiguration())
+            ->setDryRun(true);
+
+        $migrator = $this->createTestMigrator($this->config);
+        $migrator->migrate('2', $migratorConfiguration);
+
+        $schema = $this->config->getConnection()->getSchemaManager()->createSchema();
     }
 
     public function testMigrateDownSeveralSteps() : void

--- a/tests/Doctrine/Migrations/Tests/Stub/Functional/DryRun/DryRun1.php
+++ b/tests/Doctrine/Migrations/Tests/Stub/Functional/DryRun/DryRun1.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Stub\Functional\DryRun;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class DryRun1 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $table = $schema->createTable('foo');
+        $table->addColumn('id', 'integer');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $schema->dropTable('foo');
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Stub/Functional/DryRun/DryRun2.php
+++ b/tests/Doctrine/Migrations/Tests/Stub/Functional/DryRun/DryRun2.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Stub\Functional\DryRun;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class DryRun2 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $table = $schema->getTable('foo');
+        $table->addColumn('bar', 'string', ['notnull' => false]);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $table = $schema->getTable('foo');
+        $table->dropColumn('bar');
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutionResultTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutionResultTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests\Version;
 
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Version\ExecutionResult;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 class ExecutionResultTest extends TestCase
 {
@@ -93,6 +95,23 @@ class ExecutionResultTest extends TestCase
         $this->versionExecutionResult->setException($exception);
 
         self::assertSame($exception, $this->versionExecutionResult->getException());
+    }
+
+    public function testToSchema() : void
+    {
+        $toSchema = $this->createMock(Schema::class);
+
+        $this->versionExecutionResult->setToSchema($toSchema);
+
+        self::assertSame($toSchema, $this->versionExecutionResult->getToSchema());
+    }
+
+    public function testToSchemaThrowsRuntimExceptionWhenToSchemaIsNull() : void
+    {
+        self::expectException(RuntimeException::class);
+        self::expectExceptionMessage('Cannot call getToSchema() when toSchema is null.');
+
+        $this->versionExecutionResult->getToSchema();
     }
 
     protected function setUp() : void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #806 

#### Summary

When you execute a dry run of a migration, you cannot reference tables created in earlier migrations in later migrations due to the from Schema always being fetched from the current state of the database. Since it is a dry run, nothing is committed to the database. The fix is to use the same `Schema` object throughout the whole chain of migrations when executing a dry run.

Added a test to cover this scenario that fails before the fix:

```
1) Doctrine\Migrations\Tests\Functional\FunctionalTest::testDryRunWithTableCreatedWithSchemaInFirstMigration
Doctrine\DBAL\Schema\SchemaException: There is no table with name 'public.foo' in the schema.
/home/travis/build/doctrine/migrations/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/SchemaException.php:30
/home/travis/build/doctrine/migrations/vendor/doctrine/dbal/lib/Doctrine/DBAL/Schema/Schema.php:168
/home/travis/build/doctrine/migrations/tests/Doctrine/Migrations/Tests/Stub/Functional/DryRun/DryRun2.php:14
/home/travis/build/doctrine/migrations/lib/Doctrine/Migrations/Version/Executor.php:209
/home/travis/build/doctrine/migrations/lib/Doctrine/Migrations/Version/Executor.php:131
/home/travis/build/doctrine/migrations/lib/Doctrine/Migrations/Version/Version.php:187
/home/travis/build/doctrine/migrations/lib/Doctrine/Migrations/Migrator.php:180
/home/travis/build/doctrine/migrations/lib/Doctrine/Migrations/Migrator.php:144
/home/travis/build/doctrine/migrations/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php:201
```