### PR TITLE
Fix of branch name for doctrine website build

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -12,7 +12,7 @@
         },
         {
             "name": "2.1",
-            "branchName": "2.1",
+            "branchName": "2.1.x",
             "slug": "2.1",
             "current": true
         },


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

This should fix the migrations version infos and the build error `error: pathspec 'origin/2.1' did not match any file(s) known to git` on Doctrine website build.
