### PR TITLE
Allow to decorate dependency factory services

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -296,6 +296,12 @@ class DependencyFactory
         $this->dependencies[$id] = $service;
     }
 
+    public function decorateService(string $id, callable $callback) : void
+    {
+        $this->assertNotFrozen();
+        $this->dependencies[$id] = $callback($this);
+    }
+
     private function getMetadataStorageConfiguration() : MetadataStorageConfiguration
     {
         return $this->getDependency(MetadataStorageConfiguration::class, static function () : MetadataStorageConfiguration {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | -
| Fixed issues | -

#### Summary

The DI factory become a central extension point for doctrine migrations. 
Being able to decorate services is fundamental for most of DI containers and allows to apply composition over inheritance
