### PR TITLE
[DOCS] Added use statement for `Events`

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -20,6 +20,7 @@ listens for all possible migrations events.
     use Doctrine\Common\EventSubscriber;
     use Doctrine\Migrations\Event\MigrationsEventArgs;
     use Doctrine\Migrations\Event\MigrationsVersionEventArgs;
+    use Doctrine\Migrations\Events;
 
     class MigrationsListener implements EventSubscriber
     {


### PR DESCRIPTION
To clarify the usage example

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary

In the example in the docs the 'use statement' for the used class `Events` was missing.
