### PR TITLE
Mark the execute() method as protected to match the symfony signature

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -98,7 +98,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $versions  = $input->getArgument('versions');
         $path      = $input->getOption('write-sql');

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -52,7 +52,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $configuration = $this->getDependencyFactory()->getConfiguration();
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
@@ -26,7 +26,7 @@ class LatestCommand extends DoctrineCommand
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $aliasResolver = $this->getDependencyFactory()->getVersionAliasResolver();
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
@@ -39,7 +39,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : int
+    protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $versions = $this->getSortedVersions(
             $this->getDependencyFactory()->getMigrationRepository()->getMigrations(), // available migrations

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -114,7 +114,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $allowNoMigration = $input->getOption('allow-no-migration');
         $versionAlias     = $input->getArgument('version');

--- a/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
@@ -35,7 +35,7 @@ EOT
             );
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $question = 'WARNING! You are about to execute a database migration that could result in schema changes and data loss. Are you sure you wish to continue? (y/n)';
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -38,7 +38,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $storage       = $this->getDependencyFactory()->getMetadataStorage();
         $migrationRepo = $this->getDependencyFactory()->getMigrationRepository();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -45,7 +45,7 @@ EOT
         parent::configure();
     }
 
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         $statusCalculator = $this->getDependencyFactory()->getMigrationStatusCalculator();
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -102,7 +102,7 @@ EOT
     /**
      * @throws InvalidOptionUsage
      */
-    public function execute(InputInterface $input, OutputInterface $output) : ?int
+    protected function execute(InputInterface $input, OutputInterface $output) : ?int
     {
         if ($input->getOption('add') === false && $input->getOption('delete') === false) {
             throw InvalidOptionUsage::new('You must specify whether you want to --add or --delete the specified version.');


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | https://github.com/doctrine/migrations/pull/923

Change of the visibility from "public" to "protected" on Command classes to match the declaration with Symfony/Console

Implementation of https://github.com/doctrine/migrations/pull/923 with tests