### PR TITLE
Update the default migration template to adhere to PSR 12 formatting

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -24,7 +24,7 @@ listens for all possible migrations events.
 
     class MigrationsListener implements EventSubscriber
     {
-        public function getSubscribedEvents() : array
+        public function getSubscribedEvents(): array
         {
             return [
                 Events::onMigrationsMigrating,
@@ -35,27 +35,27 @@ listens for all possible migrations events.
             ];
         }
 
-        public function onMigrationsMigrating(MigrationsEventArgs $args) : void
+        public function onMigrationsMigrating(MigrationsEventArgs $args): void
         {
             // ...
         }
 
-        public function onMigrationsMigrated(MigrationsEventArgs $args) : void
+        public function onMigrationsMigrated(MigrationsEventArgs $args): void
         {
             // ...
         }
 
-        public function onMigrationsVersionExecuting(MigrationsVersionEventArgs $args) : void
+        public function onMigrationsVersionExecuting(MigrationsVersionEventArgs $args): void
         {
             // ...
         }
 
-        public function onMigrationsVersionExecuted(MigrationsVersionEventArgs $args) : void
+        public function onMigrationsVersionExecuted(MigrationsVersionEventArgs $args): void
         {
             // ...
         }
 
-        public function onMigrationsVersionSkipped(MigrationsVersionEventArgs $args) : void
+        public function onMigrationsVersionSkipped(MigrationsVersionEventArgs $args): void
         {
             // ...
         }

--- a/docs/en/reference/generating-migrations.rst
+++ b/docs/en/reference/generating-migrations.rst
@@ -43,17 +43,17 @@ the ORM. To test this functionality, create a new ``User`` entity located at ``l
             $this->id = $id;
         }
 
-        public function getId() : ?int
+        public function getId(): ?int
         {
             return $this->id;
         }
 
-        public function setUsername(string $username) : void
+        public function setUsername(string $username): void
         {
             $this->username = $username;
         }
 
-        public function getUsername() : ?string
+        public function getUsername(): ?string
         {
             return $this->username;
         }
@@ -95,12 +95,12 @@ Take a look at the generated migration:
      */
     final class Version20180601215504 extends AbstractMigration
     {
-        public function getDescription() : string
+        public function getDescription(): string
         {
             return '';
         }
 
-        public function up(Schema $schema) : void
+        public function up(Schema $schema): void
         {
             // this up() migration is auto-generated, please modify it to your needs
             $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
@@ -109,7 +109,7 @@ Take a look at the generated migration:
             $this->addSql('DROP TABLE example_table');
         }
 
-        public function down(Schema $schema) : void
+        public function down(Schema $schema): void
         {
             // this down() migration is auto-generated, please modify it to your needs
             $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');

--- a/docs/en/reference/managing-migrations.rst
+++ b/docs/en/reference/managing-migrations.rst
@@ -57,17 +57,17 @@ is, it does not have anything in it so nothing would be executed! Let's add some
      */
     final class Version20180601193057 extends AbstractMigration
     {
-        public function getDescription() : string
+        public function getDescription(): string
         {
             return 'This is my example migration.';
         }
 
-        public function up(Schema $schema) : void
+        public function up(Schema $schema): void
         {
             $this->addSql('CREATE TABLE example_table (id INT AUTO_INCREMENT NOT NULL, title VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
         }
 
-        public function down(Schema $schema) : void
+        public function down(Schema $schema): void
         {
             $this->addSql('DROP TABLE example_table');
         }

--- a/docs/en/reference/migration-classes.rst
+++ b/docs/en/reference/migration-classes.rst
@@ -32,18 +32,18 @@ migration looks like:
      */
     final class Version20180601193057 extends AbstractMigration
     {
-        public function getDescription() : string
+        public function getDescription(): string
         {
             return '';
         }
 
-        public function up(Schema $schema) : void
+        public function up(Schema $schema): void
         {
             // this up() migration is auto-generated, please modify it to your needs
 
         }
 
-        public function down(Schema $schema) : void
+        public function down(Schema $schema): void
         {
             // this down() migration is auto-generated, please modify it to your needs
 
@@ -62,7 +62,7 @@ Override this method if you want to disable transactions in a migration. It defa
 
 .. code-block:: php
 
-    public function isTransactional() : bool
+    public function isTransactional(): bool
     {
         return false;
     }
@@ -85,7 +85,7 @@ will get outputted when you run the ``./vendor/bin/doctrine-migrations status --
 
 .. code-block:: php
 
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return 'The description of my awesome migration!';
     }
@@ -97,7 +97,7 @@ This method gets called before the ``up()`` is called.
 
 .. code-block:: php
 
-    public function preUp(Schema $schema) : void
+    public function preUp(Schema $schema): void
     {
     }
 
@@ -108,7 +108,7 @@ This method gets called after the ``up()`` is called.
 
 .. code-block:: php
 
-    public function postUp(Schema $schema) : void
+    public function postUp(Schema $schema): void
     {
     }
 
@@ -119,7 +119,7 @@ This method gets called before the ``down()`` is called.
 
 .. code-block:: php
 
-    public function preDown(Schema $schema) : void
+    public function preDown(Schema $schema): void
     {
     }
 
@@ -130,7 +130,7 @@ This method gets called after the ``down()`` is called.
 
 .. code-block:: php
 
-    public function postDown(Schema $schema) : void
+    public function postDown(Schema $schema): void
     {
     }
 
@@ -146,7 +146,7 @@ Warn with a message if some condition is met.
 
 .. code-block:: php
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->warnIf(true, 'Something might be going wrong');
 
@@ -160,7 +160,7 @@ Abort the migration if some condition is met:
 
 .. code-block:: php
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->abortIf(true, 'Something went wrong. Aborting.');
 
@@ -174,7 +174,7 @@ Skip the migration if some condition is met.
 
 .. code-block:: php
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->skipIf(true, 'Skipping this migration.');
 
@@ -191,7 +191,7 @@ to the addSql method as parameters.
 
 .. code-block:: php
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $users = [
             ['name' => 'mike', 'id' => 1],
@@ -211,7 +211,7 @@ Write some debug information to the console.
 
 .. code-block:: php
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->write('Doing some cool migration!');
 
@@ -226,7 +226,7 @@ The ``throwIrreversibleMigrationException`` method accepts an optional message t
 
 .. code-block:: php
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
 

--- a/lib/Doctrine/Migrations/Generator/Generator.php
+++ b/lib/Doctrine/Migrations/Generator/Generator.php
@@ -43,18 +43,18 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class <className> extends AbstractMigration
 {
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return '';
     }
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
 <up>
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
 <down>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #1119 

#### Summary

This change updates the generated migration file to follow the [PSR-12](https://www.php-fig.org/psr/psr-12/) standard. To pull the exact phrasing:

> When you have a return type declaration present, there MUST be one space after the colon followed by the type declaration. The colon and declaration MUST be on the same line as the argument list closing parenthesis with no spaces between the two characters.

This will help keep formatting consistent between the migrations and the application and removes the need to reformat the migration file after it's created.