### PR TITLE
Split migration planner and extract relative interfaces

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -35,6 +35,7 @@ use Doctrine\Migrations\Version\DbalExecutor;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Executor;
 use Doctrine\Migrations\Version\MigrationFactory;
+use Doctrine\Migrations\Version\MigrationPlanCalculator;
 use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\SortedMigrationPlanCalculator;
 use Doctrine\ORM\EntityManagerInterface;
@@ -303,9 +304,9 @@ class DependencyFactory
         });
     }
 
-    public function getMigrationPlanCalculator() : SortedMigrationPlanCalculator
+    public function getMigrationPlanCalculator() : MigrationPlanCalculator
     {
-        return $this->getDependency(SortedMigrationPlanCalculator::class, function () : SortedMigrationPlanCalculator {
+        return $this->getDependency(MigrationPlanCalculator::class, function () : MigrationPlanCalculator {
             return new SortedMigrationPlanCalculator(
                 $this->getMigrationRepository(),
                 $this->getMetadataStorage()

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -35,6 +35,7 @@ use Doctrine\Migrations\Version\DbalExecutor;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Executor;
 use Doctrine\Migrations\Version\MigrationFactory;
+use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\SortedMigrationPlanCalculator;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -292,9 +293,9 @@ class DependencyFactory
         });
     }
 
-    public function getMigrationStatusCalculator() : CurrentMigrationStatusCalculator
+    public function getMigrationStatusCalculator() : MigrationStatusCalculator
     {
-        return $this->getDependency(CurrentMigrationStatusCalculator::class, function () : CurrentMigrationStatusCalculator {
+        return $this->getDependency(MigrationStatusCalculator::class, function () : MigrationStatusCalculator {
             return new CurrentMigrationStatusCalculator(
                 $this->getMigrationRepository(),
                 $this->getMetadataStorage()

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -30,10 +30,12 @@ use Doctrine\Migrations\Tools\Console\ConsoleInputMigratorConfigurationFactory;
 use Doctrine\Migrations\Tools\Console\Helper\MigrationStatusInfosHelper;
 use Doctrine\Migrations\Tools\Console\MigratorConfigurationFactory;
 use Doctrine\Migrations\Version\AliasResolver;
+use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DbalExecutor;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Executor;
 use Doctrine\Migrations\Version\MigrationFactory;
+use Doctrine\Migrations\Version\SortedMigrationPlanCalculator;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -285,15 +287,25 @@ class DependencyFactory
             return new DefaultAliasResolver(
                 $this->getMigrationRepository(),
                 $this->getMetadataStorage(),
-                $this->getMigrationPlanCalculator()
+                $this->getMigrationStatusCalculator()
             );
         });
     }
 
-    public function getMigrationPlanCalculator() : MigrationPlanCalculator
+    public function getMigrationStatusCalculator() : CurrentMigrationStatusCalculator
     {
-        return $this->getDependency(MigrationPlanCalculator::class, function () : MigrationPlanCalculator {
-            return new MigrationPlanCalculator(
+        return $this->getDependency(CurrentMigrationStatusCalculator::class, function () : CurrentMigrationStatusCalculator {
+            return new CurrentMigrationStatusCalculator(
+                $this->getMigrationRepository(),
+                $this->getMetadataStorage()
+            );
+        });
+    }
+
+    public function getMigrationPlanCalculator() : SortedMigrationPlanCalculator
+    {
+        return $this->getDependency(SortedMigrationPlanCalculator::class, function () : SortedMigrationPlanCalculator {
+            return new SortedMigrationPlanCalculator(
                 $this->getMigrationRepository(),
                 $this->getMetadataStorage()
             );

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -130,7 +130,8 @@ EOT
         }
 
         $planCalculator                = $this->getDependencyFactory()->getMigrationPlanCalculator();
-        $executedUnavailableMigrations = $planCalculator->getExecutedUnavailableMigrations();
+        $statusCalculator              = $this->getDependencyFactory()->getMigrationStatusCalculator();
+        $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
 
         if ($this->checkExecutedUnavailableMigrations($executedUnavailableMigrations, $input, $output) === false) {
             return 3;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -50,15 +50,15 @@ EOT
 
     public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
-        $storage        = $this->getDependencyFactory()->getMetadataStorage();
-        $migrationRepo  = $this->getDependencyFactory()->getMigrationRepository();
-        $planCalculator = $this->getDependencyFactory()->getMigrationPlanCalculator();
+        $storage       = $this->getDependencyFactory()->getMetadataStorage();
+        $migrationRepo = $this->getDependencyFactory()->getMigrationRepository();
 
         $availableMigrations = $migrationRepo->getMigrations();
         $executedMigrations  = $storage->getExecutedMigrations();
 
-        $newMigrations                 = $planCalculator->getNewMigrations();
-        $executedUnavailableMigrations = $planCalculator->getExecutedUnavailableMigrations();
+        $statusCalculator              = $this->getDependencyFactory()->getMigrationStatusCalculator();
+        $newMigrations                 = $statusCalculator->getNewMigrations();
+        $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
 
         $infosHelper = $this->getDependencyFactory()->getMigrationStatusInfosHelper();
         $infosHelper->showMigrationsInfo($output, $availableMigrations, $executedMigrations, $newMigrations, $executedUnavailableMigrations);

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -37,9 +37,11 @@ EOT
 
     public function execute(InputInterface $input, OutputInterface $output) : ?int
     {
-        $planCalculator                = $this->getDependencyFactory()->getMigrationPlanCalculator();
-        $executedUnavailableMigrations = $planCalculator->getExecutedUnavailableMigrations();
-        $newMigrations                 = $planCalculator->getNewMigrations();
+        $statusCalculator = $this->getDependencyFactory()->getMigrationStatusCalculator();
+
+        $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
+
+        $newMigrations = $statusCalculator->getNewMigrations();
 
         $newMigrationsCount                 = count($newMigrations);
         $executedUnavailableMigrationsCount =  count($executedUnavailableMigrations);

--- a/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
@@ -35,7 +35,7 @@ final class CurrentMigrationStatusCalculator implements MigrationStatusCalculato
         $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
         $availableMigrationsSet = $this->migrationRepository->getMigrations();
 
-        return new ExecutedMigrationsSet(array_filter($executedMigrationsSet->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigrationsSet) {
+        return new ExecutedMigrationsSet(array_filter($executedMigrationsSet->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigrationsSet) : bool {
             return ! $availableMigrationsSet->hasMigration($migrationInfo->getVersion());
         }));
     }
@@ -45,7 +45,7 @@ final class CurrentMigrationStatusCalculator implements MigrationStatusCalculato
         $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
         $availableMigrationsSet = $this->migrationRepository->getMigrations();
 
-        return new AvailableMigrationsList(array_filter($availableMigrationsSet->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrationsSet) {
+        return new AvailableMigrationsList(array_filter($availableMigrationsSet->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrationsSet) : bool {
             return ! $executedMigrationsSet->hasMigration($migrationInfo->getVersion());
         }));
     }

--- a/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
@@ -15,10 +15,8 @@ use function array_filter;
 /**
  * The MigrationPlanCalculator is responsible for calculating the plan for migrating from the current
  * version to another version.
- *
- * @internal
  */
-final class CurrentMigrationStatusCalculator
+final class CurrentMigrationStatusCalculator implements MigrationStatusCalculator
 {
     /** @var MigrationRepository */
     private $migrationRepository;

--- a/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Version;
+
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\ExecutedMigration;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
+use Doctrine\Migrations\MigrationRepository;
+use function array_filter;
+
+/**
+ * The MigrationPlanCalculator is responsible for calculating the plan for migrating from the current
+ * version to another version.
+ *
+ * @internal
+ */
+final class CurrentMigrationStatusCalculator
+{
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    /** @var MetadataStorage */
+    private $metadataStorage;
+
+    public function __construct(MigrationRepository $migrationRepository, MetadataStorage $metadataStorage)
+    {
+        $this->migrationRepository = $migrationRepository;
+        $this->metadataStorage     = $metadataStorage;
+    }
+
+    public function getExecutedUnavailableMigrations() : ExecutedMigrationsSet
+    {
+        $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
+        $availableMigrationsSet = $this->migrationRepository->getMigrations();
+
+        return new ExecutedMigrationsSet(array_filter($executedMigrationsSet->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigrationsSet) {
+            return ! $availableMigrationsSet->hasMigration($migrationInfo->getVersion());
+        }));
+    }
+
+    public function getNewMigrations() : AvailableMigrationsList
+    {
+        $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
+        $availableMigrationsSet = $this->migrationRepository->getMigrations();
+
+        return new AvailableMigrationsList(array_filter($availableMigrationsSet->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrationsSet) {
+            return ! $executedMigrationsSet->hasMigration($migrationInfo->getVersion());
+        }));
+    }
+}

--- a/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
+++ b/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
@@ -31,13 +31,13 @@ final class DefaultAliasResolver implements AliasResolver
     /** @var MetadataStorage */
     private $metadataStorage;
 
-    /** @var CurrentMigrationStatusCalculator */
+    /** @var MigrationStatusCalculator */
     private $migrationStatusCalculator;
 
     public function __construct(
         MigrationRepository $migrationRepository,
         MetadataStorage $metadataStorage,
-        CurrentMigrationStatusCalculator $migrationStatusCalculator
+        MigrationStatusCalculator $migrationStatusCalculator
     ) {
         $this->migrationRepository       = $migrationRepository;
         $this->metadataStorage           = $metadataStorage;

--- a/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
+++ b/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
@@ -8,7 +8,6 @@ use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Exception\NoMigrationsToExecute;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-use Doctrine\Migrations\MigrationPlanCalculator;
 use Doctrine\Migrations\MigrationRepository;
 use function count;
 use function substr;
@@ -32,14 +31,17 @@ final class DefaultAliasResolver implements AliasResolver
     /** @var MetadataStorage */
     private $metadataStorage;
 
-    /** @var MigrationPlanCalculator */
-    private $migrationPlanCalculator;
+    /** @var CurrentMigrationStatusCalculator */
+    private $migrationStatusCalculator;
 
-    public function __construct(MigrationRepository $migrationRepository, MetadataStorage $metadataStorage, MigrationPlanCalculator $migrationPlanCalculator)
-    {
-        $this->migrationRepository     = $migrationRepository;
-        $this->metadataStorage         = $metadataStorage;
-        $this->migrationPlanCalculator = $migrationPlanCalculator;
+    public function __construct(
+        MigrationRepository $migrationRepository,
+        MetadataStorage $metadataStorage,
+        CurrentMigrationStatusCalculator $migrationStatusCalculator
+    ) {
+        $this->migrationRepository       = $migrationRepository;
+        $this->metadataStorage           = $metadataStorage;
+        $this->migrationStatusCalculator = $migrationStatusCalculator;
     }
 
     /**
@@ -82,7 +84,7 @@ final class DefaultAliasResolver implements AliasResolver
                 }
                 break;
             case self::ALIAS_NEXT:
-                $newMigrations = $this->migrationPlanCalculator->getNewMigrations();
+                $newMigrations = $this->migrationStatusCalculator->getNewMigrations();
 
                 try {
                     return $newMigrations->getFirst()->getVersion();
@@ -106,7 +108,7 @@ final class DefaultAliasResolver implements AliasResolver
                     $val             = (int) substr($alias, 7);
                     $targetMigration = null;
                     if ($val > 0) {
-                        $newMigrations = $this->migrationPlanCalculator->getNewMigrations();
+                        $newMigrations = $this->migrationStatusCalculator->getNewMigrations();
 
                         return $newMigrations->getFirst($val - 1)->getVersion();
                     }

--- a/lib/Doctrine/Migrations/Version/MigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/Version/MigrationPlanCalculator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Version;
+
+use Doctrine\Migrations\Metadata\MigrationPlanList;
+
+/**
+ * The MigrationPlanCalculator is responsible for calculating the plan for migrating from the current
+ * version to another version.
+ */
+interface MigrationPlanCalculator
+{
+    public function getPlanForExactVersion(Version $version, string $direction) : MigrationPlanList;
+
+    public function getPlanUntilVersion(?Version $to = null) : MigrationPlanList;
+}

--- a/lib/Doctrine/Migrations/Version/MigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/MigrationStatusCalculator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Version;
+
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+
+/**
+ * The MigrationStatusCalculator is responsible for calculating the current status of
+ * migrated and not available versions.
+ */
+interface MigrationStatusCalculator
+{
+    public function getExecutedUnavailableMigrations() : ExecutedMigrationsSet;
+
+    public function getNewMigrations() : AvailableMigrationsList;
+}

--- a/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
@@ -2,20 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Migrations;
+namespace Doctrine\Migrations\Version;
 
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Exception\NoMigrationsToExecute;
+use Doctrine\Migrations\Metadata;
 use Doctrine\Migrations\Metadata\AvailableMigration;
-use Doctrine\Migrations\Metadata\AvailableMigrationsList;
-use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
 use Doctrine\Migrations\Metadata\MigrationPlan;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-use Doctrine\Migrations\Version\Direction;
-use Doctrine\Migrations\Version\Version;
-use function array_filter;
+use Doctrine\Migrations\MigrationRepository;
 use function array_map;
 use function array_reverse;
 
@@ -25,7 +21,7 @@ use function array_reverse;
  *
  * @internal
  */
-final class MigrationPlanCalculator
+final class SortedMigrationPlanCalculator
 {
     /** @var MigrationRepository */
     private $migrationRepository;
@@ -112,25 +108,5 @@ final class MigrationPlanCalculator
         }
 
         return $toExecute;
-    }
-
-    public function getExecutedUnavailableMigrations() : ExecutedMigrationsSet
-    {
-        $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
-        $availableMigrationsSet = $this->migrationRepository->getMigrations();
-
-        return new ExecutedMigrationsSet(array_filter($executedMigrationsSet->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigrationsSet) {
-            return ! $availableMigrationsSet->hasMigration($migrationInfo->getVersion());
-        }));
-    }
-
-    public function getNewMigrations() : AvailableMigrationsList
-    {
-        $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
-        $availableMigrationsSet = $this->migrationRepository->getMigrations();
-
-        return new AvailableMigrationsList(array_filter($availableMigrationsSet->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrationsSet) {
-            return ! $executedMigrationsSet->hasMigration($migrationInfo->getVersion());
-        }));
     }
 }

--- a/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
@@ -21,7 +21,7 @@ use function array_reverse;
  *
  * @internal
  */
-final class SortedMigrationPlanCalculator
+final class SortedMigrationPlanCalculator implements MigrationPlanCalculator
 {
     /** @var MigrationRepository */
     private $migrationRepository;

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -11,12 +11,12 @@ use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
-use Doctrine\Migrations\MigrationPlanCalculator;
 use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Migrator;
 use Doctrine\Migrations\MigratorConfiguration;
 use Doctrine\Migrations\QueryWriter;
 use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
+use Doctrine\Migrations\Version\SortedMigrationPlanCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -149,7 +149,7 @@ class ExecuteCommandTest extends TestCase
             ->method('getMigration')
             ->willReturn($m1);
 
-        $planCalculator = new MigrationPlanCalculator($migrationRepository, $storage);
+        $planCalculator = new SortedMigrationPlanCalculator($migrationRepository, $storage);
 
         $configuration = new Configuration();
         $configuration->setMetadataStorageConfiguration(new TableMetadataStorageConfiguration());

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -13,8 +13,8 @@ use Doctrine\Migrations\Exception\UnknownMigrationVersion;
 use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
-use Doctrine\Migrations\MigrationPlanCalculator;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
@@ -34,8 +34,8 @@ final class AliasResolverTest extends TestCase
     /** @var TableMetadataStorage */
     private $metadataStorage;
 
-    /** @var MigrationPlanCalculator */
-    private $planCalculator;
+    /** @var CurrentMigrationStatusCalculator */
+    private $statusCalculator;
 
     /**
      * @dataProvider getAliases
@@ -137,11 +137,11 @@ final class AliasResolverTest extends TestCase
             $versionFactory
         );
         $this->metadataStorage      = new TableMetadataStorage($conn);
-        $this->planCalculator       = new MigrationPlanCalculator($this->migrationRepository, $this->metadataStorage);
+        $this->statusCalculator     = new CurrentMigrationStatusCalculator($this->migrationRepository, $this->metadataStorage);
         $this->versionAliasResolver = new DefaultAliasResolver(
             $this->migrationRepository,
             $this->metadataStorage,
-            $this->planCalculator
+            $this->statusCalculator
         );
     }
 

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -19,6 +19,7 @@ use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\MigrationFactory;
+use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 use function sys_get_temp_dir;
@@ -34,7 +35,7 @@ final class AliasResolverTest extends TestCase
     /** @var TableMetadataStorage */
     private $metadataStorage;
 
-    /** @var CurrentMigrationStatusCalculator */
+    /** @var MigrationStatusCalculator */
     private $statusCalculator;
 
     /**

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationPlanCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationPlanCalculatorTest.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Version\Direction;
+use Doctrine\Migrations\Version\MigrationPlanCalculator;
 use Doctrine\Migrations\Version\SortedMigrationPlanCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -21,7 +22,7 @@ use function count;
 
 final class MigrationPlanCalculatorTest extends TestCase
 {
-    /** @var SortedMigrationPlanCalculator */
+    /** @var MigrationPlanCalculator */
     private $migrationPlanCalculator;
 
     /** @var MockObject|MigrationRepository */

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Version;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\ExecutedMigration;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
+use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
+use Doctrine\Migrations\Version\Version;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class MigrationStatusCalculatorTest extends TestCase
+{
+    /** @var CurrentMigrationStatusCalculator */
+    private $migrationStatusCalculator;
+
+    /** @var MockObject|MigrationRepository */
+    private $migrationRepository;
+
+    /** @var MockObject|MetadataStorage */
+    private $metadataStorage;
+
+    /** @var MockObject|AbstractMigration */
+    private $abstractMigration;
+
+    protected function setUp() : void
+    {
+        $this->abstractMigration = $this->createMock(AbstractMigration::class);
+
+        $this->migrationRepository       = $this->createMock(MigrationRepository::class);
+        $this->metadataStorage           = $this->createMock(MetadataStorage::class);
+        $this->migrationStatusCalculator = new CurrentMigrationStatusCalculator($this->migrationRepository, $this->metadataStorage);
+    }
+
+    public function testGetNewMigrations() : void
+    {
+        $m1 = new AvailableMigration(new Version('A'), $this->abstractMigration);
+        $m2 = new AvailableMigration(new Version('B'), $this->abstractMigration);
+        $m3 = new AvailableMigration(new Version('C'), $this->abstractMigration);
+
+        $e1 = new ExecutedMigration(new Version('A'));
+
+        $this->migrationRepository
+            ->expects(self::any())
+            ->method('getMigrations')
+            ->willReturn(new AvailableMigrationsList([$m1, $m2, $m3]));
+
+        $this->metadataStorage
+            ->expects(self::atLeastOnce())
+            ->method('getExecutedMigrations')
+            ->willReturn(new ExecutedMigrationsSet([$e1]));
+
+        $newSet = $this->migrationStatusCalculator->getNewMigrations();
+
+        self::assertSame([$m2, $m3], $newSet->getItems());
+    }
+
+    public function testGetExecutedUnavailableMigrations() : void
+    {
+        $a1 = new AvailableMigration(new Version('A'), $this->abstractMigration);
+
+        $e1 = new ExecutedMigration(new Version('A'));
+        $e2 = new ExecutedMigration(new Version('B'));
+        $e3 = new ExecutedMigration(new Version('C'));
+
+        $this->migrationRepository
+            ->expects(self::any())
+            ->method('getMigrations')
+            ->willReturn(new AvailableMigrationsList([$a1]));
+
+        $this->metadataStorage
+            ->expects(self::atLeastOnce())
+            ->method('getExecutedMigrations')
+            ->willReturn(new ExecutedMigrationsSet([$e1, $e2, $e3]));
+
+        $newSet = $this->migrationStatusCalculator->getExecutedUnavailableMigrations();
+
+        self::assertSame([$e2, $e3], $newSet->getItems());
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
@@ -12,13 +12,14 @@ use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
+use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class MigrationStatusCalculatorTest extends TestCase
 {
-    /** @var CurrentMigrationStatusCalculator */
+    /** @var MigrationStatusCalculator */
     private $migrationStatusCalculator;
 
     /** @var MockObject|MigrationRepository */


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

This PR splits the current migration calculator in two separate interfaces. one for planing the migrations, and one for calculating the current migration status.
