### PR TITLE
Fixed docs for required params in the configuration

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -90,29 +90,29 @@ Please note that if you want to use the YAML configuration option, you will need
 
 Here are details about what each configuration option does:
 
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| Name                       | Required   | Default                    | Description                                                                      |
-+============================+============+============================+==================================================================================+
-| name                       | no         | Doctrine Migrations        | The name that shows at the top of the migrations console application.            |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| migrations_namespace       | no         | null                       | The PHP namespace your migration classes are located under.                      |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| table_name                 | no         | doctrine_migration_versions| The name of the table to track executed migrations in.                           |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| column_name                | no         | version                    | The name of the column which stores the version name.                            |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| column_length              | no         | 14                         | The length of the column which stores the version name.                          |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| executed_at_column_name    | no         | executed_at                | The name of the column which stores the date that a migration was executed.      |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| migrations_directory       | no         | null                       | The path to a directory where to look for migration classes.                     |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| all_or_nothing             | no         | false                      | Whether or not to wrap multiple migrations in a single transaction.              |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| migrations                 | no         | []                         | Manually specify the array of migration versions instead of finding migrations.  |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
-| check_database_platform    | no         | true                       | Whether to add a database platform check at the beginning of the generated code. |
-+----------------------------+------------+----------------------------+----------------------------------------------------------------------------------+
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| Name                       | Required    | Default                    | Description                                                                      |
++============================+=============+============================+==================================================================================+
+| name                       | no          | Doctrine Migrations        | The name that shows at the top of the migrations console application.            |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| migrations_namespace       | yes         | null                       | The PHP namespace your migration classes are located under.                      |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| table_name                 | no          | doctrine_migration_versions| The name of the table to track executed migrations in.                           |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| column_name                | no          | version                    | The name of the column which stores the version name.                            |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| column_length              | no          | 14                         | The length of the column which stores the version name.                          |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| executed_at_column_name    | no          | executed_at                | The name of the column which stores the date that a migration was executed.      |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| migrations_directory       | yes         | null                       | The path to a directory where to look for migration classes.                     |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| all_or_nothing             | no          | false                      | Whether or not to wrap multiple migrations in a single transaction.              |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| migrations                 | no          | []                         | Manually specify the array of migration versions instead of finding migrations.  |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
+| check_database_platform    | no          | true                       | Whether to add a database platform check at the beginning of the generated code. |
++----------------------------+-------------+----------------------------+----------------------------------------------------------------------------------+
 
 Manually Providing Migrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

It looks like `migrations_namespace` and `migrations_directory` are
mandatory to use any commands. Otherwise we are getting exception.

Ref:

- in AbstractCommand on initialize we validate the configuration:
https://github.com/doctrine/migrations/blob/0069f40df5d7fbe54c32f03843bb36a1c7123bc9/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php#L67-L75

- and here is the validate method of configuration:
https://github.com/doctrine/migrations/blob/0069f40df5d7fbe54c32f03843bb36a1c7123bc9/lib/Doctrine/Migrations/Configuration/Configuration.php#L264-L273