### PR TITLE
Fixed default name in the documentation: Doctrine Database Migrations

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -90,29 +90,29 @@ Please note that if you want to use the YAML configuration option, you will need
 
 Here are details about what each configuration option does:
 
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| Name                       | Required    | Default                    | Description                                                                      |
-+============================+=============+============================+==================================================================================+
-| name                       | no          | Doctrine Migrations        | The name that shows at the top of the migrations console application.            |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| migrations_namespace       | yes         | null                       | The PHP namespace your migration classes are located under.                      |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| table_name                 | no          | doctrine_migration_versions| The name of the table to track executed migrations in.                           |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| column_name                | no          | version                    | The name of the column which stores the version name.                            |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| column_length              | no          | 14                         | The length of the column which stores the version name.                          |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| executed_at_column_name    | no          | executed_at                | The name of the column which stores the date that a migration was executed.      |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| migrations_directory       | yes         | null                       | The path to a directory where to look for migration classes.                     |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| all_or_nothing             | no          | false                      | Whether or not to wrap multiple migrations in a single transaction.              |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| migrations                 | no          | []                         | Manually specify the array of migration versions instead of finding migrations.  |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
-| check_database_platform    | no          | true                       | Whether to add a database platform check at the beginning of the generated code. |
-+----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| Name                       | Required   | Default                      | Description                                                                      |
++============================+============+==============================+==================================================================================+
+| name                       | no         | Doctrine Database Migrations | The name that shows at the top of the migrations console application.            |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| migrations_namespace       | yes        | null                         | The PHP namespace your migration classes are located under.                      |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| table_name                 | no         | doctrine_migration_versions  | The name of the table to track executed migrations in.                           |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| column_name                | no         | version                      | The name of the column which stores the version name.                            |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| column_length              | no         | 14                           | The length of the column which stores the version name.                          |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| executed_at_column_name    | no         | executed_at                  | The name of the column which stores the date that a migration was executed.      |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| migrations_directory       | yes        | null                         | The path to a directory where to look for migration classes.                     |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| all_or_nothing             | no         | false                        | Whether or not to wrap multiple migrations in a single transaction.              |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| migrations                 | no         | []                           | Manually specify the array of migration versions instead of finding migrations.  |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
+| check_database_platform    | no         | true                         | Whether to add a database platform check at the beginning of the generated code. |
++----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 
 Manually Providing Migrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Default name for is `Doctrine Database Migrations`, not as it is said in the documentation `Doctrine Migrations`.

Ref:
https://github.com/doctrine/migrations/blob/941231fde05b95678f4fc9fdc1368acb42c174e2/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php#L100
https://github.com/doctrine/migrations/blob/c369ce8f1f41275faed0e57c786ce291d9d83164/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php#L46
