### PR TITLE
Add `onMigrationsQueryExecuting` and  `onMigrationsQueryExecuted` events

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -8,6 +8,8 @@ there are no versions to be executed.
 - ``onMigrationsVersionExecuting``: dispatched before a single version executes.
 - ``onMigrationsVersionExecuted``: dispatched after a single version executes.
 - ``onMigrationsVersionSkipped``: dispatched when a single version is skipped.
+- ``onMigrationsQueryExecuting``: dispatched before a single query executes.
+- ``onMigrationsQueryExecuted``: dispatched after a single query executes.
 - ``onMigrationsMigrated``: dispatched when all versions have been executed.
 
 All of these events are emitted via the DBAL connection's event manager. Here's an example event subscriber that
@@ -19,6 +21,7 @@ listens for all possible migrations events.
 
     use Doctrine\Common\EventSubscriber;
     use Doctrine\Migrations\Event\MigrationsEventArgs;
+    use Doctrine\Migrations\Event\MigrationsQueryEventArgs;
     use Doctrine\Migrations\Event\MigrationsVersionEventArgs;
     use Doctrine\Migrations\Events;
 
@@ -32,6 +35,8 @@ listens for all possible migrations events.
                 Events::onMigrationsVersionExecuting,
                 Events::onMigrationsVersionExecuted,
                 Events::onMigrationsVersionSkipped,
+                Events::onMigrationsQueryExecuting,
+                Events::onMigrationsQueryExecuted,
             ];
         }
 
@@ -56,6 +61,16 @@ listens for all possible migrations events.
         }
 
         public function onMigrationsVersionSkipped(MigrationsVersionEventArgs $args) : void
+        {
+            // ...
+        }
+
+        public function onMigrationsQueryExecuting(MigrationsQueryEventArgs $args) : void
+        {
+            // ...
+        }
+
+        public function onMigrationsQueryExecuted(MigrationsQueryEventArgs $args) : void
         {
             // ...
         }

--- a/lib/Doctrine/Migrations/Event/MigrationsQueryEventArgs.php
+++ b/lib/Doctrine/Migrations/Event/MigrationsQueryEventArgs.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\Metadata\MigrationPlan;
+use Doctrine\Migrations\MigratorConfiguration;
+use Doctrine\Migrations\Query\Query;
+
+/**
+ * The MigrationsQueryEventArgs class is passed to events related to a single migration query from a version.
+ */
+final class MigrationsQueryEventArgs extends EventArgs
+{
+    /** @var Connection */
+    private $connection;
+
+    /** @var MigrationPlan */
+    private $plan;
+
+    /** @var MigratorConfiguration */
+    private $migratorConfiguration;
+
+    /** @var Query */
+    private $query;
+
+    public function __construct(
+        Connection $connection,
+        MigrationPlan $plan,
+        MigratorConfiguration $migratorConfiguration,
+        Query $query
+    ) {
+        $this->connection            = $connection;
+        $this->plan                  = $plan;
+        $this->migratorConfiguration = $migratorConfiguration;
+        $this->query                 = $query;
+    }
+
+    public function getConnection() : Connection
+    {
+        return $this->connection;
+    }
+
+    public function getPlan() : MigrationPlan
+    {
+        return $this->plan;
+    }
+
+    public function getMigratorConfiguration() : MigratorConfiguration
+    {
+        return $this->migratorConfiguration;
+    }
+
+    public function getQuery() : Query
+    {
+        return $this->query;
+    }
+}

--- a/lib/Doctrine/Migrations/EventDispatcher.php
+++ b/lib/Doctrine/Migrations/EventDispatcher.php
@@ -8,9 +8,11 @@ use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Event\MigrationsEventArgs;
+use Doctrine\Migrations\Event\MigrationsQueryEventArgs;
 use Doctrine\Migrations\Event\MigrationsVersionEventArgs;
 use Doctrine\Migrations\Metadata\MigrationPlan;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
