### PR TITLE
allow_failures: - php: 7.4snapshot removed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ install:
 script:
   - ./vendor/bin/phpunit
 
-jobs:
-  allow_failures:
-    - php: 7.4snapshot
-
   include:
     - stage: Test
       env: DEPENDENCIES=low

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ install:
   - rm composer.lock
   - travis_retry composer update --prefer-dist
 
+jobs:
+
 script:
   - ./vendor/bin/phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ install:
   - rm composer.lock
   - travis_retry composer update --prefer-dist
 
-jobs:
-
 script:
   - ./vendor/bin/phpunit
 
+jobs:
   include:
     - stage: Test
       env: DEPENDENCIES=low

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -376,7 +376,7 @@ class FunctionalTest extends MigrationTestCase
     {
         foreach ($migrations as $key => $class) {
             $migrator = $this->createTestMigrator($this->config);
-            $this->config->registerMigration($key->getName(), $class);
+            $this->config->registerMigration((string) $key, $class);
             $sql = $migrator->migrate();
             self::assertCount(1, $sql, 'should have executed one migration');
         }

--- a/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
+++ b/tests/Doctrine/Migrations/Tests/Functional/FunctionalTest.php
@@ -376,7 +376,7 @@ class FunctionalTest extends MigrationTestCase
     {
         foreach ($migrations as $key => $class) {
             $migrator = $this->createTestMigrator($this->config);
-            $this->config->registerMigration((string) $key, $class);
+            $this->config->registerMigration($key->getName(), $class);
             $sql = $migrator->migrate();
             self::assertCount(1, $sql, 'should have executed one migration');
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #861 

#### Summary

I just remove these two lines ```  allow_failures:
    - php: 7.4snapshot``` + the jobs one also (because i think it's not usefull anymore for now)
