### PR TITLE
Remove trailing spaces from generated SQL

### DIFF
--- a/lib/Doctrine/Migrations/Generator/SqlGenerator.php
+++ b/lib/Doctrine/Migrations/Generator/SqlGenerator.php
@@ -10,6 +10,7 @@ use SqlFormatter;
 use function array_unshift;
 use function count;
 use function implode;
+use function preg_replace;
 use function sprintf;
 use function stripos;
 use function strlen;
@@ -74,6 +75,6 @@ class SqlGenerator
             );
         }
 
-        return implode("\n", $code);
+        return preg_replace('/ +$/m', '', implode("\n", $code));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement?
| BC Break     | no
| Fixed issues | -

When generating a new version using the diff command with `--formatted` option, the SQL formatted by the `jdorn/sql-formatter` lib contains trailing spaces. This PR makes the internal SQL generator removes them.

A better solution would probably be to do the same PR on `jdorn/sql-formatter` but the package seems abandoned.