### PR TITLE
Make migration class final by default in custom_template tests

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/_files/migration.tpl
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/_files/migration.tpl
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 /**
 * Auto-generated Migration: Please modify to your needs!
 */
-class Version<version> extends AbstractMigration
+final class Version<version> extends AbstractMigration
 {
     public function up(Schema $schema)
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

It's a good habbit to make everything final by default. 