### PR TITLE
Add option allow-empty-diff for diff command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ phpunit.xml
 /.phpcs-cache
 /box.phar
 /box.json
+
+# Please don't add your IDE's files here, use global gitignore instead.

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -59,7 +59,7 @@ class MigrateCommand extends AbstractCommand
                 'allow-no-migration',
                 null,
                 InputOption::VALUE_NONE,
-                'Don\'t throw an exception if no migration is available (CI).'
+                'Do not throw an exception if no migration is available.'
             )
             ->addOption(
                 'all-or-nothing',

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -49,10 +49,15 @@ final class DiffCommandTest extends TestCase
 
         $input->expects(self::at(3))
             ->method('getOption')
-            ->with('check-database-platform')
+            ->with('allow-empty-diff')
             ->willReturn(true);
 
         $input->expects(self::at(4))
+            ->method('getOption')
+            ->with('check-database-platform')
+            ->willReturn(true);
+
+        $input->expects(self::at(5))
             ->method('getOption')
             ->with('editor-cmd')
             ->willReturn('mate');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #833

#### Summary

`--allow-no-diff` is new option for `DiffCommand`, it allow to display a message instead of an Exception when there's no changes in mapping information.
