### PR TITLE
Escape backslash in YAML example

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -38,7 +38,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
     .. code-block:: yaml
 
         name: "My Project Migrations"
-        migrations_namespace: "MyProject\Migrations"
+        migrations_namespace: "MyProject\\Migrations"
         table_name: "doctrine_migration_versions"
         column_name: "version"
         column_length: 14


### PR DESCRIPTION
Single backslash in double quotes causes malformed YAML error

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | ~

#### Summary

Escape backslash inside double quote in YAML configuration example. It was causing a YamlNotValid exception.
