### PR TITLE
Lazy console commands

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -22,6 +22,9 @@ use function sprintf;
  */
 class DiffCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:diff';
+
     /** @var SchemaProviderInterface|null */
     protected $schemaProvider;
 
@@ -37,7 +40,6 @@ class DiffCommand extends AbstractCommand
         parent::configure();
 
         $this
-            ->setName('migrations:diff')
             ->setAliases(['diff'])
             ->setDescription('Generate a migration by comparing your current database to your mapping information.')
             ->setHelp(<<<EOT

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -19,12 +19,14 @@ use function sprintf;
  */
 class DumpSchemaCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:dump-schema';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('migrations:dump-schema')
             ->setAliases(['dump-schema'])
             ->setDescription('Dump the schema for your database to a migration.')
             ->setHelp(<<<EOT

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -17,10 +17,12 @@ use function getcwd;
  */
 class ExecuteCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:execute';
+
     protected function configure() : void
     {
         $this
-            ->setName('migrations:execute')
             ->setAliases(['execute'])
             ->setDescription(
                 'Execute a single migration version up or down manually.'

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -14,10 +14,12 @@ use function sprintf;
  */
 class GenerateCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:generate';
+
     protected function configure() : void
     {
         $this
-            ->setName('migrations:generate')
             ->setAliases(['generate'])
             ->setDescription('Generate a blank migration class.')
             ->addOption(

--- a/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
@@ -13,10 +13,12 @@ use function sprintf;
  */
 class LatestCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:latest';
+
     protected function configure() : void
     {
         $this
-            ->setName('migrations:latest')
             ->setAliases(['latest'])
             ->setDescription('Outputs the latest version number');
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -22,10 +22,12 @@ use function substr;
  */
 class MigrateCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:migrate';
+
     protected function configure() : void
     {
         $this
-            ->setName('migrations:migrate')
             ->setAliases(['migrate'])
             ->setDescription(
                 'Execute a migration to a specified version or the latest available version.'

--- a/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
@@ -14,12 +14,14 @@ use function sprintf;
  */
 class RollupCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:rollup';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('migrations:rollup')
             ->setAliases(['rollup'])
             ->setDescription('Rollup migrations by deleting all tracked versions and insert the one version that exists.')
             ->setHelp(<<<EOT

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -23,10 +23,12 @@ use function strlen;
  */
 class StatusCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:status';
+
     protected function configure() : void
     {
         $this
-            ->setName('migrations:status')
             ->setAliases(['status'])
             ->setDescription('View the status of a set of migrations.')
             ->addOption(

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -16,10 +16,12 @@ use function sprintf;
  */
 class UpToDateCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:up-to-date';
+
     protected function configure() : void
     {
         $this
-            ->setName('migrations:up-to-date')
             ->setAliases(['up-to-date'])
             ->setDescription('Tells you if your schema is up-to-date.')
             ->addOption('fail-on-unregistered', 'u', InputOption::VALUE_NONE, 'Whether to fail when there are unregistered extra migrations found')

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -19,13 +19,15 @@ use function sprintf;
  */
 class VersionCommand extends AbstractCommand
 {
+    /** @var string */
+    protected static $defaultName = 'migrations:version';
+
     /** @var bool */
     private $markMigrated;
 
     protected function configure() : void
     {
         $this
-            ->setName('migrations:version')
             ->setAliases(['version'])
             ->setDescription('Manually add and delete migration versions from the version table.')
             ->addArgument(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Since Symfony `3.4` console commands can be lazy thanks to [a static name property](https://github.com/symfony/symfony/pull/23887).
This change does not break BC because the BC layer is already [in the base command's constructor](https://github.com/symfony/symfony/pull/23887/files#diff-8e80595663798837db1b033187835535R75).