+use Doctrine\Migrations\Query\Query;
 
 /**
  * The EventDispatcher class is responsible for dispatching events internally that a user can listen for.
@@ -54,6 +56,21 @@ final class EventDispatcher
         $this->dispatchEvent($eventName, $event);
     }
 
+    public function dispatchQueryExecuteEvent(
+        string $eventName,
+        MigrationPlan $plan,
+        MigratorConfiguration $migratorConfiguration,
+        Query $query
+    ) : void {
+        $event = $this->createMigrationsQueryEventArgs(
+            $plan,
+            $migratorConfiguration,
+            $query
+        );
+
+        $this->dispatchEvent($eventName, $event);
+    }
+
     private function dispatchEvent(string $eventName, ?EventArgs $args = null) : void
     {
         $this->eventManager->dispatchEvent($eventName, $args);
@@ -74,6 +91,19 @@ final class EventDispatcher
             $this->connection,
             $plan,
             $migratorConfiguration
+        );
+    }
+
+    private function createMigrationsQueryEventArgs(
+        MigrationPlan $plan,
+        MigratorConfiguration $migratorConfiguration,
+        Query $query
+    ) : MigrationsQueryEventArgs {
+        return new MigrationsQueryEventArgs(
+            $this->connection,
+            $plan,
+            $migratorConfiguration,
+            $query
         );
     }
 }

--- a/lib/Doctrine/Migrations/Events.php
+++ b/lib/Doctrine/Migrations/Events.php
@@ -11,6 +11,8 @@ final class Events
 {
     public const onMigrationsMigrating        = 'onMigrationsMigrating';
     public const onMigrationsMigrated         = 'onMigrationsMigrated';
+    public const onMigrationsQueryExecuting   = 'onMigrationsQueryExecuting';
+    public const onMigrationsQueryExecuted    = 'onMigrationsQueryExecuted';
     public const onMigrationsVersionExecuting = 'onMigrationsVersionExecuting';
     public const onMigrationsVersionExecuted  = 'onMigrationsVersionExecuted';
     public const onMigrationsVersionSkipped   = 'onMigrationsVersionSkipped';

--- a/lib/Doctrine/Migrations/Query/Query.php
+++ b/lib/Doctrine/Migrations/Query/Query.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Query;
+
+/**
+ * The Query wraps the sql query, parameters and types. It used in MigrationsQueryEventArgs.
+ */
+final class Query
+{
+    /** @var string */
+    private $statement;
+
+    /** @var mixed[] */
+    private $parameters;
+
+    /** @var mixed[] */
+    private $types;
+
+    /**
+     * @param mixed[] $parameters
+     * @param mixed[] $types
+     */
+    public function __construct(string $statement, array $parameters = [], array $types = [])
+    {
+        $this->statement  = $statement;
+        $this->parameters = $parameters;
+        $this->types      = $types;
+    }
+
+    public function getStatement() : string
+    {
+        return $this->statement;
+    }
+
+    /** @return mixed[] */
+    public function getParameters() : array
+    {
+        return $this->parameters;
+    }
+
+    /** @return mixed[] */
+    public function getTypes() : array
+    {
+        return $this->types;
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Event/EventArgsTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/EventArgsTest.php
@@ -7,10 +7,12 @@ namespace Doctrine\Migrations\Tests\Event;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Event\MigrationsEventArgs;
+use Doctrine\Migrations\Event\MigrationsQueryEventArgs;
 use Doctrine\Migrations\Event\MigrationsVersionEventArgs;
 use Doctrine\Migrations\Metadata\MigrationPlan;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
 use Doctrine\Migrations\MigratorConfiguration;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -42,6 +44,17 @@ class EventArgsTest extends TestCase
         self::assertSame($this->connection, $event->getConnection());
         self::assertSame($this->config, $event->getMigratorConfiguration());
         self::assertSame($this->plan, $event->getPlan());
+    }
+
+    public function testMigrationsQueryEventArgs() : void
+    {
+        $query = new Query('SELECT 1');
+        $event = new MigrationsQueryEventArgs($this->connection, $this->plan, $this->config, $query);
+
+        self::assertSame($this->connection, $event->getConnection());
+        self::assertSame($this->config, $event->getMigratorConfiguration());
+        self::assertSame($this->plan, $event->getPlan());
+        self::assertSame($query, $event->getQuery());
     }
 
     public function testMigrationsEventArgs() : void

--- a/tests/Doctrine/Migrations/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/Migrations/Tests/Query/QueryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Query;
+
+use Doctrine\Migrations\Query\Query;
+use Doctrine\Migrations\Tests\MigrationTestCase;
+
+final class QueryTest extends MigrationTestCase
+{
+    public function testGetQuery() : void
+    {
+        $query = new Query('foo', ['bar', 'baz'], ['qux', 'quux']);
+
+        self::assertSame('foo', $query->getStatement());
+        self::assertSame(['bar', 'baz'], $query->getParameters());
+        self::assertSame(['qux', 'quux'], $query->getTypes());
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Event\MigrationsQueryEventArgs;
 use Doctrine\Migrations\EventDispatcher;
 use Doctrine\Migrations\Events;
 use Doctrine\Migrations\Metadata\MigrationPlan;
@@ -27,6 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 use Throwable;
+use function implode;
 
 class ExecutorTest extends TestCase
 {
@@ -62,6 +64,9 @@ class ExecutorTest extends TestCase
 
     /** @var MockObject */
     private $metadataStorage;
+
+    /** @var Listener */
+    private $listener;
 
     public function testAddSql() : void
     {
@@ -180,32 +185,9 @@ class ExecutorTest extends TestCase
         $migratorConfiguration = (new MigratorConfiguration())
             ->setTimeAllQueries(true);
 
-        $listener = new class() {
-            /** @var bool */
-            public $onMigrationsVersionExecuting = false;
-            /** @var bool */
-            public $onMigrationsVersionExecuted = false;
-            /** @var bool */
-            public $onMigrationsVersionSkipped = false;
-
-            public function onMigrationsVersionExecuting() : void
-            {
-                $this->onMigrationsVersionExecuting = true;
-            }
-
-            public function onMigrationsVersionExecuted() : void
-            {
-                $this->onMigrationsVersionExecuted = true;
-            }
-
-            public function onMigrationsVersionSkipped() : void
-            {
-                $this->onMigrationsVersionSkipped = true;
-            }
-        };
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $this->listener);
 
         $plan                  = new MigrationPlan($this->version, $this->migration, Direction::UP);
         $this->migration->skip = true;
@@ -223,9 +205,11 @@ class ExecutorTest extends TestCase
         self::assertFalse($this->migration->preDownExecuted);
         self::assertFalse($this->migration->postDownExecuted);
 
-        self::assertFalse($listener->onMigrationsVersionExecuted);
-        self::assertTrue($listener->onMigrationsVersionSkipped);
-        self::assertTrue($listener->onMigrationsVersionExecuting);
+        self::assertFalse($this->listener->onMigrationsVersionExecuted);
+        self::assertTrue($this->listener->onMigrationsVersionSkipped);
+        self::assertTrue($this->listener->onMigrationsVersionExecuting);
+        self::assertFalse($this->listener->onMigrationsQueryExecuting);
+        self::assertFalse($this->listener->onMigrationsQueryExecuted);
     }
 
     /**
@@ -238,31 +222,21 @@ class ExecutorTest extends TestCase
 
         $plan = new MigrationPlan($this->version, $this->migration, Direction::UP);
 
-        $listener = new class() {
-            /** @var bool */
-            public $onMigrationsVersionExecuting = false;
-            /** @var bool */
-            public $onMigrationsVersionExecuted = false;
-
-            public function onMigrationsVersionExecuting() : void
-            {
-                $this->onMigrationsVersionExecuting = true;
-            }
-
-            public function onMigrationsVersionExecuted() : void
-            {
-                $this->onMigrationsVersionExecuted = true;
-            }
-        };
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsQueryExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsQueryExecuted, $this->listener);
 
         $this->versionExecutor->execute(
             $plan,
             $migratorConfiguration
         );
-        self::assertTrue($listener->onMigrationsVersionExecuted);
-        self::assertTrue($listener->onMigrationsVersionExecuting);
+        self::assertTrue($this->listener->onMigrationsVersionExecuted);
+        self::assertTrue($this->listener->onMigrationsVersionExecuting);
+        self::assertTrue($this->listener->onMigrationsQueryExecuting);
+        self::assertTrue($this->listener->onMigrationsQueryExecuted);
+        self::assertSame('SELECT 1;SELECT 2', implode(';', $this->listener->executingQueries));
+        self::assertSame('SELECT 1;SELECT 2', implode(';', $this->listener->executedQueries));
     }
 
     /**
@@ -280,32 +254,11 @@ class ExecutorTest extends TestCase
         $plan                   = new MigrationPlan($this->version, $this->migration, Direction::UP);
         $this->migration->error = true;
 
-        $listener = new class() {
-            /** @var bool */
-            public $onMigrationsVersionExecuting = false;
-            /** @var bool */
-            public $onMigrationsVersionExecuted = false;
-            /** @var bool */
-            public $onMigrationsVersionSkipped = false;
-
-            public function onMigrationsVersionExecuting() : void
-            {
-                $this->onMigrationsVersionExecuting = true;
-            }
-
-            public function onMigrationsVersionExecuted() : void
-            {
-                $this->onMigrationsVersionExecuted = true;
-            }
-
-            public function onMigrationsVersionSkipped() : void
-            {
-                $this->onMigrationsVersionSkipped = true;
-            }
-        };
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsQueryExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsQueryExecuted, $this->listener);
 
         $migrationSucceed = false;
         try {
@@ -315,9 +268,11 @@ class ExecutorTest extends TestCase
             );
             $migrationSucceed = true;
         } catch (Throwable $e) {
-            self::assertFalse($listener->onMigrationsVersionExecuted);
-            self::assertTrue($listener->onMigrationsVersionSkipped);
-            self::assertTrue($listener->onMigrationsVersionExecuting);
+            self::assertFalse($this->listener->onMigrationsVersionExecuted);
+            self::assertTrue($this->listener->onMigrationsVersionSkipped);
+            self::assertTrue($this->listener->onMigrationsVersionExecuting);
+            self::assertFalse($this->listener->onMigrationsQueryExecuting);
+            self::assertFalse($this->listener->onMigrationsQueryExecuted);
 
             $result = $plan->getResult();
             self::assertNotNull($result);
@@ -352,32 +307,11 @@ class ExecutorTest extends TestCase
 
         $plan = new MigrationPlan($this->version, $this->migration, Direction::UP);
 
-        $listener = new class() {
-            /** @var bool */
-            public $onMigrationsVersionExecuting = false;
-            /** @var bool */
-            public $onMigrationsVersionExecuted = false;
-            /** @var bool */
-            public $onMigrationsVersionSkipped = false;
-
-            public function onMigrationsVersionExecuting() : void
-            {
-                $this->onMigrationsVersionExecuting = true;
-            }
-
-            public function onMigrationsVersionExecuted() : void
-            {
-                $this->onMigrationsVersionExecuted = true;
-            }
-
-            public function onMigrationsVersionSkipped() : void
-            {
-                $this->onMigrationsVersionSkipped = true;
-            }
-        };
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $listener);
-        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsQueryExecuting, $this->listener);
+        $this->eventManager->addEventListener(Events::onMigrationsQueryExecuted, $this->listener);
 
         $migrationSucceed = false;
         try {
@@ -387,9 +321,13 @@ class ExecutorTest extends TestCase
             );
             $migrationSucceed = true;
         } catch (Throwable $e) {
-            self::assertFalse($listener->onMigrationsVersionExecuted);
-            self::assertTrue($listener->onMigrationsVersionSkipped);
-            self::assertTrue($listener->onMigrationsVersionExecuting);
+            self::assertFalse($this->listener->onMigrationsVersionExecuted);
+            self::assertTrue($this->listener->onMigrationsVersionSkipped);
+            self::assertTrue($this->listener->onMigrationsVersionExecuting);
+            self::assertTrue($this->listener->onMigrationsQueryExecuting);
+            self::assertTrue($this->listener->onMigrationsQueryExecuted);
+            self::assertSame('SELECT 1;SELECT 2', implode(';', $this->listener->executingQueries));
+            self::assertSame('SELECT 1;SELECT 2', implode(';', $this->listener->executedQueries));
 
             $result = $plan->getResult();
             self::assertNotNull($result);
@@ -465,6 +403,55 @@ class ExecutorTest extends TestCase
         $stopwatchEvent->expects(self::any())
             ->method('getMemory')
             ->willReturn(100);
+
+        $this->listener = new Listener();
+    }
+}
+
+class Listener
+{
+    /** @var bool */
+    public $onMigrationsVersionExecuting = false;
+    /** @var bool */
+    public $onMigrationsVersionExecuted = false;
+    /** @var bool */
+    public $onMigrationsVersionSkipped = false;
+    /** @var bool */
+    public $onMigrationsQueryExecuting = false;
+    /** @var bool */
+    public $onMigrationsQueryExecuted = false;
+    /** @var string[] */
+    public $executingQueries = [];
+    /** @var string[] */
+    public $executedQueries = [];
+
+    public function onMigrationsVersionExecuting() : void
+    {
+        $this->onMigrationsVersionExecuting = true;
+    }
+
+    public function onMigrationsVersionExecuted() : void
+    {
+        $this->onMigrationsVersionExecuted = true;
+    }
+
+    public function onMigrationsVersionSkipped() : void
+    {
+        $this->onMigrationsVersionSkipped = true;
+    }
+
+    public function onMigrationsQueryExecuting(MigrationsQueryEventArgs $migrationsQueryEventArgs) : void
+    {
+        $this->onMigrationsQueryExecuting = true;
+
+        $this->executingQueries[] = $migrationsQueryEventArgs->getQuery()->getStatement();
+    }
+
+    public function onMigrationsQueryExecuted(MigrationsQueryEventArgs $migrationsQueryEventArgs) : void
+    {
+        $this->onMigrationsQueryExecuted = true;
+
+        $this->executedQueries[] = $migrationsQueryEventArgs->getQuery()->getStatement();
     }
 }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary
This PR adds new events `onMigrationsQueryExecuting` and `onMigrationsQueryExecuted`.

#### Use case
When you are using Mysql cluster and you alter big table, this operation blocks the whole cluster until the alter is done (blocking DDL operations). With event `onMigrationsQueryExecuting` you can check if the migration contains query with alter for big table and stop it before it executes with exception to avoid DB problems.
Big alters are then processed manually with https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html

For more info: https://www.percona.com/blog/2014/11/18/avoiding-mysql-alter-table-downtime/
