### PR TITLE
Allow dump schema when migrations in other namespaces are present

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Exception/SchemaDumpRequiresNoMigrations.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Exception/SchemaDumpRequiresNoMigrations.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tools\Console\Exception;
 
 use RuntimeException;
+use function sprintf;
 
 final class SchemaDumpRequiresNoMigrations extends RuntimeException implements ConsoleException
 {
-    public static function new() : self
+    public static function new(string $namespace) : self
     {
-        return new self('Delete any previous migrations before dumping your schema.');
+        return new self(sprintf(
+            'Delete any previous migrations in the namespace "%s" before dumping your schema.',
+            $namespace
+        ));
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -41,12 +41,12 @@ final class DumpSchemaCommandTest extends TestCase
     public function testExecuteThrowsRuntimeException() : void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Delete any previous migrations before dumping your schema.');
+        $this->expectExceptionMessage('Delete any previous migrations in the namespace "FooNs" before dumping your schema.');
 
         $input  = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
 
-        $migration = new AvailableMigration(new Version('1'), $this->createMock(AbstractMigration::class));
+        $migration = new AvailableMigration(new Version('FooNs\Abc'), $this->createMock(AbstractMigration::class));
 
         $this->migrationRepository->expects(self::once())
             ->method('getMigrations')


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | yes/no
| Fixed issues | -

#### Summary

Being able to define migrations in multiple namespaces/folders, means that probably they belong to different part of the application, thus should be possible to dump those parts of the schema independently 