### PR TITLE
Mark registerMigrationInstance as private

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,8 @@ please refer to the [Code BC breaks](#code-bc-breaks) section.
   please update your scripts. 
   Console output is not covered by the BC promise, so please try not to rely on specific a output.
   Different levels of verbosity are available now (`-v`, `-vv` and `-vvv` ).
+- The `--show-versions` option from `migrations:status` command has been removed, 
+  use `migrations:list` instead. 
 
 ## Migrations table
 

--- a/docs/en/reference/custom-configuration.rst
+++ b/docs/en/reference/custom-configuration.rst
@@ -57,10 +57,12 @@ Once you have your custom integration setup, you can modify it to look like the 
         new Command\ExecuteCommand($dependencyFactory),
         new Command\GenerateCommand($dependencyFactory),
         new Command\LatestCommand($dependencyFactory),
+        new Command\ListCommand($dependencyFactory),
         new Command\MigrateCommand($dependencyFactory),
         new Command\RollupCommand($dependencyFactory),
         new Command\StatusCommand($dependencyFactory),
-        new Command\VersionCommand($dependencyFactory)
+        new Command\VersionCommand($dependencyFactory),
+        new Command\SyncMetadataCommand($dependencyFactory),
     ));
 
     $cli->run();

--- a/docs/en/reference/custom-integration.rst
+++ b/docs/en/reference/custom-integration.rst
@@ -48,10 +48,12 @@ Now place the following code in the ``migrations`` file:
         new Command\ExecuteCommand($dependencyFactory),
         new Command\GenerateCommand($dependencyFactory),
         new Command\LatestCommand($dependencyFactory),
+        new Command\ListCommand($dependencyFactory),
         new Command\MigrateCommand($dependencyFactory),
         new Command\RollupCommand($dependencyFactory),
         new Command\StatusCommand($dependencyFactory),
-        new Command\VersionCommand($dependencyFactory)
+        new Command\VersionCommand($dependencyFactory),
+        new Command\ListCommand($dependencyFactory),
     ));
 
     $cli->run();

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -61,10 +61,7 @@ class MigrationRepository
         $this->registerMigrations($classes);
     }
 
