### PR TITLE
Make configuration and dependency injection container immutable

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/Migrations/Configuration/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Configuration;
 
+use Doctrine\Migrations\Configuration\Exception\FrozenConfiguration;
 use Doctrine\Migrations\Configuration\Exception\MissingNamespaceConfiguration;
 use Doctrine\Migrations\Configuration\Exception\UnknownConfigurationValue;
 use Doctrine\Migrations\Exception\MigrationException;
@@ -49,8 +50,27 @@ final class Configuration
     /** @var MetadataStorageConfiguration */
     private $metadataStorageConfiguration;
 
+    /** @var bool */
+    private $frozen = false;
+
+    public function freeze() : void
+    {
+        if (! $this->frozen) {
+            $this->validate();
+        }
+        $this->frozen = true;
+    }
+
+    private function assertNotFrozen() : void
+    {
+        if ($this->frozen) {
+            throw FrozenConfiguration::new();
+        }
+    }
+
     public function setMetadataStorageConfiguration(MetadataStorageConfiguration $metadataStorageConfiguration) : void
     {
+        $this->assertNotFrozen();
         $this->metadataStorageConfiguration = $metadataStorageConfiguration;
     }
 
@@ -64,6 +84,7 @@ final class Configuration
 
     public function addMigrationClass(string $className) : void
     {
+        $this->assertNotFrozen();
         $this->migrationClasses[] = $className;
     }
 
@@ -74,6 +95,7 @@ final class Configuration
 
     public function addMigrationsDirectory(string $namespace, string $path) : void
     {
+        $this->assertNotFrozen();
         $this->migrationsDirectories[$namespace] = $path;
     }
 
@@ -87,6 +109,7 @@ final class Configuration
 
     public function setName(string $name) : void
     {
+        $this->assertNotFrozen();
         $this->name = $name;
     }
 
@@ -97,6 +120,7 @@ final class Configuration
 
     public function setCustomTemplate(?string $customTemplate) : void
     {
+        $this->assertNotFrozen();
         $this->customTemplate = $customTemplate;
     }
 
@@ -116,6 +140,7 @@ final class Configuration
     public function setMigrationsAreOrganizedByYear(
         bool $migrationsAreOrganizedByYear = true
     ) : void {
+        $this->assertNotFrozen();
         $this->migrationsAreOrganizedByYear = $migrationsAreOrganizedByYear;
     }
 
@@ -125,6 +150,7 @@ final class Configuration
     public function setMigrationsAreOrganizedByYearAndMonth(
         bool $migrationsAreOrganizedByYearAndMonth = true
     ) : void {
+        $this->assertNotFrozen();
         $this->migrationsAreOrganizedByYear         = $migrationsAreOrganizedByYearAndMonth;
         $this->migrationsAreOrganizedByYearAndMonth = $migrationsAreOrganizedByYearAndMonth;
     }
@@ -134,8 +160,7 @@ final class Configuration
         return $this->migrationsAreOrganizedByYearAndMonth;
     }
 
