### PR TITLE
Initialize schema table even on reset

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -108,6 +108,10 @@ final class TableMetadataStorage implements MetadataStorage
 
     public function reset() : void
     {
+        if (! $this->isInitialized()) {
+            $this->initialize();
+        }
+
         $this->connection->executeUpdate(
             sprintf(
                 'DELETE FROM %s WHERE 1 = 1',

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -172,4 +172,15 @@ class TableMetadataStorageTest extends TestCase
 
         self::assertCount(0, $this->connection->fetchAll($sql));
     }
+
+    public function testResetWithEmptySchema() : void
+    {
+        $this->storage->reset();
+
+        $sql = sprintf(
+            'SELECT * FROM %s',
+            $this->connection->getDatabasePlatform()->quoteIdentifier($this->config->getTableName())
+        );
+        self::assertCount(0, $this->connection->fetchAll($sql));
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | -

#### Summary

Do not crash when calling `reset` on a database that has no schema table yet
