### PR TITLE
Display descriptions while migrating

### DIFF
--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -197,11 +197,7 @@ final class Executor implements ExecutorInterface
 
         $migration->{'pre' . ucfirst($direction)}($fromSchema);
 
-        if ($direction === Direction::UP) {
-            $this->outputWriter->write("\n" . sprintf('  <info>++</info> migrating <comment>%s</comment>', $version->getVersion()) . "\n");
-        } else {
-            $this->outputWriter->write("\n" . sprintf('  <info>--</info> reverting <comment>%s</comment>', $version->getVersion()) . "\n");
-        }
+        $this->outputWriter->write("\n" . $this->getMigrationHeader($version, $migration, $direction) . "\n");
 
         $version->setState(State::EXEC);
 
@@ -272,6 +268,22 @@ final class Executor implements ExecutorInterface
         );
 
         return $versionExecutionResult;
+    }
+
+    private function getMigrationHeader(Version $version, AbstractMigration $migration, string $direction) : string
+    {
+        $versionInfo = $version->getVersion();
+        $description = $migration->getDescription();
+
+        if ($description !== '') {
+            $versionInfo .= ' (' . $description . ')';
+        }
+
+        if ($direction === Direction::UP) {
+            return sprintf('  <info>++</info> migrating <comment>%s</comment>', $versionInfo);
+        }
+
+        return sprintf('  <info>--</info> reverting <comment>%s</comment>', $versionInfo);
     }
 
     private function skipMigration(

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -62,29 +62,6 @@ class ExecutorTest extends TestCase
 
     public function testExecuteUp() : void
     {
-        $platform = $this->createMock(AbstractPlatform::class);
-
-        $this->connection->expects(self::once())
-            ->method('getDatabasePlatform')
-            ->willReturn($platform);
-
-        $stopwatchEvent = $this->createMock(StopwatchEvent::class);
-
-        $this->stopwatch->expects(self::any())
-            ->method('start')
-            ->willReturn($stopwatchEvent);
-
-        $stopwatchEvent->expects(self::any())
-            ->method('stop');
-
-        $stopwatchEvent->expects(self::any())
-            ->method('getDuration')
-            ->willReturn(100);
-
-        $stopwatchEvent->expects(self::any())
-            ->method('getMemory')
-            ->willReturn(100);
-
         $this->outputWriter->expects(self::at(0))
             ->method('write')
             ->with("\n  <info>++</info> migrating <comment>001</comment>\n");
@@ -132,23 +109,6 @@ class ExecutorTest extends TestCase
 
     public function testExecuteDown() : void
     {
-        $stopwatchEvent = $this->createMock(StopwatchEvent::class);
-
-        $this->stopwatch->expects(self::any())
-            ->method('start')
-            ->willReturn($stopwatchEvent);
-
-        $stopwatchEvent->expects(self::any())
-            ->method('stop');
-
-        $stopwatchEvent->expects(self::any())
-            ->method('getDuration')
-            ->willReturn(100);
-
-        $stopwatchEvent->expects(self::any())
-            ->method('getMemory')
-            ->willReturn(100);
-
         $this->outputWriter->expects(self::at(0))
             ->method('write')
             ->with("\n  <info>--</info> reverting <comment>001</comment>\n");
@@ -216,6 +176,10 @@ class ExecutorTest extends TestCase
             ->method('getConnection')
             ->willReturn($this->connection);
 
+        $this->connection->expects(self::any())
+            ->method('getDatabasePlatform')
+            ->willReturn($this->createMock(AbstractPlatform::class));
+
         $this->version = new Version(
             $this->configuration,
             '001',
@@ -224,6 +188,23 @@ class ExecutorTest extends TestCase
         );
 
         $this->migration = new VersionExecutorTestMigration($this->version);
+
+        $stopwatchEvent = $this->createMock(StopwatchEvent::class);
+
+        $this->stopwatch->expects(self::any())
+            ->method('start')
+            ->willReturn($stopwatchEvent);
+
+        $stopwatchEvent->expects(self::any())
+            ->method('stop');
+
+        $stopwatchEvent->expects(self::any())
+            ->method('getDuration')
+            ->willReturn(100);
+
+        $stopwatchEvent->expects(self::any())
+            ->method('getMemory')
+            ->willReturn(100);
     }
 }
 
@@ -240,6 +221,21 @@ class VersionExecutorTestMigration extends AbstractMigration
 
     /** @var bool */
     public $postDownExecuted = false;
+
+    /** @var string */
+    private $description;
+
+    public function __construct(Version $version, string $description = '')
+    {
+        parent::__construct($version);
+
+        $this->description = $description;
+    }
+
+    public function getDescription() : string
+    {
+        return $this->description;
+    }
 
     public function preUp(Schema $fromSchema) : void
     {

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -107,6 +107,26 @@ class ExecutorTest extends TestCase
         self::assertFalse($this->migration->postDownExecuted);
     }
 
+    /**
+     * @test
+     */
+    public function executeUpShouldAppendDescriptionWhenItIsNotEmpty() : void
+    {
+        $this->outputWriter->expects(self::at(0))
+            ->method('write')
+            ->with("\n  <info>++</info> migrating <comment>001 (testing)</comment>\n");
+
+        $migratorConfiguration = (new MigratorConfiguration())
+            ->setTimeAllQueries(true);
+
+        $this->versionExecutor->execute(
+            $this->version,
+            new VersionExecutorTestMigration($this->version, 'testing'),
+            Direction::UP,
+            $migratorConfiguration
+        );
+    }
+
     public function testExecuteDown() : void
     {
         $this->outputWriter->expects(self::at(0))
@@ -152,6 +172,26 @@ class ExecutorTest extends TestCase
         self::assertFalse($this->migration->postUpExecuted);
         self::assertTrue($this->migration->preDownExecuted);
         self::assertTrue($this->migration->postDownExecuted);
+    }
+
+    /**
+     * @test
+     */
+    public function executeDownShouldAppendDescriptionWhenItIsNotEmpty() : void
+    {
+        $this->outputWriter->expects(self::at(0))
+            ->method('write')
+            ->with("\n  <info>--</info> reverting <comment>001 (testing)</comment>\n");
+
+        $migratorConfiguration = (new MigratorConfiguration())
+            ->setTimeAllQueries(true);
+
+        $this->versionExecutor->execute(
+            $this->version,
+            new VersionExecutorTestMigration($this->version, 'testing'),
+            Direction::DOWN,
+            $migratorConfiguration
+        );
     }
 
     protected function setUp() : void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

This makes the migration descriptions a bit more useful, by appending it to the version number in the log.
