### PR TITLE
Generator Template: Accept Properties

### DIFF
--- a/lib/Doctrine/Migrations/Generator/Generator.php
+++ b/lib/Doctrine/Migrations/Generator/Generator.php
@@ -39,6 +39,8 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version<version> extends AbstractMigration
 {
+<properties>
+
     public function getDescription() : string
     {
         return '';
@@ -73,13 +75,15 @@ TEMPLATE;
     public function generateMigration(
         string $version,
         ?string $up = null,
-        ?string $down = null
+        ?string $down = null,
+        ?string $properties = null
     ) : string {
         $placeHolders = [
             '<namespace>',
             '<version>',
             '<up>',
             '<down>',
+            '<properties>',
         ];
 
         $replacements = [
@@ -87,6 +91,7 @@ TEMPLATE;
             $version,
             $up !== null ? '        ' . implode("\n        ", explode("\n", $up)) : null,
             $down !== null ? '        ' . implode("\n        ", explode("\n", $down)) : null,
+            $properties !== null ? '    ' . implode("\n    ", explode("\n", $properties)) : null,
         ];
 
         $code = str_replace($placeHolders, $replacements, $this->getTemplate());


### PR DESCRIPTION
### Feature Request

|    Q        |   A
|------------ | ------
| New Feature | yes
| RFC         | yes
| BC Break    | no

#### Summary

My company and I are currently implementing this doctrine migrations library and have set it up such that we can pass a custom option to our custom generate command to use different default <up> and <down> content based off of the parameter given. However along these same lines we've found the need to pass in along default properties to the generated migration version.

This could be worked around (at my work I can just write my own Generator.php file that my custom generator command uses for now) but I thought this would be fairly simple to implement and could be beneficial for anybody else looking to use their own customizable templates.