### PR TITLE
Introduce version comparator

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -32,6 +32,8 @@ use Doctrine\Migrations\Tools\Console\ConsoleInputMigratorConfigurationFactory;
 use Doctrine\Migrations\Tools\Console\Helper\MigrationStatusInfosHelper;
 use Doctrine\Migrations\Tools\Console\MigratorConfigurationFactory;
 use Doctrine\Migrations\Version\AliasResolver;
+use Doctrine\Migrations\Version\AlphabeticalComparator;
+use Doctrine\Migrations\Version\Comparator;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DbalExecutor;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
@@ -53,8 +55,6 @@ use function sprintf;
  */
 class DependencyFactory
 {
-    public const MIGRATIONS_SORTER = 'Doctrine\Migrations\MigrationsSorter';
-
     /** @var Configuration */
     private $configuration;
 
@@ -166,16 +166,16 @@ class DependencyFactory
         return $this->em;
     }
 
+    public function getVersionComparator() : Comparator
+    {
+        return $this->getDependency(Comparator::class, static function () {
+            return new AlphabeticalComparator();
+        });
+    }
+
     public function getLogger() : LoggerInterface
     {
         return $this->logger;
-    }
-
-    public function getSorter() : ?callable
-    {
-        return $this->getDependency(self::MIGRATIONS_SORTER, static function () {
-            return null;
-        });
     }
 
     public function getEventDispatcher() : EventDispatcher
@@ -280,7 +280,7 @@ class DependencyFactory
                 $this->getConfiguration()->getMigrationDirectories(),
                 $this->getMigrationsFinder(),
                 new MigrationFactory($this->getConnection(), $this->getLogger()),
-                $this->getSorter()
+                $this->getVersionComparator()
             );
         });
     }

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -168,7 +168,7 @@ class DependencyFactory
 
     public function getVersionComparator() : Comparator
     {
-        return $this->getDependency(Comparator::class, static function () {
+        return $this->getDependency(Comparator::class, static function () : AlphabeticalComparator {
             return new AlphabeticalComparator();
         });
     }

--- a/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php
+++ b/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php
@@ -6,7 +6,7 @@ namespace Doctrine\Migrations\Version;
 
 use function strcmp;
 
-class AlphabeticalComparator implements Comparator
+final class AlphabeticalComparator implements Comparator
 {
     public function compare(Version $a, Version $b) : int
     {

--- a/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php
+++ b/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Version;
+
+use function strcmp;
+
+class AlphabeticalComparator implements Comparator
+{
+    public function compare(Version $a, Version $b) : int
+    {
+        return strcmp((string) $a, (string) $b);
+    }
+}

--- a/lib/Doctrine/Migrations/Version/Comparator.php
+++ b/lib/Doctrine/Migrations/Version/Comparator.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Version;
+
+interface Comparator
+{
+    public function compare(Version $a, Version $b) : int;
+}

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version\AlphabeticalComparator;
 use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
@@ -53,7 +54,8 @@ class ExistingTableMetadataStorageTest extends TestCase
             [],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $versionFactory
+            $versionFactory,
+            new AlphabeticalComparator()
         );
         $this->migrationRepository->registerMigrationInstance(new Version('Foo\\5678'), $migration);
 

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -14,6 +14,7 @@ use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version\AlphabeticalComparator;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
 use Doctrine\Migrations\Version\Direction;
@@ -135,7 +136,8 @@ final class AliasResolverTest extends TestCase
             [],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $versionFactory
+            $versionFactory,
+            new AlphabeticalComparator()
         );
         $this->metadataStorage     = new TableMetadataStorage($conn);
         $this->metadataStorage->ensureInitialized();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | -

Closes https://github.com/doctrine/migrations/pull/902

#### Summary

This is an alternative implementation to https://github.com/doctrine/migrations/pull/902

The main change is that now the comparing function does not receive instances of `AvailableMigration` but `Version`. This change is needed if we want to be able to sort executed unavailable migrations. Being able to sort unavailable migrations is important to allow to implement properly https://github.com/doctrine/migrations/pull/908 by offering all the migrations in a single table instead of two separate.