### PR TITLE
Fixed event that was firing twice when it should only fire once.

### DIFF
--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -160,8 +160,6 @@ class Migrator
     ) : array {
         $dryRun = $migratorConfiguration->isDryRun();
 
-        $this->configuration->dispatchMigrationEvent(Events::onMigrationsMigrating, $direction, $dryRun);
-
         $connection = $this->configuration->getConnection();
 
         $allOrNothing = $migratorConfiguration->isAllOrNothing();

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -483,6 +483,7 @@ class FunctionalTest extends MigrationTestCase
             Events::onMigrationsVersionExecuting,
             Events::onMigrationsVersionExecuted,
         ] as $eventName) {
+            self::assertCount(1, $listener->events[$eventName]);
             self::assertArrayHasKey($eventName, $listener->events);
         }
     }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #814

#### Summary

The `onMigrationsMigrating` event was firing twice when it should only fire once.