### PR TITLE
Handle migrated versions metadata table auto-update 

### DIFF
--- a/lib/Doctrine/Migrations/Exception/MetadataStorageError.php
+++ b/lib/Doctrine/Migrations/Exception/MetadataStorageError.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Exception;
+
+use RuntimeException;
+
+final class MetadataStorageError extends RuntimeException implements MigrationException
+{
+    public static function notUpToDate() : self
+    {
+        return new self('The metadata storage is not up to date, please run the sync-metadata-storage command to fix this issue.');
+    }
+
+    public static function notInitialized() : self
+    {
+        return new self('The metadata storage is not initialized, please run the sync-metadata-storage command to fix this issue.');
+    }
+}

--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -9,6 +9,8 @@ use Doctrine\Migrations\Version\ExecutionResult;
 
 interface MetadataStorage
 {
+    public function ensureInitialized() : void;
+
     public function getExecutedMigrations() : ExecutedMigrationsSet;
 
     public function complete(ExecutionResult $migration) : void;

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -9,10 +9,15 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\MasterSlaveConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\TableDiff;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\Exception\MetadataStorageError;
+use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
@@ -22,6 +27,8 @@ use function array_change_key_case;
 use function floatval;
 use function round;
 use function sprintf;
+use function strlen;
+use function strpos;
 use function strtolower;
 
 final class TableMetadataStorage implements MetadataStorage
@@ -38,11 +45,18 @@ final class TableMetadataStorage implements MetadataStorage
     /** @var TableMetadataStorageConfiguration */
     private $configuration;
 
-    public function __construct(Connection $connection, ?MetadataStorageConfiguration $configuration = null)
-    {
-        $this->connection    = $connection;
-        $this->schemaManager = $connection->getSchemaManager();
-        $this->platform      = $connection->getDatabasePlatform();
+    /** @var MigrationRepository|null */
+    private $migrationRepository;
+
+    public function __construct(
+        Connection $connection,
+        ?MetadataStorageConfiguration $configuration = null,
+        ?MigrationRepository $migrationRepository = null
+    ) {
+        $this->migrationRepository = $migrationRepository;
+        $this->connection          = $connection;
+        $this->schemaManager       = $connection->getSchemaManager();
+        $this->platform            = $connection->getDatabasePlatform();
 
         if ($configuration !== null && ! ($configuration instanceof TableMetadataStorageConfiguration)) {
             throw new InvalidArgumentException(sprintf('%s accepts only %s as configuration', self::class, TableMetadataStorageConfiguration::class));
@@ -50,34 +64,9 @@ final class TableMetadataStorage implements MetadataStorage
         $this->configuration = $configuration ?: new TableMetadataStorageConfiguration();
     }
 
-    private function isInitialized() : bool
-    {
-        if ($this->connection instanceof MasterSlaveConnection) {
-            $this->connection->connect('master');
-        }
-
-        return $this->schemaManager->tablesExist([$this->configuration->getTableName()]);
-    }
-
-    private function initialize() : void
-    {
-        $schemaChangelog = new Table($this->configuration->getTableName());
-
-        $schemaChangelog->addColumn($this->configuration->getVersionColumnName(), 'string', ['notnull' => true, 'length' => $this->configuration->getVersionColumnLength()]);
-        $schemaChangelog->addColumn($this->configuration->getExecutedAtColumnName(), 'datetime', ['notnull' => false]);
-        $schemaChangelog->addColumn($this->configuration->getExecutionTimeColumnName(), 'integer', ['notnull' => false]);
-
-        $schemaChangelog->setPrimaryKey([$this->configuration->getVersionColumnName()]);
-
-        $this->schemaManager->createTable($schemaChangelog);
-    }
-
     public function getExecutedMigrations() : ExecutedMigrationsSet
     {
-        if (! $this->isInitialized()) {
-            $this->initialize();
-        }
-
+        $this->checkInitialization();
         $rows = $this->connection->fetchAll(sprintf('SELECT * FROM %s', $this->configuration->getTableName()));
 
         $migrations = [];
@@ -109,9 +98,7 @@ final class TableMetadataStorage implements MetadataStorage
 
     public function reset() : void
     {
-        if (! $this->isInitialized()) {
-            $this->initialize();
-        }
+        $this->checkInitialization();
 
         $this->connection->executeUpdate(
             sprintf(
@@ -123,9 +110,7 @@ final class TableMetadataStorage implements MetadataStorage
 
     public function complete(ExecutionResult $result) : void
     {
-        if (! $this->isInitialized()) {
-            $this->initialize();
-        }
+        $this->checkInitialization();
 
         if ($result->getDirection() === Direction::DOWN) {
             $this->connection->delete($this->configuration->getTableName(), [
@@ -142,5 +127,112 @@ final class TableMetadataStorage implements MetadataStorage
                 Type::INTEGER,
             ]);
         }
+    }
+
+    public function ensureInitialized() : void
+    {
+        $expectedSchemaChangelog = $this->getExpectedTable();
+
+        if (! $this->isInitialized($expectedSchemaChangelog)) {
+            $this->schemaManager->createTable($expectedSchemaChangelog);
+
+            return;
+        }
+
+        $diff = $this->needsUpdate($expectedSchemaChangelog);
+        if ($diff === null) {
+            return;
+        }
+
+        $this->schemaManager->alterTable($diff);
+        $this->updateMigratedVersionsFromV1orV2toV3();
+    }
+
+    private function needsUpdate(Table $expectedTable) : ?TableDiff
+    {
+        $comparator   = new Comparator();
+        $currentTable = $this->schemaManager->listTableDetails($this->configuration->getTableName());
+        $diff         = $comparator->diffTable($currentTable, $expectedTable);
+
+        return $diff instanceof TableDiff ? $diff : null;
+    }
+
+    private function isInitialized(Table $expectedTable) : bool
+    {
+        if ($this->connection instanceof MasterSlaveConnection) {
+            $this->connection->connect('master');
+        }
+
+        return $this->schemaManager->tablesExist([$expectedTable->getName()]);
+    }
+
+    private function checkInitialization() : void
+    {
+        $expectedTable = $this->getExpectedTable();
+
+        if (! $this->isInitialized($expectedTable)) {
+            throw MetadataStorageError::notInitialized();
+        }
+
+        if ($this->needsUpdate($expectedTable)!== null) {
+            throw MetadataStorageError::notUpToDate();
+        }
+    }
+
+    private function getExpectedTable() : Table
+    {
+        $schemaChangelog = new Table($this->configuration->getTableName());
+
+        $schemaChangelog->addColumn(
+            $this->configuration->getVersionColumnName(),
+            'string',
+            ['notnull' => true, 'length' => $this->configuration->getVersionColumnLength()]
+        );
+        $schemaChangelog->addColumn($this->configuration->getExecutedAtColumnName(), 'datetime', ['notnull' => false]);
+        $schemaChangelog->addColumn($this->configuration->getExecutionTimeColumnName(), 'integer', ['notnull' => false]);
+
+        $schemaChangelog->setPrimaryKey([$this->configuration->getVersionColumnName()]);
+
+        return $schemaChangelog;
+    }
+
+    private function updateMigratedVersionsFromV1orV2toV3() : void
+    {
+        if ($this->migrationRepository === null) {
+            return;
+        }
+
+        $availableMigrations = $this->migrationRepository->getMigrations()->getItems();
+        $executedMigrations  = $this->getExecutedMigrations()->getItems();
+
+        foreach ($availableMigrations as $availableMigration) {
+            foreach ($executedMigrations as $k => $executedMigration) {
+                if ($this->isAlreadyV3Format($availableMigration, $executedMigration)) {
+                    continue;
+                }
+
+                $this->connection->update(
+                    $this->configuration->getTableName(),
+                    [
+                        $this->configuration->getVersionColumnName() => (string) $availableMigration->getVersion(),
+                    ],
+                    [
+                        $this->configuration->getVersionColumnName() => (string) $executedMigration->getVersion(),
+                    ]
+                );
+                unset($executedMigrations[$k]);
+            }
+        }
+    }
+
+    private function isAlreadyV3Format(AvailableMigration $availableMigration, ExecutedMigration $executedMigration) : bool
+    {
+        return strpos(
+            (string) $availableMigration->getVersion(),
+            (string) $executedMigration->getVersion()
+        ) !== (
+                strlen((string) $availableMigration->getVersion()) -
+                strlen((string) $executedMigration->getVersion())
+            );
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -132,6 +132,7 @@ EOT
             return 1;
         }
 
+        $this->getDependencyFactory()->getMetadataStorage()->ensureInitialized();
         $migrator->migrate($plan, $migratorConfiguration);
 
         return 0;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -180,6 +180,7 @@ EOT
             return 3;
         }
 
+        $this->getDependencyFactory()->getMetadataStorage()->ensureInitialized();
         $migrator->migrate($plan, $migratorConfiguration);
 
         return 0;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
@@ -35,10 +35,17 @@ EOT
             );
     }
 
-    public function execute(
-        InputInterface $input,
-        OutputInterface $output
-    ) : ?int {
+    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    {
+        $question = 'WARNING! You are about to execute a database migration that could result in schema changes and data loss. Are you sure you wish to continue? (y/n)';
+
+        if (! $this->canExecute($question, $input, $output)) {
+            $output->writeln('<error>Migration cancelled!</error>');
+
+            return 3;
+        }
+
+        $this->getDependencyFactory()->getMetadataStorage()->ensureInitialized();
         $version = $this->getDependencyFactory()->getRollup()->rollup();
 
         $output->writeln(sprintf(

--- a/lib/Doctrine/Migrations/Tools/Console/Command/SyncMetadataCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/SyncMetadataCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tools\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncMetadataCommand extends DoctrineCommand
+{
+    /** @var string */
+    protected static $defaultName = 'migrations:sync-metadata-storage';
+
+    protected function configure() : void
+    {
+        parent::configure();
+
+        $this
+            ->setAliases(['sync-metadata-storage'])
+            ->setDescription('Ensures that the metadata storage is at the latest version.')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command updates metadata storage the latest version.
+
+    <info>%command.full_name%</info>
+EOT
+            );
+    }
+
+    public function execute(
+        InputInterface $input,
+        OutputInterface $output
+    ) : int {
+        $this->getDependencyFactory()->getMetadataStorage()->ensureInitialized();
+
+        $output->writeln('Metadata storage synchronized');
+
+        return 0;
+    }
+}

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
+use Doctrine\Migrations\Exception\MetadataStorageError;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -39,7 +40,16 @@ EOT
     {
         $statusCalculator = $this->getDependencyFactory()->getMigrationStatusCalculator();
 
-        $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
+        try {
+            $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
+        } catch (MetadataStorageError $metadataStorageError) {
+            $output->writeln(sprintf(
+                '<error>%s</error>',
+                $metadataStorageError->getMessage()
+            ));
+
+            return 3;
+        }
 
         $newMigrations = $statusCalculator->getNewMigrations();
 

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Tools\Console\Command\LatestCommand;
 use Doctrine\Migrations\Tools\Console\Command\MigrateCommand;
 use Doctrine\Migrations\Tools\Console\Command\RollupCommand;
 use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
+use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
 use Doctrine\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
 use PackageVersions\Versions;
@@ -59,6 +60,7 @@ class ConsoleRunner
             new StatusCommand(),
             new VersionCommand(),
             new UpToDateCommand(),
+            new SyncMetadataCommand(),
         ]);
 
         if (! $cli->getHelperSet()->has('em')) {

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Metadata\Storage;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Finder\RecursiveRegexFinder;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version\MigrationFactory;
+use Doctrine\Migrations\Version\Version;
+use PHPUnit\Framework\TestCase;
+use function sprintf;
+
+class ExistingTableMetadataStorageTest extends TestCase
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var TableMetadataStorage */
+    private $storage;
+
+    /** @var TableMetadataStorageConfiguration */
+    private $config;
+
+    /** @var AbstractSchemaManager */
+    private $schemaManager;
+
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    private function getSqliteConnection() : Connection
+    {
+        $params = ['driver' => 'pdo_sqlite', 'memory' => true];
+
+        return DriverManager::getConnection($params);
+    }
+
+    public function setUp() : void
+    {
+        $this->connection    = $this->getSqliteConnection();
+        $this->schemaManager = $this->connection->getSchemaManager();
+
+        $migration                 = $this->createMock(AbstractMigration::class);
+        $versionFactory            = $this->createMock(MigrationFactory::class);
+        $this->migrationRepository = new MigrationRepository(
+            [],
+            [],
+            new RecursiveRegexFinder('#.*\\.php$#i'),
+            $versionFactory
+        );
+        $this->migrationRepository->registerMigrationInstance(new Version('Foo\\5678'), $migration);
+
+        $this->config = new TableMetadataStorageConfiguration();
+
+        $this->storage = new TableMetadataStorage($this->connection, $this->config, $this->migrationRepository);
+
+        // create partial table
+        $table = new Table($this->config->getTableName());
+        $table->addColumn($this->config->getVersionColumnName(), 'string', ['notnull' => true, 'length' => 24]);
+        $table->setPrimaryKey([ $this->config->getVersionColumnName()]);
+        $this->schemaManager->createTable($table);
+    }
+
+    public function testMigratedVersionUpdate() : void
+    {
+        $this->connection->insert($this->config->getTableName(), [$this->config->getVersionColumnName() => '1234']);
+        $this->connection->insert($this->config->getTableName(), [$this->config->getVersionColumnName() => '5678']);
+
+        $this->storage->ensureInitialized();
+
+        $rows = $this->connection->fetchAll(sprintf(
+            'SELECT * FROM %s ORDER BY %s ASC',
+            $this->config->getTableName(),
+            $this->config->getVersionColumnName()
+        ));
+
+        self::assertCount(2, $rows);
+
+        self::assertSame([
+            'version' => '1234',
+            'executed_at' => null,
+            'execution_time' => null,
+        ], $rows[0]);
+        self::assertSame([
+            'version' => 'Foo\\5678',
+            'executed_at' => null,
+            'execution_time' => null,
+        ], $rows[1]);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -143,6 +143,8 @@ class TableMetadataStorageTest extends TestCase
 
     public function testCompleteWithFloatTime() : void
     {
+        $this->storage->ensureInitialized();
+
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
         $result->setTime(31.49);
         $this->storage->complete($result);
@@ -245,6 +247,8 @@ class TableMetadataStorageTest extends TestCase
 
     public function testResetWithEmptySchema() : void
     {
+        $this->storage->ensureInitialized();
+
         $this->storage->reset();
 
         $sql = sprintf(

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/LatestCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/LatestCommandTest.php
@@ -46,6 +46,7 @@ class LatestCommandTest extends MigrationTestCase
 
         $this->migrationRepository = $dependencyFactory->getMigrationRepository();
         $this->metadataStorage     = $dependencyFactory->getMetadataStorage();
+        $this->metadataStorage->ensureInitialized();
 
         $this->command       = new LatestCommand(null, $dependencyFactory);
         $this->commandTester = new CommandTester($this->command);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -315,5 +315,6 @@ class MigrateCommandTest extends MigrationTestCase
         $this->migrateCommandTester = new CommandTester($this->migrateCommand);
 
         $this->storage = $this->dependencyFactory->getMetadataStorage();
+        $this->storage->ensureInitialized();
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
@@ -47,6 +47,7 @@ class MigrationVersionTest extends MigrationTestCase
 
         $this->migrationRepository = $dependencyFactory->getMigrationRepository();
         $this->metadataStorage     = $dependencyFactory->getMetadataStorage();
+        $this->metadataStorage->ensureInitialized();
 
         $this->command       = new VersionCommand(null, $dependencyFactory);
         $this->commandTester = new CommandTester($this->command);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/RollupCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/RollupCommandTest.php
@@ -10,6 +10,8 @@ use Doctrine\Migrations\Tools\Console\Command\RollupCommand;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -26,8 +28,46 @@ final class RollupCommandTest extends TestCase
 
     public function testExecute() : void
     {
+        $this->dependencyFactory
+            ->expects(self::once())
+            ->method('getRollup')
+            ->willReturn($this->rollup);
+
+        $this->rollup->expects(self::once())
+            ->method('rollup')
+            ->willReturn(new Version('1234'));
+
         $input  = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
+
+        $output->expects(self::once())
+            ->method('writeln')
+            ->with('Rolled up migrations to version <info>1234</info>');
+
+        $this->rollupCommand->execute($input, $output);
+    }
+
+    public function testExecutionContinuesWhenAnsweringYes() : void
+    {
+        $questions = $this->createMock(QuestionHelper::class);
+        $questions->expects(self::once())
+            ->method('ask')
+            ->willReturn(true);
+
+        $this->rollupCommand->setHelperSet(new HelperSet(['question' => $questions]));
+
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->expects(self::atLeastOnce())
+            ->method('isInteractive')
+            ->willReturn(true);
+
+        $output = $this->createMock(OutputInterface::class);
+
+        $this->dependencyFactory
+            ->expects(self::once())
+            ->method('getRollup')
+            ->willReturn($this->rollup);
 
         $this->rollup->expects(self::once())
             ->method('rollup')
@@ -40,16 +80,38 @@ final class RollupCommandTest extends TestCase
         $this->rollupCommand->execute($input, $output);
     }
 
+    public function testExecutionStoppedWhenAnsweringNo() : void
+    {
+        $questions = $this->createMock(QuestionHelper::class);
+        $questions->expects(self::once())
+            ->method('ask')
+            ->willReturn(false);
+
+        $input = $this->createMock(InputInterface::class);
+        $input
+            ->expects(self::atLeastOnce())
+            ->method('isInteractive')
+            ->willReturn(true);
+
+        $output = $this->createMock(OutputInterface::class);
+
+        $this->dependencyFactory
+            ->expects(self::never())
+            ->method('getRollup');
+
+        $this->rollup->expects(self::never())
+            ->method('rollup');
+
+        $this->rollupCommand->setHelperSet(new HelperSet(['question' => $questions]));
+        $exitCode = $this->rollupCommand->execute($input, $output);
+
+        self::assertSame(3, $exitCode);
+    }
+
     protected function setUp() : void
     {
         $this->rollup            = $this->createMock(Rollup::class);
         $this->dependencyFactory = $this->createMock(DependencyFactory::class);
-
-        $this->dependencyFactory
-            ->expects(self::once())
-            ->method('getRollup')
-            ->willReturn($this->rollup);
-
-        $this->rollupCommand = new RollupCommand(null, $this->dependencyFactory);
+        $this->rollupCommand     = new RollupCommand(null, $this->dependencyFactory);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
@@ -52,6 +52,8 @@ class StatusCommandTest extends MigrationTestCase
         $this->migrationRepository = $dependencyFactory->getMigrationRepository();
         $this->metadataStorage     = $dependencyFactory->getMetadataStorage();
 
+        $this->metadataStorage->ensureInitialized();
+
         $this->command       = new StatusCommand(null, $dependencyFactory);
         $this->commandTester = new CommandTester($this->command);
     }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/SyncMetadataCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/SyncMetadataCommandTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Tools\Console\Command;
+
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
+use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class SyncMetadataCommandTest extends TestCase
+{
+    /** @var DependencyFactory|MockObject */
+    private $dependencyFactory;
+
+    /** @var MetadataStorage|MockObject */
+    private $storage;
+
+    /** @var SyncMetadataCommand */
+    private $storageCommand;
+
+    public function testExecute() : void
+    {
+        $input  = $this->createMock(InputInterface::class);
+        $output = $this->createMock(OutputInterface::class);
+
+        $this->storage->expects(self::once())
+            ->method('ensureInitialized');
+
+        $output->expects(self::once())
+            ->method('writeln')
+            ->with('Metadata storage synchronized');
+
+        $this->storageCommand->execute($input, $output);
+    }
+
+    protected function setUp() : void
+    {
+        $this->storage           = $this->createMock(MetadataStorage::class);
+        $this->dependencyFactory = $this->createMock(DependencyFactory::class);
+
+        $this->dependencyFactory
+            ->expects(self::once())
+            ->method('getMetadataStorage')
+            ->willReturn($this->storage);
+
+        $this->storageCommand = new SyncMetadataCommand(null, $this->dependencyFactory);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -131,13 +131,15 @@ final class AliasResolverTest extends TestCase
 
         $versionFactory = $this->createMock(MigrationFactory::class);
 
-        $this->migrationRepository  = new MigrationRepository(
+        $this->migrationRepository = new MigrationRepository(
             [],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
             $versionFactory
         );
-        $this->metadataStorage      = new TableMetadataStorage($conn);
+        $this->metadataStorage     = new TableMetadataStorage($conn);
+        $this->metadataStorage->ensureInitialized();
+
         $this->statusCalculator     = new CurrentMigrationStatusCalculator($this->migrationRepository, $this->metadataStorage);
         $this->versionAliasResolver = new DefaultAliasResolver(
             $this->migrationRepository,


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #788 #828

#### Summary

This PR:
- adds a command `migrations:sync-metadata-storage` that ensure the table scheme `doctrine_migrations` is always up to date
- auto-migrates the v2 table structure to the v3 table structure
- each command before starting checks if the metadata table is up to date


~The `Allow phpunit 7.5` commit should be removed when https://github.com/doctrine/migrations/pull/879 will be merged~