### PR TITLE
Fix XML configuration support for custom templates

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/XML/configuration.xsd
+++ b/lib/Doctrine/Migrations/Configuration/XML/configuration.xsd
@@ -7,6 +7,7 @@
         <xs:complexType>
             <xs:all minOccurs="0">
                 <xs:element type="xs:string" name="name" minOccurs="0" maxOccurs="1"/>
+                <xs:element type="xs:string" name="custom-template" minOccurs="0" maxOccurs="1"/>
                 <xs:element type="xs:string" name="migrations-namespace" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="table" minOccurs="0" maxOccurs="1">
                     <xs:complexType>

--- a/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/XmlConfiguration.php
@@ -54,6 +54,10 @@ class XmlConfiguration extends AbstractFileConfiguration
             $config['name'] = (string) $xml->name;
         }
 
+        if (isset($xml->{'custom-template'})) {
+            $config['custom_template'] = (string) $xml->{'custom-template'};
+        }
+
         if (isset($xml->table['name'])) {
             $config['table_name'] = (string) $xml->table['name'];
         }

--- a/tests/Doctrine/Migrations/Tests/Configuration/AbstractConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/AbstractConfigurationTest.php
@@ -131,6 +131,13 @@ abstract class AbstractConfigurationTest extends MigrationTestCase
         $this->loadConfiguration('organize_invalid');
     }
 
+    public function testCustomTemplate() : void
+    {
+        $config = $this->loadConfiguration('custom_template');
+
+        self::assertSame('template.tpl', $config->getCustomTemplate());
+    }
+
     public function testVersionsOrganizationIncompatibleFinder() : void
     {
         $this->expectException(MigrationException::class);

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.json
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.json
@@ -1,0 +1,3 @@
+{
+  "custom_template" : "template.tpl"
+}

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return ['custom_template' => 'template.tpl'];

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.xml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration
+                    http://doctrine-project.org/schemas/migrations/configuration.xsd">
+
+    <custom-template>template.tpl</custom-template>
+</doctrine-migrations>

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.yml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_custom_template.yml
@@ -1,0 +1,2 @@
+---
+custom_template: "template.tpl"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug (can be seen as a feature but we just forgot it for XML)
| BC Break     | no

#### Summary

This functionality has been added on previous versions but it seems we forgot to expose the configuration options for XML.
