### PR TITLE
Allow to throw Exception in Migrations

### DIFF
--- a/lib/Doctrine/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/Migrations/AbstractMigration.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\Migrations;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\AbortMigration;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
+use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Psr\Log\LoggerInterface;
 use function func_get_args;
@@ -93,24 +95,42 @@ abstract class AbstractMigration
         }
     }
 
+    /**
+     * @throws MigrationException|DBALException
+     */
     public function preUp(Schema $schema) : void
     {
     }
 
+    /**
+     * @throws MigrationException|DBALException
+     */
     public function postUp(Schema $schema) : void
     {
     }
 
+    /**
+     * @throws MigrationException|DBALException
+     */
     public function preDown(Schema $schema) : void
     {
     }
 
+    /**
+     * @throws MigrationException|DBALException
+     */
     public function postDown(Schema $schema) : void
     {
     }
 
+    /**
+     * @throws MigrationException|DBALException
+     */
     abstract public function up(Schema $schema) : void;
 
+    /**
+     * @throws MigrationException|DBALException
+     */
     abstract public function down(Schema $schema) : void;
 
     /**
@@ -138,6 +158,9 @@ abstract class AbstractMigration
         $this->logger->notice($message, ['migration' => $this]);
     }
 
+    /**
+     * @throws IrreversibleMigration
+     */
     protected function throwIrreversibleMigrationException(?string $message = null) : void
     {
         if ($message === null) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

<!-- Provide a summary your change. -->
When generating a migration, I getting
```
public function up(Schema $schema): void
    {
        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');

        ...
    }
```

This means the up function is allowed to throw AbortIf and DBAL Exception but it's not specified in the phpdoc of the parent function. The parent/children Exception should be compatible and some tools are looking for `@throws` tag to check this.