### PR TITLE
Change Sorter callable to class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,8 @@
 - The "version" is the FQCN of the migration class (existing entries in the migrations table will be automatically updated).
 - `MigrationsEventArgs` and `MigrationsVersionEventArgs` expose different API, 
 please refer to the [Code BC breaks](#code-bc-breaks) section.
+- The `sorter` used in MigrationRepository is not callable anymore but a normal class. If you have custom sorting function 
+for sorting the migrations, please put this custom function in new class that implements the `Doctrine\Migrations\Sorter` interface.
 
 ## Console
 - Console output changed. The commands use a different output style. If you were relying on specific output, 

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -53,8 +53,6 @@ use function sprintf;
  */
 class DependencyFactory
 {
-    public const MIGRATIONS_SORTER = 'Doctrine\Migrations\MigrationsSorter';
-
     /** @var Configuration */
     private $configuration;
 
@@ -104,10 +102,10 @@ class DependencyFactory
         return $this->connection;
     }
 
-    public function getSorter() : ?callable
+    public function getSorter() : Sorter
     {
-        return $this->getDependency(self::MIGRATIONS_SORTER, static function () {
-            return null;
+        return $this->getDependency(MigrationsSorter::class, static function () : Sorter {
+            return new MigrationsSorter();
         });
     }
 

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -13,8 +13,6 @@ use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
 use function class_exists;
-use function strcmp;
-use function uasort;
 
 /**
  * The MigrationRepository class is responsible for retrieving migrations, determing what the current migration
@@ -39,7 +37,7 @@ class MigrationRepository
     /** @var AvailableMigration[] */
     private $migrations = [];
 
-    /** @var callable */
+    /** @var Sorter */
     private $sorter;
 
     /**
@@ -51,14 +49,12 @@ class MigrationRepository
         array $migrationDirectories,
         MigrationFinder $migrationFinder,
         MigrationFactory $versionFactory,
-        ?callable $sorter = null
+        Sorter $sorter
     ) {
         $this->migrationDirectories = $migrationDirectories;
         $this->migrationFinder      = $migrationFinder;
         $this->versionFactory       = $versionFactory;
-        $this->sorter               = $sorter ?: static function (AvailableMigration $m1, AvailableMigration $m2) {
-            return strcmp((string) $m1->getVersion(), (string) $m2->getVersion());
-        };
+        $this->sorter               = $sorter;
 
         $this->registerMigrations($classes);
     }
@@ -76,8 +72,6 @@ class MigrationRepository
         }
 
         $this->migrations[(string) $version] = new AvailableMigration($version, $migration);
-
-        uasort($this->migrations, $this->sorter);
 
         return $this->migrations[(string) $version];
     }
@@ -159,5 +153,7 @@ class MigrationRepository
                 );
                 $this->registerMigrations($migrations);
         }
+
+        $this->sorter->sort($this->migrations);
     }
 }

--- a/lib/Doctrine/Migrations/MigrationsSorter.php
+++ b/lib/Doctrine/Migrations/MigrationsSorter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use function strcmp;
+use function uasort;
+
+/**
+ * The MigrationsSorter class is responsible for sorting the migrations.
+ *
+ * @internal
+ */
+final class MigrationsSorter implements Sorter
+{
+    /** @var callable */
+    private $sortFunc;
+
+    public function __construct(?callable $sortFunc = null)
+    {
+        $this->sortFunc = $sortFunc ?: static function (AvailableMigration $m1, AvailableMigration $m2) {
+            return strcmp((string) $m1->getVersion(), (string) $m2->getVersion());
+        };
+    }
+
+    /** @param AvailableMigration[] $migrations */
+    public function sort(array &$migrations) : void
+    {
+        uasort($migrations, $this->sortFunc);
+    }
+}

--- a/lib/Doctrine/Migrations/Sorter.php
+++ b/lib/Doctrine/Migrations/Sorter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations;
+
+use Doctrine\Migrations\Metadata\AvailableMigration;
+
+/**
+ * The MigrationsSorter class is responsible for sorting the migrations.
+ *
+ * @internal
+ */
+interface Sorter
+{
+    /** @param AvailableMigration[] $migrations */
+    public function sort(array &$migrations) : void;
+}

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\MigrationsSorter;
 use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
@@ -53,7 +54,8 @@ class ExistingTableMetadataStorageTest extends TestCase
             [],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $versionFactory
+            $versionFactory,
+            new MigrationsSorter()
         );
         $this->migrationRepository->registerMigrationInstance(new Version('Foo\\5678'), $migration);
 

--- a/tests/Doctrine/Migrations/Tests/MigrationRepository/CustomMigrationsSorter.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationRepository/CustomMigrationsSorter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\MigrationRepository;
+
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Sorter;
+use function strcmp;
+use function uasort;
+
+class CustomMigrationsSorter implements Sorter
+{
+    /** @param AvailableMigration[] $migrations */
+    public function sort(array &$migrations) : void
+    {
+        uasort($migrations, static function (AvailableMigration $m1, AvailableMigration $m2) {
+            return strcmp((string) $m1->getVersion(), (string) $m2->getVersion())*-1;
+        });
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/MigrationRepository/MigrationRepositoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationRepository/MigrationRepositoryTest.php
@@ -8,8 +8,8 @@ use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Exception\DuplicateMigrationVersion;
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
 use Doctrine\Migrations\Finder\RecursiveRegexFinder;
-use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\MigrationsSorter;
 use Doctrine\Migrations\Tests\MigrationRepository\Migrations\A\A;
 use Doctrine\Migrations\Tests\MigrationRepository\Migrations\A\B;
 use Doctrine\Migrations\Tests\MigrationRepository\Migrations\B\C;
@@ -17,7 +17,6 @@ use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use function strcmp;
 
 class MigrationRepositoryTest extends TestCase
 {
@@ -53,7 +52,8 @@ class MigrationRepositoryTest extends TestCase
             [A::class],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $this->versionFactory
+            $this->versionFactory,
+            new MigrationsSorter()
         );
 
         $migrations = $migrationRepository->getMigrations();
@@ -70,7 +70,8 @@ class MigrationRepositoryTest extends TestCase
                 'Doctrine\Migrations\Tests\MigrationRepository\Migrations' => __DIR__ . '/NoMigrations',
             ],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $this->versionFactory
+            $this->versionFactory,
+            new MigrationsSorter()
         );
 
         $migrations = $migrationRepository->getMigrations();
@@ -87,9 +88,7 @@ class MigrationRepositoryTest extends TestCase
             ],
             new RecursiveRegexFinder('#.*\\.php$#i'),
             $this->versionFactory,
-            static function (AvailableMigration $m1, AvailableMigration $m2) {
-                return strcmp((string) $m1->getVersion(), (string) $m2->getVersion())*-1;
-            }
+            new CustomMigrationsSorter()
         );
 
         $migrations = $migrationRepository->getMigrations();
@@ -157,7 +156,8 @@ class MigrationRepositoryTest extends TestCase
                 'Doctrine\Migrations\Tests\MigrationRepository\Migrations' => __DIR__ . '/Migrations',
             ],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $this->versionFactory
+            $this->versionFactory,
+            new MigrationsSorter()
         );
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -14,6 +14,7 @@ use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\MigrationsSorter;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Direction;
@@ -135,7 +136,8 @@ final class AliasResolverTest extends TestCase
             [],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $versionFactory
+            $versionFactory,
+            new MigrationsSorter()
         );
         $this->metadataStorage     = new TableMetadataStorage($conn);
         $this->metadataStorage->ensureInitialized();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         |  improvement
| BC Break     | yes
| Fixed issues | -

#### Summary
This PR replaces the custom callable for sorting migrations with the class implementing new interface `Doctrine\Migrations\Sorter`.
It can help to define different sorting algorithms not just using the function `uasort`. I think it will be more universal for some edge cases.

It can be merged to master (prepared v3) which has not been tagged yet.

