### PR TITLE
Fix migration timing/memory-usage display

### DIFF
--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -235,21 +235,23 @@ final class Executor implements ExecutorInterface
         }
 
         $stopwatchEvent->stop();
+        $periods    = $stopwatchEvent->getPeriods();
+        $lastPeriod = $periods[count($periods) -1];
 
-        $versionExecutionResult->setTime($stopwatchEvent->getDuration());
-        $versionExecutionResult->setMemory($stopwatchEvent->getMemory());
+        $versionExecutionResult->setTime($lastPeriod->getDuration());
+        $versionExecutionResult->setMemory($lastPeriod->getMemory());
 
         if ($direction === Direction::UP) {
             $this->outputWriter->write(sprintf(
                 "\n  <info>++</info> migrated (took %sms, used %s memory)",
-                $stopwatchEvent->getDuration(),
-                BytesFormatter::formatBytes($stopwatchEvent->getMemory())
+                $lastPeriod->getDuration(),
+                BytesFormatter::formatBytes($lastPeriod->getMemory())
             ));
         } else {
             $this->outputWriter->write(sprintf(
                 "\n  <info>--</info> reverted (took %sms, used %s memory)",
-                $stopwatchEvent->getDuration(),
-                BytesFormatter::formatBytes($stopwatchEvent->getMemory())
+                $lastPeriod->getDuration(),
+                BytesFormatter::formatBytes($lastPeriod->getMemory())
             ));
         }
 

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -21,6 +21,7 @@ use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Stopwatch\StopwatchEvent;
+use Symfony\Component\Stopwatch\StopwatchPeriod;
 
 class ExecutorTest extends TestCase
 {
@@ -212,12 +213,10 @@ class ExecutorTest extends TestCase
             $this->stopwatch
         );
 
-        $this->configuration->expects(self::any())
-            ->method('getConnection')
+        $this->configuration->method('getConnection')
             ->willReturn($this->connection);
 
-        $this->connection->expects(self::any())
-            ->method('getDatabasePlatform')
+        $this->connection->method('getDatabasePlatform')
             ->willReturn($this->createMock(AbstractPlatform::class));
 
         $this->version = new Version(
@@ -231,20 +230,25 @@ class ExecutorTest extends TestCase
 
         $stopwatchEvent = $this->createMock(StopwatchEvent::class);
 
-        $this->stopwatch->expects(self::any())
-            ->method('start')
+        $this->stopwatch->method('start')
             ->willReturn($stopwatchEvent);
 
-        $stopwatchEvent->expects(self::any())
-            ->method('stop');
+        $stopwatchEvent->method('stop');
 
-        $stopwatchEvent->expects(self::any())
-            ->method('getDuration')
+        $stopwatchEvent->method('getDuration')
             ->willReturn(100);
 
-        $stopwatchEvent->expects(self::any())
-            ->method('getMemory')
+        $stopwatchEvent->method('getMemory')
             ->willReturn(100);
+
+        $stopWatchPeriod = $this->createMock(StopwatchPeriod::class);
+        $stopWatchPeriod->method('getDuration')
+            ->willReturn(100);
+        $stopWatchPeriod->method('getMemory')
+            ->willReturn(100);
+
+        $stopwatchEvent->method('getPeriods')
+            ->willReturn([$stopWatchPeriod]);
     }
 }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

For single migrations, the timing and memory-consumption values shown in the CLI are about the overall migration process, not about the single migration that just completed.

Using the stopwatch periods, we can use the right values for the current migration.