### PR TITLE
Fix the installation instruction

### DIFF
--- a/docs/en/reference/introduction.rst
+++ b/docs/en/reference/introduction.rst
@@ -26,7 +26,7 @@ Now to install with Composer it is as simple as running the following command in
 
 .. code-block:: sh
 
-    composer require doctrine/migrations:2.0
+    composer require "doctrine/migrations:^2.0"
 
 Now you will have a file in ``vendor/bin`` available to run the migrations console application:
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | doc
| BC Break     | no
| Fixed issues | n/a

#### Summary

We should not recommend an exact match on 2.0.

I used double quotes to make this command work as is cross-platform (the `^` char needs to be escaped in Windows as it has a special meaning)