-    /**
-     * @internal DO NOT USE, THIS METHOD IS HERE ONLY TO EASE THE TESTING, WILL BE REMOVED IN UPCOMING MINOR/BUGFIX RELEASE
-     */
-    public function registerMigrationInstance(Version $version, AbstractMigration $migration) : AvailableMigration
+    private function registerMigrationInstance(Version $version, AbstractMigration $migration) : AvailableMigration
     {
         if (isset($this->migrations[(string) $version])) {
             throw DuplicateMigrationVersion::new(

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tools\Console\Command;
+
+use DateTimeInterface;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\ExecutedMigration;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Version\Version;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function uasort;
+
+/**
+ * The ListCommand class is responsible for outputting a list of all available migrations and their status.
+ */
+final class ListCommand extends DoctrineCommand
+{
+    /** @var string */
+    protected static $defaultName = 'migrations:list';
+
+    protected function configure() : void
+    {
+        $this
+            ->setAliases(['list-migrations'])
+            ->setDescription('Display a list of all available migrations and their status.')
+            ->setHelp(<<<EOT
+The <info>%command.name%</info> command outputs a list of all available migrations and their status:
+
+    <info>%command.full_name%</info>
+EOT
+            );
+
+        parent::configure();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $this->showVersions(
+            $this->getDependencyFactory()->getMigrationRepository()->getMigrations(), // available migrations
+            $this->getDependencyFactory()->getMetadataStorage()->getExecutedMigrations(), // executed migrations
+            $output
+        );
+
+        return 0;
+    }
+
+    private function showVersions(
+        AvailableMigrationsList $availableMigrations,
+        ExecutedMigrationsSet $executedMigrations,
+        OutputInterface $output
+    ) : void {
+        $table = new Table($output);
+        $table->setHeaders(
+            [
+                [new TableCell('Migration Versions', ['colspan' => 4])],
+                ['Migration', 'Status', 'Migrated At', 'Execution Time', 'Description'],
+            ]
+        );
+
+        foreach ($this->getSortedVersions($availableMigrations, $executedMigrations) as $version) {
+            $description   = null;
+            $executedAt    = null;
+            $executionTime = null;
+
+            if ($executedMigrations->hasMigration($version)) {
+                $executedMigration = $executedMigrations->getMigration($version);
+                $executionTime     = $executedMigration->getExecutionTime();
+                $executedAt        = $executedMigration->getExecutedAt() instanceof DateTimeInterface
+                    ? $executedMigration->getExecutedAt()->format('Y-m-d H:i:s')
+                    : null;
+            }
+
+            if ($availableMigrations->hasMigration($version)) {
+                $description = $availableMigrations->getMigration($version)->getMigration()->getDescription();
+            }
+
+            if ($executedMigrations->hasMigration($version) && $availableMigrations->hasMigration($version)) {
+                $status = '<info>migrated</info>';
+            } elseif ($executedMigrations->hasMigration($version)) {
+                $status = '<error>migrated, not available</error>';
+            } else {
+                $status = '<comment>not migrated</comment>';
+            }
+
+            $table->addRow([
+                (string) $version,
+                $status,
+                (string) $executedAt,
+                $executionTime !== null ? $executionTime . 's': '',
+                $description,
+            ]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * @return Version[]
+     */
+    private function getSortedVersions(AvailableMigrationsList $availableMigrations, ExecutedMigrationsSet $executedMigrations) : array
+    {
+        $availableVersions = array_map(static function (AvailableMigration $availableMigration) : Version {
+            return $availableMigration->getVersion();
+        }, $availableMigrations->getItems());
+
+        $executedVersions = array_map(static function (ExecutedMigration $executedMigration) : Version {
+            return $executedMigration->getVersion();
+        }, $executedMigrations->getItems());
+
+        $versions = array_unique(array_merge($availableVersions, $executedVersions));
+
+        $comparator = $this->getDependencyFactory()->getVersionComparator();
+        uasort($versions, static function (Version $a, Version $b) use ($comparator) : int {
+            return $comparator->compare($a, $b);
+        });
+
+        return $versions;
+    }
+}

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
-use DateTimeImmutable;
-use Doctrine\Migrations\Metadata\AvailableMigrationsList;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Helper\TableCell;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use function count;
 
 /**
  * The StatusCommand class is responsible for outputting what the current state is of all your migrations. It shows
@@ -38,10 +32,6 @@ class StatusCommand extends DoctrineCommand
 The <info>%command.name%</info> command outputs the status of a set of migrations:
 
     <info>%command.full_name%</info>
-
-You can output a list of all available migrations and their status with <comment>--show-versions</comment>:
-
-    <info>%command.full_name% --show-versions</info>
 EOT
             );
 
@@ -63,73 +53,6 @@ EOT
         $infosHelper = $this->getDependencyFactory()->getMigrationStatusInfosHelper();
         $infosHelper->showMigrationsInfo($output, $availableMigrations, $executedMigrations, $newMigrations, $executedUnavailableMigrations);
 
-        if ($input->getOption('show-versions') === false) {
-            return 0;
-        }
-
-        if (count($availableMigrations) !== 0) {
-            $this->showVersions($availableMigrations, $executedMigrations, $output);
-        }
-
-        if (count($executedUnavailableMigrations) !== 0) {
-            $this->showUnavailableVersions($output, $executedUnavailableMigrations);
-        }
-
         return 0;
-    }
-
-    private function showUnavailableVersions(OutputInterface $output, ExecutedMigrationsSet $executedUnavailableMigrations) : void
-    {
-        $table = new Table($output);
-        $table->setHeaders(
-            [
-                [new TableCell('<error>Previously Executed Unavailable Migration Versions</error>', ['colspan' => 2])],
-                ['Migration', 'Migrated At'],
-            ]
-        );
-        foreach ($executedUnavailableMigrations->getItems() as $executedUnavailableMigration) {
-            $table->addRow([
-                (string) $executedUnavailableMigration->getVersion(),
-                $executedUnavailableMigration->getExecutedAt() !== null
-                    ? $executedUnavailableMigration->getExecutedAt()->format('Y-m-d H:i:s')
-                    : null,
-            ]);
-        }
-
-        $table->render();
-    }
-
-    private function showVersions(
-        AvailableMigrationsList $availableMigrationsSet,
-        ExecutedMigrationsSet $executedMigrationsSet,
-        OutputInterface $output
-    ) : void {
-        $table = new Table($output);
-        $table->setHeaders(
-            [
-                [new TableCell('Available Migration Versions', ['colspan' => 4])],
-                ['Migration', 'Migrated', 'Migrated At', 'Description'],
-            ]
-        );
-        foreach ($availableMigrationsSet->getItems() as $availableMigration) {
-            $executedMigration = $executedMigrationsSet->hasMigration($availableMigration->getVersion())
-                ? $executedMigrationsSet->getMigration($availableMigration->getVersion())
-                : null;
-
-            $executedAt = $executedMigration!==null && $executedMigration->getExecutedAt() instanceof DateTimeImmutable
-                ? $executedMigration->getExecutedAt()->format('Y-m-d H:i:s')
-                : null;
-
-            $description = $availableMigration->getMigration()->getDescription();
-
-            $table->addRow([
-                (string) $availableMigration->getVersion(),
-                $executedMigration !== null ? '<comment>migrated</comment>' : '<error>not migrated</error>',
-                (string) $executedAt,
-                $description,
-            ]);
-        }
-
-        $table->render();
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
@@ -11,6 +11,7 @@ use Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand;
 use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
 use Doctrine\Migrations\Tools\Console\Command\GenerateCommand;
 use Doctrine\Migrations\Tools\Console\Command\LatestCommand;
+use Doctrine\Migrations\Tools\Console\Command\ListCommand;
 use Doctrine\Migrations\Tools\Console\Command\MigrateCommand;
 use Doctrine\Migrations\Tools\Console\Command\RollupCommand;
 use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
@@ -109,6 +110,7 @@ class ConsoleRunner
             new VersionCommand($dependencyFactory),
             new UpToDateCommand($dependencyFactory),
             new SyncMetadataCommand($dependencyFactory),
+            new ListCommand($dependencyFactory),
         ]);
 
         if ($dependencyFactory === null || ! $dependencyFactory->hasEntityManager()) {

--- a/tests/Doctrine/Migrations/Tests/Helper.php
+++ b/tests/Doctrine/Migrations/Tests/Helper.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests;
 
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Version\Version;
+use ReflectionMethod;
 use function array_map;
 use function glob;
 use function is_file;
@@ -12,6 +16,13 @@ use function unlink;
 
 class Helper
 {
+    public static function registerMigrationInstance(MigrationRepository $repository, Version $version, AbstractMigration $migration) : void
+    {
+        $reflection = new ReflectionMethod(MigrationRepository::class, 'registerMigrationInstance');
+        $reflection->setAccessible(true);
+        $reflection->invoke($repository, $version, $migration);
+    }
+
     /**
      * Delete a directory.
      *

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Version\AlphabeticalComparator;
 use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
@@ -57,7 +58,7 @@ class ExistingTableMetadataStorageTest extends TestCase
             $versionFactory,
             new AlphabeticalComparator()
         );
-        $this->migrationRepository->registerMigrationInstance(new Version('Foo\\5678'), $migration);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('Foo\\5678'), $migration);
 
         $this->config = new TableMetadataStorageConfiguration();
 

--- a/tests/Doctrine/Migrations/Tests/MigrationRepository/MigrationRepositoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationRepository/MigrationRepositoryTest.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\Exception\DuplicateMigrationVersion;
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
 use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Tests\MigrationRepository\Migrations\A\A;
 use Doctrine\Migrations\Tests\MigrationRepository\Migrations\A\B;
 use Doctrine\Migrations\Tests\MigrationRepository\Migrations\B\C;
@@ -111,7 +112,7 @@ class MigrationRepositoryTest extends TestCase
 
     public function testLoadMigrationInstance() : void
     {
-        $this->migrationRepository->registerMigrationInstance(new Version('Z'), $this->createMock(AbstractMigration::class));
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('Z'), $this->createMock(AbstractMigration::class));
 
         $migrations = $this->migrationRepository->getMigrations();
 
@@ -122,8 +123,8 @@ class MigrationRepositoryTest extends TestCase
     public function testDuplicateLoadMigrationInstance() : void
     {
         $this->expectException(DuplicateMigrationVersion::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('Z'), $this->createMock(AbstractMigration::class));
-        $this->migrationRepository->registerMigrationInstance(new Version('Z'), $this->createMock(AbstractMigration::class));
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('Z'), $this->createMock(AbstractMigration::class));
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('Z'), $this->createMock(AbstractMigration::class));
     }
 
     public function testFindMigrations() : void

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/LatestCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/LatestCommandTest.php
@@ -11,6 +11,7 @@ use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tools\Console\Command\LatestCommand;
 use Doctrine\Migrations\Version\ExecutionResult;
@@ -59,8 +60,8 @@ class LatestCommandTest extends MigrationTestCase
     public function testExecute() : void
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1231'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1230'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1231'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1230'), $migrationClass);
 
         $this->metadataStorage->complete(new ExecutionResult(new Version('1231')));
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ListCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ListCommandTest.php
@@ -12,6 +12,7 @@ use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tools\Console\Command\ListCommand;
 use Doctrine\Migrations\Version\Direction;
@@ -67,8 +68,8 @@ class ListCommandTest extends MigrationTestCase
             ->method('getDescription')
             ->willReturn('foo');
 
-        $this->migrationRepository->registerMigrationInstance(new Version('1231'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1230'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1231'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1230'), $migrationClass);
 
         $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-01 02:03:04'));
         $result->setTime(10.0);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ListCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ListCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Tools\Console\Command;
+
+use DateTimeImmutable;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\MigrationTestCase;
+use Doctrine\Migrations\Tools\Console\Command\ListCommand;
+use Doctrine\Migrations\Version\Direction;
+use Doctrine\Migrations\Version\ExecutionResult;
+use Doctrine\Migrations\Version\Version;
+use Symfony\Component\Console\Tester\CommandTester;
+use function array_map;
+use function explode;
+use function sys_get_temp_dir;
+use function trim;
+
+class ListCommandTest extends MigrationTestCase
+{
+    /** @var ListCommand */
+    private $command;
+
+    /** @var MigrationRepository */
+    private $migrationRepository;
+
+    /** @var MetadataStorage */
+    private $metadataStorage;
+
+    /** @var CommandTester */
+    private $commandTester;
+
+    protected function setUp() : void
+    {
+        $configuration = new Configuration();
+        $configuration->setMetadataStorageConfiguration(new TableMetadataStorageConfiguration());
+        $configuration->addMigrationsDirectory('DoctrineMigrations', sys_get_temp_dir());
+
+        $conn = $this->getSqliteConnection();
+
+        $dependencyFactory = DependencyFactory::fromConnection(
+            new Configuration\ExistingConfiguration($configuration),
+            new ExistingConnection($conn)
+        );
+
+        $this->migrationRepository = $dependencyFactory->getMigrationRepository();
+        $this->metadataStorage     = $dependencyFactory->getMetadataStorage();
+
+        $this->metadataStorage->ensureInitialized();
+
+        $this->command       = new ListCommand($dependencyFactory);
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function testExecute() : void
+    {
+        $migrationClass = $this->createMock(AbstractMigration::class);
+        $migrationClass
+            ->expects(self::atLeastOnce())
+            ->method('getDescription')
+            ->willReturn('foo');
+
+        $this->migrationRepository->registerMigrationInstance(new Version('1231'), $migrationClass);
+        $this->migrationRepository->registerMigrationInstance(new Version('1230'), $migrationClass);
+
+        $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-01 02:03:04'));
+        $result->setTime(10.0);
+        $this->metadataStorage->complete($result);
+
+        $result = new ExecutionResult(new Version('1229'), Direction::UP, new DateTimeImmutable('2010-01-01 02:03:04'));
+        $this->metadataStorage->complete($result);
+
+        $this->commandTester->execute([]);
+
+        $lines = array_map('trim', explode("\n", trim($this->commandTester->getDisplay(true))));
+
+        self::assertSame(
+            [
+                0 => '+-----------+-------------------------+---------------------+----------------+-------------+',
+                1 => '| Migration Versions                                                         |             |',
+                2 => '+-----------+-------------------------+---------------------+----------------+-------------+',
+                3 => '| Migration | Status                  | Migrated At         | Execution Time | Description |',
+                4 => '+-----------+-------------------------+---------------------+----------------+-------------+',
+                5 => '| 1229      | migrated, not available | 2010-01-01 02:03:04 |                |             |',
+                6 => '| 1230      | migrated                | 2010-01-01 02:03:04 | 10s            | foo         |',
+                7 => '| 1231      | not migrated            |                     |                | foo         |',
+                8 => '+-----------+-------------------------+---------------------+----------------+-------------+',
+            ],
+            $lines
+        );
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -14,6 +14,7 @@ use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Migrator;
 use Doctrine\Migrations\MigratorConfiguration;
 use Doctrine\Migrations\QueryWriter;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tools\Console\Command\MigrateCommand;
 use Doctrine\Migrations\Version\ExecutionResult;
@@ -285,8 +286,8 @@ class MigrateCommandTest extends MigrationTestCase
 
         $migration = $this->createMock(AbstractMigration::class);
 
-        $repo = $this->dependencyFactory->getMigrationRepository();
-        $repo->registerMigrationInstance(new Version('A'), $migration);
+        $migrationRepository = $this->dependencyFactory->getMigrationRepository();
+        Helper::registerMigrationInstance($migrationRepository, new Version('A'), $migration);
 
         $this->migrateCommand = $this->getMockBuilder(MigrateCommand::class)
             ->setConstructorArgs([$this->dependencyFactory])

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrationVersionTest.php
@@ -10,6 +10,7 @@ use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tests\TestLogger;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
@@ -64,11 +65,11 @@ class MigrationVersionTest extends MigrationTestCase
     public function testAddRangeOption() : void
     {
         $mock = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1233'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1234'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1235'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1239'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1240'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1235'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1239'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1240'), $mock);
 
         $this->commandTester->execute(
             [
@@ -163,11 +164,11 @@ class MigrationVersionTest extends MigrationTestCase
     public function testDeleteRangeOption() : void
     {
         $mock = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1233'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1234'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1235'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1239'), $mock);
-        $this->migrationRepository->registerMigrationInstance(new Version('1240'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1235'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1239'), $mock);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1240'), $mock);
 
         foreach (['1233', '1234', '1239', '1240'] as $v) {
             $r = new ExecutionResult(new Version($v));
@@ -198,9 +199,9 @@ class MigrationVersionTest extends MigrationTestCase
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
 
-        $this->migrationRepository->registerMigrationInstance(new Version('1231'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1232'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1234'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1231'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1232'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $migrationClass);
 
         $result = new ExecutionResult(new Version('1234'), Direction::UP);
         $this->metadataStorage->complete($result);
@@ -226,7 +227,7 @@ class MigrationVersionTest extends MigrationTestCase
     public function testDeleteAllOption() : void
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1233'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $migrationClass);
 
         $result = new ExecutionResult(new Version('1233'), Direction::UP);
         $this->metadataStorage->complete($result);
@@ -256,8 +257,8 @@ class MigrationVersionTest extends MigrationTestCase
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
 
-        $this->migrationRepository->registerMigrationInstance(new Version('1232'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1234'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1232'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $migrationClass);
 
         $this->commandTester->execute(
             [
@@ -279,8 +280,8 @@ class MigrationVersionTest extends MigrationTestCase
     public function testDeleteOption() : void
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1233'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1234'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $migrationClass);
 
         $result = new ExecutionResult(new Version('1233'), Direction::UP);
         $this->metadataStorage->complete($result);
@@ -312,8 +313,8 @@ class MigrationVersionTest extends MigrationTestCase
 
         $migrationClass = $this->createMock(AbstractMigration::class);
 
-        $this->migrationRepository->registerMigrationInstance(new Version('1233'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1234'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $migrationClass);
 
         $result = new ExecutionResult(new Version('1233'), Direction::UP);
         $this->metadataStorage->complete($result);
@@ -333,7 +334,7 @@ class MigrationVersionTest extends MigrationTestCase
     public function testDeleteOptionIfVersionNotMigrated() : void
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1233'), $migrationClass);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $migrationClass);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The version "1233" does not exist in the version table.');

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Tools\Console\Command;
 
 use DateTimeImmutable;
-use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
-use Doctrine\Migrations\MigrationRepository;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
 use Doctrine\Migrations\Version\Direction;
@@ -30,9 +28,6 @@ class StatusCommandTest extends MigrationTestCase
 {
     /** @var StatusCommand */
     private $command;
-
-    /** @var MigrationRepository */
-    private $migrationRepository;
 
     /** @var MetadataStorage */
     private $metadataStorage;
@@ -53,8 +48,7 @@ class StatusCommandTest extends MigrationTestCase
             new ExistingConnection($conn)
         );
 
-        $this->migrationRepository = $dependencyFactory->getMigrationRepository();
-        $this->metadataStorage     = $dependencyFactory->getMetadataStorage();
+        $this->metadataStorage = $dependencyFactory->getMetadataStorage();
 
         $this->metadataStorage->ensureInitialized();
 
@@ -110,74 +104,6 @@ class StatusCommandTest extends MigrationTestCase
                 24 => '|----------------------------------------------------------------------------------------------------------------------|',
                 25 => sprintf('| Migration Namespaces | DoctrineMigrations   | %s |', str_pad(sys_get_temp_dir(), 70)),
                 26 => '+----------------------+----------------------+------------------------------------------------------------------------+',
-            ],
-            $lines
-        );
-    }
-
-    public function testExecuteDetails() : void
-    {
-        $migrationClass = $this->createMock(AbstractMigration::class);
-        $this->migrationRepository->registerMigrationInstance(new Version('1231'), $migrationClass);
-        $this->migrationRepository->registerMigrationInstance(new Version('1230'), $migrationClass);
-
-        $result = new ExecutionResult(new Version('1230'), Direction::UP, new DateTimeImmutable('2010-01-01 02:03:04'));
-        $result->setTime(10.0);
-        $this->metadataStorage->complete($result);
-
-        $result = new ExecutionResult(new Version('1233'), Direction::UP);
-        $this->metadataStorage->complete($result);
-
-        $this->commandTester->execute(
-            ['--show-versions' => true],
-            ['interactive' => false]
-        );
-
-        $lines = array_map('trim', explode("\n", trim($this->commandTester->getDisplay(true))));
-        self::assertSame(
-            [
-                0 => '+----------------------+----------------------+------------------------------------------------------------------------+',
-                1 => '| Configuration                                                                                                        |',
-                2 => '+----------------------+----------------------+------------------------------------------------------------------------+',
-                3 => '| Project              | Doctrine Database Migrations                                                                  |',
-                4 => '|----------------------------------------------------------------------------------------------------------------------|',
-                5 => '| Project              | Doctrine Database Migrations                                                                  |',
-                6 => '|----------------------------------------------------------------------------------------------------------------------|',
-                7 => '| Storage              | Type                 | Doctrine\\Migrations\\Metadata\\Storage\\TableMetadataStorageConfiguration |',
-                8 => '|                      | Table Name           | doctrine_migration_versions                                            |',
-                9 => '|                      | Column Name          | version                                                                |',
-                10 => '|----------------------------------------------------------------------------------------------------------------------|',
-                11 => '| Database             | Driver               | pdo_sqlite                                                             |',
-                12 => '|                      | Host                 |                                                                        |',
-                13 => '|                      | Name                 |                                                                        |',
-                14 => '|----------------------------------------------------------------------------------------------------------------------|',
-                15 => '| Versions             | Previous             | 1230                                                                   |',
-                16 => '|                      | Current              | 1233                                                                   |',
-                17 => '|                      | Next                 | 1231                                                                   |',
-                18 => '|                      | Latest               | 1231                                                                   |',
-                19 => '|----------------------------------------------------------------------------------------------------------------------|',
-                20 => '| Migrations           | Executed             | 2                                                                      |',
-                21 => '|                      | Executed Unavailable | 1                                                                      |',
-                22 => '|                      | Available            | 2                                                                      |',
-                23 => '|                      | New                  | 1                                                                      |',
-                24 => '|----------------------------------------------------------------------------------------------------------------------|',
-                25 => sprintf('| Migration Namespaces | DoctrineMigrations   | %s |', str_pad(sys_get_temp_dir(), 70)),
-                26 => '+----------------------+----------------------+------------------------------------------------------------------------+',
-                27 => '+-----------+--------------+---------------------+-------------+',
-                28 => '| Available Migration Versions                                 |',
-                29 => '+-----------+--------------+---------------------+-------------+',
-                30 => '| Migration | Migrated     | Migrated At         | Description |',
-                31 => '+-----------+--------------+---------------------+-------------+',
-                32 => '| 1230      | migrated     | 2010-01-01 02:03:04 |             |',
-                33 => '| 1231      | not migrated |                     |             |',
-                34 => '+-----------+--------------+---------------------+-------------+',
-                35 => '+---------------------------+---------------------------+',
-                36 => '| Previously Executed Unavailable Migration Versions    |',
-                37 => '+---------------------------+---------------------------+',
-                38 => '| Migration                 | Migrated At               |',
-                39 => '+---------------------------+---------------------------+',
-                40 => '| 1233                      |                           |',
-                41 => '+---------------------------+---------------------------+',
             ],
             $lines
         );

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 use Doctrine\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\Migrations\Version\Direction;
@@ -76,7 +77,7 @@ class UpToDateCommandTest extends MigrationTestCase
     {
         $migrationClass = $this->createMock(AbstractMigration::class);
         foreach ($migrations as $version) {
-            $this->migrationRepository->registerMigrationInstance(new Version($version), $migrationClass);
+            Helper::registerMigrationInstance($this->migrationRepository, new Version($version), $migrationClass);
         }
 
         foreach ($migratedVersions as $version) {

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
@@ -172,7 +172,7 @@ class ConsoleRunnerTest extends TestCase
     {
         $application = ConsoleRunner::createApplication();
         $commands    = $application->all('migrations');
-        self::assertCount(10, $commands);
+        self::assertCount(11, $commands);
     }
 
     public function testCreateApplicationWithEntityManager() : void
@@ -185,7 +185,7 @@ class ConsoleRunnerTest extends TestCase
 
         $application = ConsoleRunner::createApplication([], $dependencyFactory);
         $commands    = $application->all('migrations');
-        self::assertCount(11, $commands);
+        self::assertCount(12, $commands);
     }
 
     protected function setUp() : void

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -14,6 +14,7 @@ use Doctrine\Migrations\Finder\RecursiveRegexFinder;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationRepository;
+use Doctrine\Migrations\Tests\Helper;
 use Doctrine\Migrations\Version\AlphabeticalComparator;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DefaultAliasResolver;
@@ -50,7 +51,7 @@ final class AliasResolverTest extends TestCase
 
         $migrationClass = $this->createMock(AbstractMigration::class);
         foreach (['A', 'B', 'C'] as $version) {
-            $this->migrationRepository->registerMigrationInstance(new Version($version), $migrationClass);
+            Helper::registerMigrationInstance($this->migrationRepository, new Version($version), $migrationClass);
         }
 
         foreach (['A', 'B'] as $version) {
@@ -77,7 +78,7 @@ final class AliasResolverTest extends TestCase
 
         $migrationClass = $this->createMock(AbstractMigration::class);
         foreach (['A', 'B', 'C'] as $version) {
-            $this->migrationRepository->registerMigrationInstance(new Version($version), $migrationClass);
+            Helper::registerMigrationInstance($this->migrationRepository, new Version($version), $migrationClass);
         }
 
         $resolvedAlias = $this->versionAliasResolver->resolveVersionAlias($alias);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | -

Mark `MigrationRepository::registerMigrationInstance` as private as it should have been done from the begining
