### PR TITLE
return annotation for Configuration::getMigratedVersions is fixed

### DIFF
--- a/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/DBAL/Migrations/Configuration/Configuration.php
@@ -544,7 +544,7 @@ class Configuration
     /**
      * Returns all migrated versions from the versions table, in an array.
      *
-     * @return Version[]
+     * @return string[]
      */
     public function getMigratedVersions()
     {

--- a/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
+++ b/lib/Doctrine/DBAL/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Migrations\Version;
 
 class MigrationStatusInfosHelper
 {
-    /** @var Version[] */
+    /** @var string[] */
     private $executedMigrations;
 
     /** @var Version[] */

--- a/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
+++ b/tests/Doctrine/DBAL/Migrations/Tests/VersionTest.php
@@ -164,10 +164,10 @@ class VersionTest extends MigrationTestCase
      */
     public function testGetExecutionState($state)
     {
-        $configuration     = new Configuration($this->getSqliteConnection());
-        $version           = new Version(
+        $configuration   = new Configuration($this->getSqliteConnection());
+        $version         = new Version(
             $configuration,
-            $versionName   = '003',
+            $versionName = '003',
             VersionDummy::class
         );
         $reflectionVersion = new \ReflectionClass(Version::class);
@@ -370,7 +370,7 @@ class VersionTest extends MigrationTestCase
             $versionName = '005',
             VersionOutputSql::class
         );
-        $path            = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations';
+        $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'migrations';
 
         $version->writeSqlFile($path, $direction);
 


### PR DESCRIPTION
- https://github.com/doctrine/migrations/blob/master/lib/Doctrine/Migrations/Configuration/Configuration.php#L414

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | in 1.x version there is wrong return type annotation which can mislead developers. In last 2.x version this is fixed.

#### Summary

<!-- Provide a summary your change. -->
return type annotation for Configuration::getMigratedVersions was corrected from `Version[]` into `string[]`