-    /** @throws MigrationException */
-    public function validate() : void
+    private function validate() : void
     {
         if (count($this->migrationsDirectories) === 0) {
             throw MissingNamespaceConfiguration::new();
@@ -144,6 +169,7 @@ final class Configuration
 
     public function setIsDryRun(bool $isDryRun) : void
     {
+        $this->assertNotFrozen();
         $this->isDryRun = $isDryRun;
     }
 
@@ -154,6 +180,7 @@ final class Configuration
 
     public function setAllOrNothing(bool $allOrNothing) : void
     {
+        $this->assertNotFrozen();
         $this->allOrNothing = $allOrNothing;
     }
 
@@ -174,6 +201,7 @@ final class Configuration
 
     public function setMigrationOrganization(string $migrationOrganization) : void
     {
+        $this->assertNotFrozen();
         if (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR) === 0) {
             $this->setMigrationsAreOrganizedByYear();
         } elseif (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH) === 0) {

--- a/lib/Doctrine/Migrations/Configuration/Exception/FrozenConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/Exception/FrozenConfiguration.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Configuration\Exception;
+
+use LogicException;
+
+final class FrozenConfiguration extends LogicException implements ConfigurationException
+{
+    public static function new() : self
+    {
+        return new self('The configuration is frozen and cannot be edited anymore.');
+    }
+}

--- a/lib/Doctrine/Migrations/Exception/FrozenDependencies.php
+++ b/lib/Doctrine/Migrations/Exception/FrozenDependencies.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Exception;
+
+use LogicException;
+
+final class FrozenDependencies extends LogicException implements MigrationException
+{
+    public static function new() : self
+    {
+        return new self('The dependencies are frozen and cannot be edited anymore.');
+    }
+}

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php
@@ -31,14 +31,6 @@ abstract class DoctrineCommand extends Command
     /** @var DependencyFactory|null */
     private $dependencyFactory;
 
-    public function initialize(
-        InputInterface $input,
-        OutputInterface $output
-    ) : void {
-        $this->initializeDependencies($input, $output);
-        $this->getDependencyFactory()->getConfiguration()->validate();
-    }
-
     public function __construct(?string $name = null, ?DependencyFactory $dependencyFactory = null)
     {
         parent::__construct($name);
@@ -74,13 +66,14 @@ abstract class DoctrineCommand extends Command
         $output->writeln('');
     }
 
-    protected function initializeDependencies(
-        InputInterface $input,
-        OutputInterface $output
-    ) : void {
+    protected function initialize(InputInterface $input, OutputInterface $output) : void
+    {
         if ($this->dependencyFactory !== null) {
+            $this->dependencyFactory->freeze();
+
             return;
         }
+
         $helperSet = $this->getHelperSet() ?: new HelperSet();
 
         if ($helperSet->has('configuration') && $helperSet->get('configuration') instanceof ConfigurationHelper) {
@@ -104,6 +97,7 @@ abstract class DoctrineCommand extends Command
 
         $logger                  = new ConsoleLogger($output);
         $this->dependencyFactory = new DependencyFactory($configuration, $connection, $em, $logger);
+        $this->dependencyFactory->freeze();
     }
 
     protected function getDependencyFactory() : DependencyFactory

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Configuration;
 
 use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Configuration\Exception\FrozenConfiguration;
 use Doctrine\Migrations\Configuration\Exception\MissingNamespaceConfiguration;
 use Doctrine\Migrations\Configuration\Exception\UnknownConfigurationValue;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorageConfiguration;
@@ -53,7 +54,18 @@ class ConfigurationTest extends TestCase
         $this->expectExceptionMessage('There are no namespaces configured.');
 
         $config = new Configuration();
-        $config->validate();
+        $config->freeze();
+    }
+
+    public function testFreezeConfiguration() : void
+    {
+        $config = new Configuration();
+        $config->addMigrationsDirectory('foo', 'bar');
+        $config->freeze();
+
+        $this->expectException(FrozenConfiguration::class);
+        $this->expectExceptionMessage('The configuration is frozen and cannot be edited anymore.');
+        $config->setName('foo');
     }
 
     public function testMigrationOrganizationByYear() : void

--- a/tests/Doctrine/Migrations/Tests/DependencyFactoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/DependencyFactoryTest.php
@@ -7,9 +7,11 @@ namespace Doctrine\Migrations\Tests;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Exception\FrozenDependencies;
 use Doctrine\Migrations\Finder\GlobFinder;
 use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use PHPUnit\Framework\MockObject\MockObject;
+use stdClass;
 
 final class DependencyFactoryTest extends MigrationTestCase
 {
@@ -19,6 +21,19 @@ final class DependencyFactoryTest extends MigrationTestCase
     public function setUp() : void
     {
         $this->connection = $this->createMock(Connection::class);
+    }
+
+    public function testFreeze() : void
+    {
+        $conf = new Configuration();
+        $conf->addMigrationsDirectory('foo', 'bar');
+
+        $di = new DependencyFactory($conf, $this->connection);
+        $di->freeze();
+
+        $this->expectException(FrozenDependencies::class);
+        $this->expectExceptionMessage('The dependencies are frozen and cannot be edited anymore.');
+        $di->setService('foo', new stdClass());
     }
 
     public function testFinderForYearMonthStructure() : void

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DoctrineCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DoctrineCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Tools\Console\Command;
+
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Tests\MigrationTestCase;
+use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class DoctrineCommandTest extends MigrationTestCase
+{
+    public function testCommandFreezes() : void
+    {
+        $dependencyFactory = $this->getMockBuilder(DependencyFactory::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['freeze'])
+            ->getMock();
+
+        $dependencyFactory
+            ->expects(self::once())
+            ->method('freeze');
+
+        $command = $this->getMockBuilder(DoctrineCommand::class)
+            ->setConstructorArgs(['foo', $dependencyFactory])
+            ->onlyMethods(['execute'])
+            ->getMockForAbstractClass();
+
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute(
+            [],
+            ['interactive' => false]
+        );
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes
| Fixed issues | -

#### Summary

This PR makes the configuration and dependency injection container immutable. (frozen state)

This avoids having other services hacking into the DI container or config object at runtime (avoiding inconsistent retrieval of services
