### PR TITLE
enable verbosity for OutputWrite

### DIFF
--- a/lib/Doctrine/Migrations/OutputWriter.php
+++ b/lib/Doctrine/Migrations/OutputWriter.php
@@ -31,9 +31,9 @@ class OutputWriter
         $this->callback = $callback;
     }
 
-    public function write(string $message) : void
+    public function write(string $message, int $option = 0) : void
     {
-        ($this->callback)($message);
+        ($this->callback)($message, $option);
     }
 
     public function getLastMessage() : string

--- a/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -123,8 +123,8 @@ abstract class AbstractCommand extends Command
             $this->migrationConfiguration = $configHelper->getMigrationConfig($input);
 
             $this->migrationConfiguration->getOutputWriter()->setCallback(
-                static function (string $message) use ($output) : void {
-                    $output->writeln($message);
+                static function (string $message, int $options) use ($output) : void {
+                    $output->writeln($message, $options);
                 }
             );
         }

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -16,6 +16,7 @@ use Doctrine\Migrations\ParameterFormatterInterface;
 use Doctrine\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\Migrations\Stopwatch;
 use Doctrine\Migrations\Tools\BytesFormatter;
+use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
 use function count;
 use function rtrim;
@@ -197,7 +198,8 @@ final class Executor implements ExecutorInterface
 
         $migration->{'pre' . ucfirst($direction)}($fromSchema);
 
-        $this->outputWriter->write("\n" . $this->getMigrationHeader($version, $migration, $direction) . "\n");
+        $this->outputWriter->write("\n" . $this->getMigrationHeader($version, $migration, $direction));
+        $this->outputWriter->write("\n", OutputInterface::VERBOSITY_VERBOSE);
 
         $version->setState(State::EXEC);
 
@@ -239,15 +241,17 @@ final class Executor implements ExecutorInterface
         $versionExecutionResult->setTime($stopwatchEvent->getDuration());
         $versionExecutionResult->setMemory($stopwatchEvent->getMemory());
 
+        $this->outputWriter->write("\n", OutputInterface::VERBOSITY_VERBOSE);
+
         if ($direction === Direction::UP) {
             $this->outputWriter->write(sprintf(
-                "\n  <info>++</info> migrated (took %sms, used %s memory)",
+                '  <info>++</info> migrated (took %sms, used %s memory)',
                 $stopwatchEvent->getDuration(),
                 BytesFormatter::formatBytes($stopwatchEvent->getMemory())
             ));
         } else {
             $this->outputWriter->write(sprintf(
-                "\n  <info>--</info> reverted (took %sms, used %s memory)",
+                '  <info>--</info> reverted (took %sms, used %s memory)',
                 $stopwatchEvent->getDuration(),
                 BytesFormatter::formatBytes($stopwatchEvent->getMemory())
             ));
@@ -377,11 +381,14 @@ final class Executor implements ExecutorInterface
             $this->types[$idx] ?? []
         );
 
