### PR TITLE
Introduce query value object to wrap sql queries

### DIFF
--- a/lib/Doctrine/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/Migrations/AbstractMigration.php
@@ -13,8 +13,8 @@ use Doctrine\Migrations\Exception\AbortMigration;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
 use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Exception\SkipMigration;
+use Doctrine\Migrations\Query\Query;
 use Psr\Log\LoggerInterface;
-use function func_get_args;
 
 /**
  * The AbstractMigration class is for end users to extend from when creating migrations. Extend this class
@@ -34,7 +34,7 @@ abstract class AbstractMigration
     /** @var LoggerInterface */
     private $logger;
 
-    /** @var mixed[] */
+    /** @var Query[] */
     private $plannedSql = [];
 
     public function __construct(Connection $connection, LoggerInterface $logger)
@@ -142,11 +142,11 @@ abstract class AbstractMigration
         array $params = [],
         array $types = []
     ) : void {
-        $this->plannedSql[] = func_get_args();
+        $this->plannedSql[] = new Query($sql, $params, $types);
     }
 
     /**
-     * @return mixed[]
+     * @return Query[]
      */
     public function getSql() : array
     {

--- a/lib/Doctrine/Migrations/DbalMigrator.php
+++ b/lib/Doctrine/Migrations/DbalMigrator.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Tools\BytesFormatter;
 use Doctrine\Migrations\Version\Executor;
 use Psr\Log\LoggerInterface;
@@ -51,7 +52,7 @@ class DbalMigrator implements Migrator
     }
 
     /**
-     * @return string[][]
+     * @return array<string, Query[]>
      */
     private function executeMigrations(
         MigrationPlanList $migrationsPlan,
@@ -85,7 +86,7 @@ class DbalMigrator implements Migrator
     }
 
     /**
-     * @return array<string, string[]>
+     * @return array<string, Query[]>
      */
     private function executePlan(MigrationPlanList $migrationsPlan, MigratorConfiguration $migratorConfiguration) : array
     {
@@ -110,7 +111,7 @@ class DbalMigrator implements Migrator
     }
 
     /**
-     * @param string[][] $sql
+     * @param array<string, Query[]> $sql
      */
     private function endMigrations(
         StopwatchEvent $stopwatchEvent,

--- a/lib/Doctrine/Migrations/FileQueryWriter.php
+++ b/lib/Doctrine/Migrations/FileQueryWriter.php
@@ -7,6 +7,7 @@ namespace Doctrine\Migrations;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Doctrine\Migrations\Generator\FileBuilder;
+use Doctrine\Migrations\Query\Query;
 use Psr\Log\LoggerInterface;
 use function file_put_contents;
 use function is_dir;
@@ -34,7 +35,7 @@ final class FileQueryWriter implements QueryWriter
     }
 
     /**
-     * @param mixed[] $queriesByVersion
+     * @param array<string,Query[]> $queriesByVersion
      */
     public function write(
         string $path,

--- a/lib/Doctrine/Migrations/Generator/ConcatenationFileBuilder.php
+++ b/lib/Doctrine/Migrations/Generator/ConcatenationFileBuilder.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Generator;
 
 use DateTimeImmutable;
 use DateTimeInterface;
+use Doctrine\Migrations\Query\Query;
 use function sprintf;
 
 /**
@@ -15,7 +16,7 @@ use function sprintf;
  */
 final class ConcatenationFileBuilder implements FileBuilder
 {
-    /** @param string[][] $queriesByVersion */
+    /** @param array<string,Query[]> $queriesByVersion */
     public function buildMigrationFile(
         array $queriesByVersion,
         string $direction,
@@ -25,12 +26,10 @@ final class ConcatenationFileBuilder implements FileBuilder
         $string = sprintf("-- Doctrine Migration File Generated on %s\n", $now->format('Y-m-d H:i:s'));
 
         foreach ($queriesByVersion as $version => $queries) {
-            $version = (string) $version;
-
             $string .= "\n-- Version " . $version . "\n";
 
             foreach ($queries as $query) {
-                $string .= $query . ";\n";
+                $string .= $query->getStatement() . ";\n";
             }
         }
 

--- a/lib/Doctrine/Migrations/Generator/FileBuilder.php
+++ b/lib/Doctrine/Migrations/Generator/FileBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Generator;
 
 use DateTimeInterface;
+use Doctrine\Migrations\Query\Query;
 
 /**
  * The ConcatenationFileBuilder class is responsible for building a migration SQL file from an array of queries per version.
@@ -13,6 +14,6 @@ use DateTimeInterface;
  */
 interface FileBuilder
 {
-    /** @param string[][] $queriesByVersion */
+    /** @param array<string,Query[]> $queriesByVersion */
     public function buildMigrationFile(array $queriesByVersion, string $direction, ?DateTimeInterface $now = null) : string;
 }

--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Doctrine\Migrations;
 
 use Doctrine\Migrations\Metadata\MigrationPlanList;
+use Doctrine\Migrations\Query\Query;
 
 /**
- * The DbalMigrator class is responsible for generating and executing the SQL for a migration.
+ * The Migrator interface is responsible for generating and executing the SQL for a migration.
  *
  * @internal
  */
 interface Migrator
 {
     /**
-     * @return array<string, string[]> A list of SQL statements executed, grouped by migration version
+     * @return array<string, Query[]> A list of SQL statements executed, grouped by migration version
      */
     public function migrate(MigrationPlanList $migrationsPlan, MigratorConfiguration $migratorConfiguration) : array;
 }

--- a/lib/Doctrine/Migrations/Query/Exception/InvalidArguments.php
+++ b/lib/Doctrine/Migrations/Query/Exception/InvalidArguments.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Query\Exception;
+
+use Doctrine\Migrations\Exception\MigrationException;
+use InvalidArgumentException;
+use function sprintf;
+
+class InvalidArguments extends InvalidArgumentException implements MigrationException
+{
+    public static function wrongTypesArgumentCount(string $statement, int $parameters, int $types) : self
+    {
+        return new self(sprintf(
+            'The number of types (%s) is higher than the number of passed parameters (%s) for the query "%s".',
+            $types,
+            $parameters,
+            $statement
+        ));
+    }
+}

--- a/lib/Doctrine/Migrations/Query/Query.php
+++ b/lib/Doctrine/Migrations/Query/Query.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Query;
 
+use Doctrine\Migrations\Query\Exception\InvalidArguments;
+use function count;
+
 /**
  * The Query wraps the sql query, parameters and types.
  */
@@ -24,6 +27,10 @@ final class Query
      */
     public function __construct(string $statement, array $parameters = [], array $types = [])
     {
+        if (count($types) > count($parameters)) {
+            throw InvalidArguments::wrongTypesArgumentCount($statement, count($parameters), count($types));
+        }
+
         $this->statement  = $statement;
         $this->parameters = $parameters;
         $this->types      = $types;

--- a/lib/Doctrine/Migrations/Query/Query.php
+++ b/lib/Doctrine/Migrations/Query/Query.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Query;
+
+/**
+ * The Query wraps the sql query, parameters and types.
+ */
+final class Query
+{
+    /** @var string */
+    private $statement;
+
+    /** @var mixed[] */
+    private $parameters;
+
+    /** @var mixed[] */
+    private $types;
+
+    /**
+     * @param mixed[] $parameters
+     * @param mixed[] $types
+     */
+    public function __construct(string $statement, array $parameters = [], array $types = [])
+    {
+        $this->statement  = $statement;
+        $this->parameters = $parameters;
+        $this->types      = $types;
+    }
+
+    public function __toString() : string
+    {
+        return $this->statement;
+    }
+
+    public function getStatement() : string
+    {
+        return $this->statement;
+    }
+
+    /** @return mixed[] */
+    public function getParameters() : array
+    {
+        return $this->parameters;
+    }
+
+    /** @return mixed[] */
+    public function getTypes() : array
+    {
+        return $this->types;
+    }
+}

--- a/lib/Doctrine/Migrations/QueryWriter.php
+++ b/lib/Doctrine/Migrations/QueryWriter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+use Doctrine\Migrations\Query\Query;
+
 /**
  * The QueryWriter defines the interface used for writing migration SQL queries to a file on disk.
  *
@@ -12,7 +14,7 @@ namespace Doctrine\Migrations;
 interface QueryWriter
 {
     /**
-     * @param string[][] $queriesByVersion
+     * @param array<string,Query[]> $queriesByVersion
      */
     public function write(
         string $path,

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -260,12 +260,6 @@ final class DbalExecutor implements Executor
             $plan,
             $configuration
         );
-
-        if ($configuration->isDryRun() || $result->isSkipped() || $result->hasError()) {
-            return;
-        }
-
-        $this->metadataStorage->complete($result);
     }
 
     private function logResult(Throwable $e, ExecutionResult $result, MigrationPlan $plan) : void

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -16,6 +16,7 @@ use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigratorConfiguration;
 use Doctrine\Migrations\ParameterFormatter;
 use Doctrine\Migrations\Provider\SchemaDiffProvider;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Stopwatch;
 use Doctrine\Migrations\Tools\BytesFormatter;
 use Psr\Log\LoggerInterface;
@@ -42,14 +43,8 @@ final class DbalExecutor implements Executor
     /** @var Stopwatch */
     private $stopwatch;
 
-    /** @var array<int, string> */
+    /** @var Query[] */
     private $sql = [];
-
-    /** @var mixed[] */
-    private $params = [];
-
-    /** @var mixed[] */
-    private $types = [];
 
     /** @var MetadataStorage */
     private $metadataStorage;
@@ -79,42 +74,16 @@ final class DbalExecutor implements Executor
     }
 
     /**
-     * @return string[]
+     * @return Query[]
      */
     public function getSql() : array
     {
         return $this->sql;
     }
 
-    /**
-     * @return mixed[]
-     */
-    public function getParams() : array
+    public function addSql(Query $sqlQuery) : void
     {
-        return $this->params;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getTypes() : array
-    {
-        return $this->types;
-    }
-
-    /**
-     * @param mixed[] $params
-     * @param mixed[] $types
-     */
-    public function addSql(string $sql, array $params = [], array $types = []) : void
-    {
-        $this->sql[] = $sql;
-
-        if (count($params) === 0) {
-            return;
-        }
-
-        $this->addQueryParams($params, $types);
+        $this->sql[] = $sqlQuery;
     }
 
     public function execute(
@@ -132,7 +101,7 @@ final class DbalExecutor implements Executor
                 $configuration
             );
 
-            $result->setSql($this->sql, $this->params, $this->types);
+            $result->setSql($this->sql);
         } catch (SkipMigration $e) {
             $result->setSkipped(true);
 
@@ -152,9 +121,7 @@ final class DbalExecutor implements Executor
         MigrationPlan $plan,
         MigratorConfiguration $configuration
     ) : void {
-        $this->sql    = [];
-        $this->params = [];
-        $this->types  = [];
+        $this->sql = [];
 
         $this->dispatcher->dispatchVersionEvent(
             Events::onMigrationsVersionExecuting,
@@ -196,20 +163,20 @@ final class DbalExecutor implements Executor
 
         $migration->$direction($toSchema);
 
-        foreach ($migration->getSql() as $sqlData) {
-            $this->addSql(...$sqlData);
+        foreach ($migration->getSql() as $sqlQuery) {
+            $this->addSql($sqlQuery);
         }
 
         foreach ($this->schemaProvider->getSqlDiffToMigrate($fromSchema, $toSchema) as $sql) {
-            $this->addSql($sql);
+            $this->addSql(new Query($sql));
         }
 
         if (count($this->sql) !== 0) {
             if (! $configuration->isDryRun()) {
                 $this->executeResult($configuration);
             } else {
-                foreach ($this->sql as $idx => $query) {
-                    $this->outputSqlQuery($idx, $query);
+                foreach ($this->sql as $query) {
+                    $this->outputSqlQuery($query);
                 }
             }
         } else {
@@ -329,12 +296,12 @@ final class DbalExecutor implements Executor
         foreach ($this->sql as $key => $query) {
             $stopwatchEvent = $this->stopwatch->start('query');
 
-            $this->outputSqlQuery($key, $query);
+            $this->outputSqlQuery($query);
 
-            if (! isset($this->params[$key])) {
-                $this->connection->executeUpdate($query);
+            if (count($query->getParameters()) === 0) {
+                $this->connection->executeUpdate($query->getStatement());
             } else {
-                $this->connection->executeUpdate($query, $this->params[$key], $this->types[$key]);
+                $this->connection->executeUpdate($query->getStatement(), $query->getParameters(), $query->getTypes());
             }
 
             $stopwatchEvent->stop();
@@ -349,26 +316,15 @@ final class DbalExecutor implements Executor
         }
     }
 
-    /**
-     * @param mixed[]|int $params
-     * @param mixed[]|int $types
-     */
-    private function addQueryParams($params, $types) : void
-    {
-        $index                = count($this->sql) - 1;
-        $this->params[$index] = $params;
-        $this->types[$index]  = $types;
-    }
-
-    private function outputSqlQuery(int $idx, string $query) : void
+    private function outputSqlQuery(Query $query) : void
     {
         $params = $this->parameterFormatter->formatParameters(
-            $this->params[$idx] ?? [],
-            $this->types[$idx] ?? []
+            $query->getParameters(),
+            $query->getTypes()
         );
 
         $this->logger->debug('{query} {params}', [
-            'query' => $query,
+            'query' => $query->getStatement(),
             'params' => $params,
         ]);
     }

--- a/lib/Doctrine/Migrations/Version/ExecutionResult.php
+++ b/lib/Doctrine/Migrations/Version/ExecutionResult.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Version;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Query\Query;
 use RuntimeException;
 use Throwable;
 use function count;
@@ -17,14 +18,8 @@ use function count;
  */
 final class ExecutionResult
 {
-    /** @var string[] */
+    /** @var Query[] */
     private $sql = [];
-
-    /** @var mixed[] */
-    private $params = [];
-
-    /** @var mixed[] */
-    private $types = [];
 
     /** @var float|null */
     private $time;
@@ -89,7 +84,7 @@ final class ExecutionResult
     }
 
     /**
-     * @return string[]
+     * @return Query[]
      */
     public function getSql() : array
     {
@@ -97,31 +92,11 @@ final class ExecutionResult
     }
 
     /**
-     * @param string[] $sql
-     * @param mixed[]  $params
-     * @param int[]    $types
+     * @param Query[] $sql
      */
-    public function setSql(array $sql, array $params = [], array $types = []) : void
+    public function setSql(array $sql) : void
     {
-        $this->sql    = $sql;
-        $this->params = $params;
-        $this->types  = $types;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getParams() : array
-    {
-        return $this->params;
-    }
-
-    /**
-     * @return mixed[]
-     */
-    public function getTypes() : array
-    {
-        return $this->types;
+        $this->sql = $sql;
     }
 
     public function getTime() : ?float

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Version;
 
 use Doctrine\Migrations\Metadata\MigrationPlan;
 use Doctrine\Migrations\MigratorConfiguration;
+use Doctrine\Migrations\Query\Query;
 
 /**
  * The Executor defines the interface used for adding sql for a migration and executing that sql.
@@ -14,11 +15,7 @@ use Doctrine\Migrations\MigratorConfiguration;
  */
 interface Executor
 {
-    /**
-     * @param mixed[] $params
-     * @param mixed[] $types
-     */
-    public function addSql(string $sql, array $params = [], array $types = []) : void;
+    public function addSql(Query $sqlQuery) : void;
 
     public function execute(MigrationPlan $plan, MigratorConfiguration $migratorConfiguration) : ExecutionResult;
 }

--- a/tests/Doctrine/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/Migrations/Tests/AbstractMigrationTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Migrations\Tests;
 use Doctrine\Migrations\Exception\AbortMigration;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
 use Doctrine\Migrations\Exception\SkipMigration;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Tests\Stub\AbstractMigrationStub;
 
 class AbstractMigrationTest extends MigrationTestCase
@@ -33,7 +34,7 @@ class AbstractMigrationTest extends MigrationTestCase
     {
         $this->migration->exposedAddSql('SELECT 1', [1], [2]);
 
-        self::assertSame([['SELECT 1', [1], [2]]], $this->migration->getSql());
+        self::assertEquals([new Query('SELECT 1', [1], [2])], $this->migration->getSql());
     }
 
     public function testWarnIfOutputMessage() : void

--- a/tests/Doctrine/Migrations/Tests/FileQueryWriterTest.php
+++ b/tests/Doctrine/Migrations/Tests/FileQueryWriterTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests;
 
 use Doctrine\Migrations\FileQueryWriter;
 use Doctrine\Migrations\Generator\FileBuilder;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\Direction;
 use Psr\Log\LoggerInterface;
 use function file_get_contents;
@@ -39,7 +40,7 @@ final class FileQueryWriterTest extends MigrationTestCase
         $migrationFileBuilder
             ->expects(self::atLeastOnce())
             ->method('buildMigrationFile')
-            ->with(['A'], Direction::UP)
+            ->with(['Foo' => [new Query('A')]], Direction::UP)
             ->willReturn('foo');
 
         $logger = $this->createMock(LoggerInterface::class);
@@ -52,7 +53,7 @@ final class FileQueryWriterTest extends MigrationTestCase
             $logger
         );
 
-        self::assertTrue($writer->write($path, Direction::UP, ['A']));
+        self::assertTrue($writer->write($path, Direction::UP, ['Foo' => [new Query('A')]]));
 
         $files = $this->getSqlFilesList($path);
 

--- a/tests/Doctrine/Migrations/Tests/Generator/ConcatenationFileBuilderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/ConcatenationFileBuilderTest.php
@@ -8,6 +8,7 @@ use DateTime;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\Migrations\Generator\ConcatenationFileBuilder;
 use Doctrine\Migrations\Generator\FileBuilder;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\Direction;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -23,17 +24,17 @@ class ConcatenationFileBuilderTest extends TestCase
     public function testBuildMigrationFile() : void
     {
         $queriesByVersion = [
-            '1' => [
-                'SELECT 1',
-                'SELECT 2',
+            'foo' => [
+                new Query('SELECT 1'),
+                new Query('SELECT 2'),
             ],
-            '2' => [
-                'SELECT 3',
-                'SELECT 4',
+            'bar' => [
+                new Query('SELECT 3'),
+                new Query('SELECT 4'),
             ],
-            '3' => [
-                'SELECT 5',
-                'SELECT 6',
+            'baz' => [
+                new Query('SELECT 5'),
+                new Query('SELECT 6'),
             ],
         ];
 
@@ -48,15 +49,15 @@ class ConcatenationFileBuilderTest extends TestCase
         $expected = <<<'FILE'
 -- Doctrine Migration File Generated on 2018-09-01 00:00:00
 
--- Version 1
+-- Version foo
 SELECT 1;
 SELECT 2;
 
--- Version 2
+-- Version bar
 SELECT 3;
 SELECT 4;
 
--- Version 3
+-- Version baz
 SELECT 5;
 SELECT 6;
 

--- a/tests/Doctrine/Migrations/Tests/MigratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigratorTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Stopwatch\Stopwatch as SymfonyStopwatch;
 use Throwable;
+use function array_map;
 use const DIRECTORY_SEPARATOR;
 
 class MigratorTest extends MigrationTestCase
@@ -72,9 +73,12 @@ class MigratorTest extends MigrationTestCase
 
         $sql = $migrator->migrate($planList, $this->migratorConfiguration);
 
-        self::assertSame([
-            'Doctrine\\Migrations\\Tests\\Stub\\Functional\\MigrateNotTouchingTheSchema' => ['SELECT 1'],
-        ], $sql);
+        self::assertCount(1, $sql);
+        self::assertArrayHasKey('Doctrine\\Migrations\\Tests\\Stub\\Functional\\MigrateNotTouchingTheSchema', $sql);
+        self::assertSame(
+            ['SELECT 1'],
+            array_map('strval', $sql['Doctrine\\Migrations\\Tests\\Stub\\Functional\\MigrateNotTouchingTheSchema'])
+        );
     }
 
     public function testEmptyPlanShowsMessage() : void
@@ -130,9 +134,13 @@ class MigratorTest extends MigrationTestCase
         $planList  = new MigrationPlanList([$plan], Direction::UP);
 
         $sql = $migrator->migrate($planList, $this->migratorConfiguration);
-        self::assertSame([
-            'Doctrine\\Migrations\\Tests\\Stub\\Functional\\MigrateNotTouchingTheSchema' => ['SELECT 1'],
-        ], $sql);
+
+        self::assertCount(1, $sql);
+        self::assertArrayHasKey('Doctrine\\Migrations\\Tests\\Stub\\Functional\\MigrateNotTouchingTheSchema', $sql);
+        self::assertSame(
+            ['SELECT 1'],
+            array_map('strval', $sql['Doctrine\\Migrations\\Tests\\Stub\\Functional\\MigrateNotTouchingTheSchema'])
+        );
     }
 
     public function testMigrateAllOrNothingRollback() : void

--- a/tests/Doctrine/Migrations/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/Migrations/Tests/Query/QueryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests\Query;
 
+use Doctrine\Migrations\Query\Exception\InvalidArguments;
 use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Tests\MigrationTestCase;
 
@@ -17,5 +18,13 @@ final class QueryTest extends MigrationTestCase
         self::assertSame('foo', (string) $query);
         self::assertSame(['bar', 'baz'], $query->getParameters());
         self::assertSame(['qux', 'quux'], $query->getTypes());
+    }
+
+    public function testInvalidTypeArguments() : void
+    {
+        $this->expectException(InvalidArguments::class);
+        $this->expectExceptionMessage('The number of types (2) is higher than the number of passed parameters (1) for the query "Select 1".');
+
+        new Query('Select 1', ['bar'], ['qux', 'quux']);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/Migrations/Tests/Query/QueryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Query;
+
+use Doctrine\Migrations\Query\Query;
+use Doctrine\Migrations\Tests\MigrationTestCase;
+
+final class QueryTest extends MigrationTestCase
+{
+    public function testGetQuery() : void
+    {
+        $query = new Query('foo', ['bar', 'baz'], ['qux', 'quux']);
+
+        self::assertSame('foo', $query->getStatement());
+        self::assertSame('foo', (string) $query);
+        self::assertSame(['bar', 'baz'], $query->getParameters());
+        self::assertSame(['qux', 'quux'], $query->getTypes());
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutionResultTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutionResultTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests\Version;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
@@ -25,13 +26,19 @@ class ExecutionResultTest extends TestCase
 
     public function testGetSetSql() : void
     {
-        self::assertSame(['SELECT 1'], $this->versionExecutionResult->getSql());
+         $queries = $this->versionExecutionResult->getSql();
+        self::assertCount(1, $queries);
+        self::assertSame('SELECT 1', $queries[0]->getStatement());
+        self::assertSame([1], $queries[0]->getParameters());
+        self::assertSame([2], $queries[0]->getTypes());
 
-        $this->versionExecutionResult->setSql(['SELECT 2'], [2], [3]);
+        $this->versionExecutionResult->setSql([new Query('SELECT 2', [2], [3])]);
 
-        self::assertSame(['SELECT 2'], $this->versionExecutionResult->getSql());
-        self::assertSame([2], $this->versionExecutionResult->getParams());
-        self::assertSame([3], $this->versionExecutionResult->getTypes());
+        $queries = $this->versionExecutionResult->getSql();
+        self::assertCount(1, $queries);
+        self::assertSame('SELECT 2', $queries[0]->getStatement());
+        self::assertSame([2], $queries[0]->getParameters());
+        self::assertSame([3], $queries[0]->getTypes());
     }
 
     public function testGetSetTime() : void
@@ -120,10 +127,6 @@ class ExecutionResultTest extends TestCase
             new Version('foo'),
             Direction::UP
         );
-        $this->versionExecutionResult->setSql(
-            ['SELECT 1'],
-            [1],
-            [2]
-        );
+        $this->versionExecutionResult->setSql([new Query('SELECT 1', [1], [2])]);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Version/Fixture/EmptyTestMigration.php
+++ b/tests/Doctrine/Migrations/Tests/Version/Fixture/EmptyTestMigration.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Version\Fixture;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class EmptyTestMigration extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+    }
+
+    public function down(Schema $schema) : void
+    {
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/Fixture/VersionExecutorTestMigration.php
+++ b/tests/Doctrine/Migrations/Tests/Version/Fixture/VersionExecutorTestMigration.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Version\Fixture;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class VersionExecutorTestMigration extends AbstractMigration
+{
+    /** @var bool */
+    public $preUpExecuted = false;
+
+    /** @var bool */
+    public $preDownExecuted = false;
+
+    /** @var bool */
+    public $postUpExecuted = false;
+
+    /** @var bool */
+    public $postDownExecuted = false;
+
+    /** @var string */
+    private $description = '';
+
+    /** @var bool */
+    public $skip = false;
+    /** @var bool */
+    public $error = false;
+
+    public function getDescription() : string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description) : void
+    {
+        $this->description = $description;
+    }
+
+    public function preUp(Schema $fromSchema) : void
+    {
+        $this->preUpExecuted = true;
+        parent::preUp($fromSchema);
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->skipIf($this->skip);
+        $this->abortIf($this->error);
+
+        $this->addSql('SELECT 1', [1], [3]);
+        $this->addSql('SELECT 2');
+    }
+
+    public function postUp(Schema $toSchema) : void
+    {
+        $this->postUpExecuted = true;
+        parent::postUp($toSchema);
+    }
+
+    public function preDown(Schema $fromSchema) : void
+    {
+        $this->preDownExecuted = true;
+        parent::preDown($fromSchema);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('SELECT 3', [5], [7]);
+        $this->addSql('SELECT 4', [6], [8]);
+    }
+
+    public function postDown(Schema $toSchema) : void
+    {
+        $this->postDownExecuted = true;
+        parent::postDown($toSchema);
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | -

#### Summary
I think that the `Query` value object was a great idea proposed by @pulzarraider in #906. Independently if #906 is going to be merged, I see value in the `Query` part, so here is a full refactoring of the code base to use it everywhere instead of the current 3 different arrays holding the same data.