### PR TITLE
Executed at must be an integer

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/ExecutedMigration.php
+++ b/lib/Doctrine/Migrations/Metadata/ExecutedMigration.php
@@ -16,20 +16,20 @@ final class ExecutedMigration
     private $executedAt;
 
     /**
-     * Milliseconds
+     * Seconds
      *
-     * @var int|null
+     * @var float|null
      */
     public $executionTime;
 
-    public function __construct(Version $version, ?DateTimeImmutable $executedAt = null, ?int $executionTime = null)
+    public function __construct(Version $version, ?DateTimeImmutable $executedAt = null, ?float $executionTime = null)
     {
         $this->version       = $version;
         $this->executedAt    = $executedAt;
         $this->executionTime = $executionTime;
     }
 
-    public function getExecutionTime() : ?int
+    public function getExecutionTime() : ?float
     {
         return $this->executionTime;
     }

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -19,7 +19,8 @@ use Doctrine\Migrations\Version\Version;
 use InvalidArgumentException;
 use const CASE_LOWER;
 use function array_change_key_case;
-use function intval;
+use function floatval;
+use function round;
 use function sprintf;
 use function strtolower;
 
@@ -91,7 +92,7 @@ final class TableMetadataStorage implements MetadataStorage
                 : null;
 
             $executionTime = isset($row[strtolower($this->configuration->getExecutionTimeColumnName())])
-                ? intval($row[strtolower($this->configuration->getExecutionTimeColumnName())])
+                ? floatval($row[strtolower($this->configuration->getExecutionTimeColumnName())]/1000)
                 : null;
 
             $migration = new ExecutedMigration(
@@ -130,7 +131,7 @@ final class TableMetadataStorage implements MetadataStorage
             $this->connection->insert($this->configuration->getTableName(), [
                 $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
                 $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
-                $this->configuration->getExecutionTimeColumnName() => $result->getTime(),
+                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : round($result->getTime()*1000),
             ], [
                 Type::STRING,
                 Type::DATETIME,

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -223,7 +223,7 @@ final class DbalExecutor implements Executor
         $migration->{'post' . ucfirst($direction)}($toSchema);
         $stopwatchEvent->stop();
 
-        $result->setTime($stopwatchEvent->getDuration());
+        $result->setTime((float) $stopwatchEvent->getDuration());
         $result->setMemory($stopwatchEvent->getMemory());
         $plan->markAsExecuted($result);
 

--- a/tests/Doctrine/Migrations/Tests/Metadata/ExecutedMigrationSetTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/ExecutedMigrationSetTest.php
@@ -116,9 +116,9 @@ class ExecutedMigrationSetTest extends TestCase
     public function testExecutedMigrationWithTiming() : void
     {
         $date = new DateTimeImmutable();
-        $m1   = new ExecutedMigration(new Version('A'), $date, 123);
+        $m1   = new ExecutedMigration(new Version('A'), $date, 123.0);
 
         self::assertSame($date, $m1->getExecutedAt());
-        self::assertSame(123, $m1->getExecutionTime());
+        self::assertSame(123.0, $m1->getExecutionTime());
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -80,7 +80,7 @@ class TableMetadataStorageTest extends TestCase
     public function testComplete() : void
     {
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
-        $result->setTime(31);
+        $result->setTime(31.0);
         $this->storage->complete($result);
 
         $sql  = sprintf(
@@ -93,7 +93,28 @@ class TableMetadataStorageTest extends TestCase
                 [
                     'version' => '1230',
                     'executed_at' => '2010-01-05 10:30:21',
-                    'execution_time' => '31',
+                    'execution_time' => '31000',
+                ],
+        ], $rows);
+    }
+
+    public function testCompleteWithFloatTime() : void
+    {
+        $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
+        $result->setTime(31.49);
+        $this->storage->complete($result);
+
+        $sql  = sprintf(
+            'SELECT * FROM %s',
+            $this->connection->getDatabasePlatform()->quoteIdentifier($this->config->getTableName())
+        );
+        $rows = $this->connection->fetchAll($sql);
+        self::assertSame([
+            0 =>
+                [
+                    'version' => '1230',
+                    'executed_at' => '2010-01-05 10:30:21',
+                    'execution_time' => '31490',
                 ],
         ], $rows);
     }
@@ -102,7 +123,7 @@ class TableMetadataStorageTest extends TestCase
     {
         $date    = new DateTimeImmutable('2010-01-05 10:30:21');
         $result1 = new ExecutionResult(new Version('1230'), Direction::UP, $date);
-        $result1->setTime(31);
+        $result1->setTime(31.0);
         $this->storage->complete($result1);
 
         $result2 = new ExecutionResult(new Version('1231'), Direction::UP);
@@ -119,7 +140,7 @@ class TableMetadataStorageTest extends TestCase
         self::assertEquals($result1->getVersion(), $m1->getVersion());
         self::assertNotNull($m1->getExecutedAt());
         self::assertSame($date->format(DateTime::ISO8601), $m1->getExecutedAt()->format(DateTime::ISO8601));
-        self::assertSame(31, $m1->getExecutionTime());
+        self::assertSame(31.0, $m1->getExecutionTime());
 
         $m2 = $executedMigrations->getMigration($result2->getVersion());
 
@@ -131,16 +152,16 @@ class TableMetadataStorageTest extends TestCase
     public function testExecutedMigrationWithTiming() : void
     {
         $date = new DateTimeImmutable();
-        $m1   = new ExecutedMigration(new Version('A'), $date, 123);
+        $m1   = new ExecutedMigration(new Version('A'), $date, 123.0);
 
         self::assertSame($date, $m1->getExecutedAt());
-        self::assertSame(123, $m1->getExecutionTime());
+        self::assertSame(123.0, $m1->getExecutionTime());
     }
 
     public function testCompleteDownRemovesTheRow() : void
     {
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
-        $result->setTime(31);
+        $result->setTime(31.0);
         $this->storage->complete($result);
 
         $sql = sprintf(
@@ -150,7 +171,7 @@ class TableMetadataStorageTest extends TestCase
         self::assertCount(1, $this->connection->fetchAll($sql));
 
         $result = new ExecutionResult(new Version('1230'), Direction::DOWN, new DateTimeImmutable('2010-01-05 10:30:21'));
-        $result->setTime(31);
+        $result->setTime(31.0);
         $this->storage->complete($result);
 
         self::assertCount(0, $this->connection->fetchAll($sql));
@@ -159,7 +180,7 @@ class TableMetadataStorageTest extends TestCase
     public function testReset() : void
     {
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
-        $result->setTime(31);
+        $result->setTime(31.0);
         $this->storage->complete($result);
 
         $sql = sprintf(

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
@@ -59,7 +59,7 @@ class StatusCommandTest extends MigrationTestCase
     public function testExecute() : void
     {
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-01 02:03:04'));
-        $result->setTime(10);
+        $result->setTime(10.0);
         $this->metadataStorage->complete($result);
 
         $result = new ExecutionResult(new Version('1233'), Direction::UP);
@@ -116,7 +116,7 @@ class StatusCommandTest extends MigrationTestCase
         $this->migrationRepository->registerMigrationInstance(new Version('1230'), $migrationClass);
 
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-01 02:03:04'));
-        $result->setTime(10);
+        $result->setTime(10.0);
         $this->metadataStorage->complete($result);
 
         $result = new ExecutionResult(new Version('1233'), Direction::UP);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | -
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary



- `executed_at` must be an integer

