### PR TITLE
Better handling of the table initialization

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -21,7 +21,6 @@ use Doctrine\Migrations\Generator\FileBuilder;
 use Doctrine\Migrations\Generator\Generator;
 use Doctrine\Migrations\Generator\SqlGenerator;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-use Doctrine\Migrations\Metadata\Storage\MetadataStorageConfiguration;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\Provider\DBALSchemaDiffProvider;
@@ -307,19 +306,12 @@ class DependencyFactory
         $this->dependencies[$id] = $service;
     }
 
-    private function getMetadataStorageConfiguration() : MetadataStorageConfiguration
-    {
-        return $this->getDependency(MetadataStorageConfiguration::class, static function () : MetadataStorageConfiguration {
-            return new TableMetadataStorageConfiguration();
-        });
-    }
-
     public function getMetadataStorage() : MetadataStorage
     {
         return $this->getDependency(MetadataStorage::class, function () : MetadataStorage {
             return new TableMetadataStorage(
                 $this->getConnection(),
-                $this->getMetadataStorageConfiguration(),
+                $this->getConfiguration()->getMetadataStorageConfiguration(),
                 $this->getMigrationRepository()
             );
         });


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | https://github.com/doctrine/migrations/issues/935

#### Summary

This PR solves https://github.com/doctrine/migrations/issues/935.

The idea behind is that:

- if there is no migration table then we consider it as if there are no executed migrations (in this case all the read command work as usual, the write command will create the table as expected on the very first migrations run)
- if there is a table but is not up to date, any command will trigger an exception and the user will have to run the sync-metadata command


With this PR the read commands will never update your DB and the write commands will do so only  after the user's consent
