### PR TITLE
[up-to-date] print the names of executed unavailable migrations

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
+use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use function array_map;
 use function count;
+use function implode;
 use function sprintf;
 
 /**
@@ -42,9 +45,9 @@ EOT
         $newMigrations                 = $planCalculator->getNewMigrations();
 
         $newMigrationsCount                 = count($newMigrations);
-        $executedUnavailableMigrationsCount =  count($executedUnavailableMigrations);
+        $executedUnavailableMigrationsCount = count($executedUnavailableMigrations);
 
-        if ($newMigrationsCount === 0 && $executedUnavailableMigrationsCount ===0) {
+        if ($newMigrationsCount === 0 && $executedUnavailableMigrationsCount === 0) {
             $output->writeln('<comment>Up-to-date! No migrations to execute.</comment>');
 
             return 0;
@@ -68,6 +71,10 @@ EOT
                 $executedUnavailableMigrationsCount > 1 ? 'are not' : 'is not a',
                 $executedUnavailableMigrationsCount > 1 ? 's' : ''
             ));
+            $names = array_map(static function (ExecutedMigration $migration) : string {
+                return (string) $migration->getVersion();
+            }, $executedUnavailableMigrations->getItems());
+            $output->writeln('>>> ' . implode(', ', $names));
         }
 
         return $executedUnavailableMigrationsCount > 0 && $input->getOption('fail-on-unregistered') === true ? 2 : 0;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

I was confused why the up-to-date command does not tell which migrations are missing. ~~From the logic in this command, we can't tell so at least we can point to the status command which will output that information.~~ As we have the list available, print it.

~~(Looking at the code, there is a scenario where i have an additional migration that should be done, and have a migration in the database that has been deleted in the filesystem. If those 2 numbers are the same, the up-to-date command will incorrectly state that all is up to date. This should be improved but i consider it out of scope for this small improvement here.)~~ (i had been looking at an outdated version of the command)