-        $this->outputWriter->write(rtrim(sprintf(
-            '     <comment>-></comment> %s %s',
-            $query,
-            $params
-        )));
+        $this->outputWriter->write(
+            rtrim(sprintf(
+                '     <comment>-></comment> %s %s',
+                $query,
+                $params
+            )),
+            OutputInterface::VERBOSITY_VERBOSE
+        );
     }
 
     private function getFromSchema(MigratorConfiguration $migratorConfiguration) : Schema

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -64,27 +64,35 @@ class ExecutorTest extends TestCase
     {
         $this->outputWriter->expects(self::at(0))
             ->method('write')
-            ->with("\n  <info>++</info> migrating <comment>001</comment>\n");
+            ->with("\n  <info>++</info> migrating <comment>001</comment>");
 
         $this->outputWriter->expects(self::at(1))
             ->method('write')
-            ->with('     <comment>-></comment> SELECT 1');
+            ->with("\n");
 
         $this->outputWriter->expects(self::at(2))
             ->method('write')
-            ->with('  <info>100ms</info>');
+            ->with('     <comment>-></comment> SELECT 1');
 
         $this->outputWriter->expects(self::at(3))
             ->method('write')
-            ->with('     <comment>-></comment> SELECT 2');
+            ->with('  <info>100ms</info>');
 
         $this->outputWriter->expects(self::at(4))
             ->method('write')
-            ->with('  <info>100ms</info>');
+            ->with('     <comment>-></comment> SELECT 2');
 
         $this->outputWriter->expects(self::at(5))
             ->method('write')
-            ->with("\n  <info>++</info> migrated (took 100ms, used 100 memory)");
+            ->with('  <info>100ms</info>');
+
+        $this->outputWriter->expects(self::at(6))
+            ->method('write')
+            ->with("\n");
+
+        $this->outputWriter->expects(self::at(7))
+            ->method('write')
+            ->with('  <info>++</info> migrated (took 100ms, used 100 memory)');
 
         $migratorConfiguration = (new MigratorConfiguration())
             ->setTimeAllQueries(true);
@@ -114,7 +122,11 @@ class ExecutorTest extends TestCase
     {
         $this->outputWriter->expects(self::at(0))
             ->method('write')
-            ->with("\n  <info>++</info> migrating <comment>001 (testing)</comment>\n");
+            ->with("\n  <info>++</info> migrating <comment>001 (testing)</comment>");
+
+        $this->outputWriter->expects(self::at(1))
+            ->method('write')
+            ->with("\n");
 
         $migratorConfiguration = (new MigratorConfiguration())
             ->setTimeAllQueries(true);
@@ -131,27 +143,35 @@ class ExecutorTest extends TestCase
     {
         $this->outputWriter->expects(self::at(0))
             ->method('write')
-            ->with("\n  <info>--</info> reverting <comment>001</comment>\n");
+            ->with("\n  <info>--</info> reverting <comment>001</comment>");
 
         $this->outputWriter->expects(self::at(1))
             ->method('write')
-            ->with('     <comment>-></comment> SELECT 3');
+            ->with("\n");
 
         $this->outputWriter->expects(self::at(2))
             ->method('write')
-            ->with('  <info>100ms</info>');
+            ->with('     <comment>-></comment> SELECT 3');
 
         $this->outputWriter->expects(self::at(3))
             ->method('write')
-            ->with('     <comment>-></comment> SELECT 4');
+            ->with('  <info>100ms</info>');
 
         $this->outputWriter->expects(self::at(4))
             ->method('write')
-            ->with('  <info>100ms</info>');
+            ->with('     <comment>-></comment> SELECT 4');
 
         $this->outputWriter->expects(self::at(5))
             ->method('write')
-            ->with("\n  <info>--</info> reverted (took 100ms, used 100 memory)");
+            ->with('  <info>100ms</info>');
+
+        $this->outputWriter->expects(self::at(6))
+            ->method('write')
+            ->with("\n");
+
+        $this->outputWriter->expects(self::at(7))
+            ->method('write')
+            ->with('  <info>--</info> reverted (took 100ms, used 100 memory)');
 
         $migratorConfiguration = (new MigratorConfiguration())
             ->setTimeAllQueries(true);
@@ -181,7 +201,11 @@ class ExecutorTest extends TestCase
     {
         $this->outputWriter->expects(self::at(0))
             ->method('write')
-            ->with("\n  <info>--</info> reverting <comment>001 (testing)</comment>\n");
+            ->with("\n  <info>--</info> reverting <comment>001 (testing)</comment>");
+
+        $this->outputWriter->expects(self::at(1))
+            ->method('write')
+            ->with("\n");
 
         $migratorConfiguration = (new MigratorConfiguration())
             ->setTimeAllQueries(true);

--- a/tests/Doctrine/Migrations/Tests/Version/VersionTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/VersionTest.php
@@ -467,8 +467,8 @@ class VersionTest extends MigrationTestCase
         $version->execute(Direction::UP, (new MigratorConfiguration())
             ->setDryRun(true));
 
-        self::assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
-        self::assertContains('SELECT 1 WHERE 1', $messages[1]);
+        self::assertCount(5, $messages, 'should have written three messages (header, footer, 1 SQL statement, 2x new line)');
+        self::assertContains('SELECT 1 WHERE 1', $messages[2]);
     }
 
     public function testDryRunWithQuestionMarkedParamsOutputsParamsWithSqlStatement() : void
@@ -491,9 +491,9 @@ class VersionTest extends MigrationTestCase
         $version->execute(Direction::UP, (new MigratorConfiguration())
             ->setDryRun(true));
 
-        self::assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
-        self::assertContains('INSERT INTO test VALUES (?, ?)', $messages[1]);
-        self::assertContains('with parameters ([one], [two])', $messages[1]);
+        self::assertCount(5, $messages, 'should have written three messages (header, footer, 1 SQL statement, 2x new line)');
+        self::assertContains('INSERT INTO test VALUES (?, ?)', $messages[2]);
+        self::assertContains('with parameters ([one], [two])', $messages[2]);
     }
 
     public function testDryRunWithNamedParametersOutputsParamsAndNamesWithSqlStatement() : void
@@ -516,9 +516,9 @@ class VersionTest extends MigrationTestCase
         $version->execute(Direction::UP, (new MigratorConfiguration())
             ->setDryRun(true));
 
-        self::assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
-        self::assertContains('INSERT INTO test VALUES (:one, :two)', $messages[1]);
-        self::assertContains('with parameters (:one => [one], :two => [two])', $messages[1]);
+        self::assertCount(5, $messages, 'should have written three messages (header, footer, 1 SQL statement, 2x new line)');
+        self::assertContains('INSERT INTO test VALUES (:one, :two)', $messages[2]);
+        self::assertContains('with parameters (:one => [one], :two => [two])', $messages[2]);
     }
 
     /** @return mixed[][] */
@@ -568,9 +568,9 @@ class VersionTest extends MigrationTestCase
         $version->execute(Direction::UP, (new MigratorConfiguration())
             ->setDryRun(true));
 
-        self::assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
-        self::assertContains('INSERT INTO test VALUES (?)', $messages[1]);
-        self::assertContains(sprintf('with parameters (%s)', $output), $messages[1]);
+        self::assertCount(5, $messages, 'should have written three messages (header, footer, 1 SQL statement, 2x new line)');
+        self::assertContains('INSERT INTO test VALUES (?)', $messages[2]);
+        self::assertContains(sprintf('with parameters (%s)', $output), $messages[2]);
     }
 
     public function testRunWithInsertNullValue() : void
@@ -599,9 +599,9 @@ class VersionTest extends MigrationTestCase
         $version->execute(Direction::UP, (new MigratorConfiguration())
             ->setDryRun(true));
 
-        self::assertCount(3, $messages, 'should have written three messages (header, footer, 1 SQL statement)');
-        self::assertContains('INSERT INTO test VALUES (?)', $messages[1]);
-        self::assertContains('with parameters ([])', $messages[1]);
+        self::assertCount(5, $messages, 'should have written three messages (header, footer, 1 SQL statement, 2x new line)');
+        self::assertContains('INSERT INTO test VALUES (?)', $messages[2]);
+        self::assertContains('with parameters ([])', $messages[2]);
     }
 
     /**


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #834 

#### Summary

`migrations:migrate` now shows less info, to show detailed output use option  `-v` (verbose).

Example output:

![97v8wEy](https://user-images.githubusercontent.com/16163762/64926370-ea0d9580-d7fc-11e9-9b72-f842296170c7.png)


