### PR TITLE
Fix migration direction calculation fails.

### DIFF
--- a/lib/Doctrine/Migrations/MigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/MigrationPlanCalculator.php
@@ -54,14 +54,12 @@ final class MigrationPlanCalculator
         string $to,
         array $migrated
     ) : bool {
-        $to = (int) $to;
-
         if ($direction === Direction::DOWN) {
             if (! in_array($version->getVersion(), $migrated, true)) {
                 return false;
             }
 
-            return (int) $version->getVersion() > $to;
+            return $version->getVersion() > $to;
         }
 
         if ($direction === Direction::UP) {

--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -242,7 +242,7 @@ class Migrator
 
     private function calculateDirection(string $from, string $to) : string
     {
-        return (int) $from > (int) $to ? Direction::DOWN : Direction::UP;
+        return $from > $to ? Direction::DOWN : Direction::UP;
     }
 
     /** @return string[][] */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/K

#### Summary

When using a timestamp for version numbers the direction calculation fails due to overflow of integer. This PR removed the (int) to allow timestamps to be used.


