### PR TITLE
Handle missing jdorn/sql-formatter dependency in dump-schema command

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
+use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use Doctrine\Migrations\Tools\Console\Exception\SchemaDumpRequiresNoMigrations;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function class_exists;
 use function count;
 use function sprintf;
 
@@ -71,6 +73,14 @@ EOT
 
         if (count($versions) > 0) {
             throw SchemaDumpRequiresNoMigrations::new();
+        }
+
+        if ($formatted) {
+            if (! class_exists('SqlFormatter')) {
+                throw InvalidOptionUsage::new(
+                    'The "--formatted" option can only be used if the sql formatter is installed. Please run "composer require jdorn/sql-formatter".'
+                );
+            }
         }
 
         $versionNumber = $this->configuration->generateVersionNumber();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

We are doing it in diff command, but not in dump-schema and because of that we are getting exception with trace on console output:

```console
$ vendor/bin/doctrine-migrations dump-schema --formatted

Fatal error: Uncaught Error: Class 'SqlFormatter' not found in /usr/src/vendor/doctrine/migrations/lib/Doctrine/Migrations/Generator/SqlGenerator.php:56
Stack trace:
#0 /usr/src/vendor/doctrine/migrations/lib/Doctrine/Migrations/SchemaDumper.php(66): Doctrine\Migrations\Generator\SqlGenerator->generate(Array, true, 120)
#1 /usr/src/vendor/doctrine/migrations/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php(79): Doctrine\Migrations\SchemaDumper->dump('20190726073612', true, 120)
#2 /usr/src/vendor/symfony/console/Command/Command.php(255): Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#3 /usr/src/vendor/symfony/console/Application.php(921): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#4 /usr/src/vendor/symfony/console/Application.php(273): Symfony\Component\Console\Appl in /usr/src/vendor/doctrine/migrations/lib/Doctrine/Migrations/Generator/SqlGenerator.php on line 56
```

Command `diff` handles it much better:
```
$ vendor/bin/doctrine-migrations diff --formatted


In InvalidOptionUsage.php line 13:
                                                                                                                                   
  The "--formatted" option can only be used if the sql formatter is installed. Please run "composer require jdorn/sql-formatter". 
```

so the user knows what to do.
                                                                                                              
