### PR TITLE
Add warning for diffCommand

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -7,8 +7,6 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 use Doctrine\Migrations\Generator\Exception\NoChangesDetected;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
-use Doctrine\Migrations\Provider\OrmSchemaProvider;
-use Doctrine\Migrations\Provider\SchemaProviderInterface;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use OutOfBoundsException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use function addslashes;
 use function assert;
 use function class_exists;
+use function count;
 use function filter_var;
 use function is_string;
 use function key;
@@ -134,6 +133,7 @@ EOT
         if ($this->checkNewMigrations($newMigrations, $input, $output) === false) {
             return 3;
         }
+
         if ($this->checkExecutedUnavailableMigrations($executedUnavailableMigrations, $input, $output) === false) {
             return 3;
         }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -126,9 +126,9 @@ EOT
 
         assert(is_string($namespace));
 
-        $planCalculator                = $this->getDependencyFactory()->getMigrationPlanCalculator();
-        $executedUnavailableMigrations = $planCalculator->getExecutedUnavailableMigrations();
-        $newMigrations                 = $planCalculator->getNewMigrations();
+        $statusCalculator              = $this->getDependencyFactory()->getMigrationStatusCalculator();
+        $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
+        $newMigrations                 = $statusCalculator->getNewMigrations();
 
         if ($this->checkNewMigrations($newMigrations, $input, $output) === false) {
             return 3;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tools\Console\Command;
 
 use Doctrine\Migrations\Generator\Exception\NoChangesDetected;
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Provider\OrmSchemaProvider;
+use Doctrine\Migrations\Provider\SchemaProviderInterface;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use OutOfBoundsException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -123,6 +127,17 @@ EOT
 
         assert(is_string($namespace));
 
+        $planCalculator                = $this->getDependencyFactory()->getMigrationPlanCalculator();
+        $executedUnavailableMigrations = $planCalculator->getExecutedUnavailableMigrations();
+        $newMigrations                 = $planCalculator->getNewMigrations();
+
+        if ($this->checkNewMigrations($newMigrations, $input, $output) === false) {
+            return 3;
+        }
+        if ($this->checkExecutedUnavailableMigrations($executedUnavailableMigrations, $input, $output) === false) {
+            return 3;
+        }
+
         $fqcn = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName($namespace);
 
         $diffGenerator = $this->getDependencyFactory()->getDiffGenerator();
@@ -167,5 +182,61 @@ EOT
         ]);
 
         return 0;
+    }
+
+    private function checkNewMigrations(
+        AvailableMigrationsList $newMigrations,
+        InputInterface $input,
+        OutputInterface $output
+    ) : bool {
+        if (count($newMigrations) !== 0) {
+            $output->writeln(sprintf(
+                '<error>WARNING! You have %s available migrations to execute.</error>',
+                count($newMigrations)
+            ));
+
+            $question = 'Are you sure you wish to continue? (y/n)';
+
+            if (! $this->canExecute($question, $input, $output)) {
+                $output->writeln('<error>Migration cancelled!</error>');
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function checkExecutedUnavailableMigrations(
+        ExecutedMigrationsSet $executedUnavailableMigrations,
+        InputInterface $input,
+        OutputInterface $output
+    ) : bool {
+        if (count($executedUnavailableMigrations) !== 0) {
+            $output->writeln(sprintf(
+                '<error>WARNING! You have %s previously executed migrations in the database that are not registered migrations.</error>',
+                count($executedUnavailableMigrations)
+            ));
+
+            foreach ($executedUnavailableMigrations->getItems() as $executedUnavailableMigration) {
+                $output->writeln(sprintf(
+                    '    <comment>>></comment> %s (<comment>%s</comment>)',
+                    $executedUnavailableMigration->getExecutedAt() !== null
+                        ? $executedUnavailableMigration->getExecutedAt()->format('Y-m-d H:i:s')
+                        : null,
+                    $executedUnavailableMigration->getVersion()
+                ));
+            }
+
+            $question = 'Are you sure you wish to continue? (y/n)';
+
+            if (! $this->canExecute($question, $input, $output)) {
+                $output->writeln('<error>Migration cancelled!</error>');
+
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -8,6 +8,7 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Generator\ClassNameGenerator;
 use Doctrine\Migrations\Generator\DiffGenerator;
+use Doctrine\Migrations\MigrationPlanCalculator;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,6 +20,9 @@ final class DiffCommandTest extends TestCase
 {
     /** @var DiffGenerator|MockObject */
     private $migrationDiffGenerator;
+
+    /** @var MigrationPlanCalculator|MockObject */
+    private $migrationPlanCalculator;
 
     /** @var Configuration */
     private $configuration;
@@ -94,6 +98,7 @@ final class DiffCommandTest extends TestCase
     protected function setUp() : void
     {
         $this->migrationDiffGenerator = $this->createMock(DiffGenerator::class);
+        $this->migrationPlanCalculator = $this->createMock(MigrationPlanCalculator::class);
         $this->configuration          = new Configuration();
         $this->configuration->addMigrationsDirectory('FooNs', sys_get_temp_dir());
 
@@ -116,6 +121,10 @@ final class DiffCommandTest extends TestCase
         $this->dependencyFactory->expects(self::any())
             ->method('getDiffGenerator')
             ->willReturn($this->migrationDiffGenerator);
+
+        $this->dependencyFactory->expects(self::any())
+            ->method('getMigrationPlanCalculator')
+            ->willReturn($this->migrationPlanCalculator);
 
         $this->diffCommand = $this->getMockBuilder(DiffCommand::class)
             ->setConstructorArgs([$this->dependencyFactory])

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -97,9 +97,9 @@ final class DiffCommandTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->migrationDiffGenerator = $this->createMock(DiffGenerator::class);
+        $this->migrationDiffGenerator  = $this->createMock(DiffGenerator::class);
         $this->migrationPlanCalculator = $this->createMock(MigrationPlanCalculator::class);
-        $this->configuration          = new Configuration();
+        $this->configuration           = new Configuration();
         $this->configuration->addMigrationsDirectory('FooNs', sys_get_temp_dir());
 
         $this->dependencyFactory = $this->createMock(DependencyFactory::class);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -8,8 +8,8 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Generator\ClassNameGenerator;
 use Doctrine\Migrations\Generator\DiffGenerator;
-use Doctrine\Migrations\MigrationPlanCalculator;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
+use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,8 +21,8 @@ final class DiffCommandTest extends TestCase
     /** @var DiffGenerator|MockObject */
     private $migrationDiffGenerator;
 
-    /** @var MigrationPlanCalculator|MockObject */
-    private $migrationPlanCalculator;
+    /** @var MigrationStatusCalculator|MockObject */
+    private $migrationStatusCalculator;
 
     /** @var Configuration */
     private $configuration;
@@ -97,9 +97,9 @@ final class DiffCommandTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->migrationDiffGenerator  = $this->createMock(DiffGenerator::class);
-        $this->migrationPlanCalculator = $this->createMock(MigrationPlanCalculator::class);
-        $this->configuration           = new Configuration();
+        $this->migrationDiffGenerator    = $this->createMock(DiffGenerator::class);
+        $this->migrationStatusCalculator = $this->createMock(MigrationStatusCalculator::class);
+        $this->configuration             = new Configuration();
         $this->configuration->addMigrationsDirectory('FooNs', sys_get_temp_dir());
 
         $this->dependencyFactory = $this->createMock(DependencyFactory::class);
@@ -123,8 +123,8 @@ final class DiffCommandTest extends TestCase
             ->willReturn($this->migrationDiffGenerator);
 
         $this->dependencyFactory->expects(self::any())
-            ->method('getMigrationPlanCalculator')
-            ->willReturn($this->migrationPlanCalculator);
+            ->method('getMigrationStatusCalculator')
+            ->willReturn($this->migrationStatusCalculator);
 
         $this->diffCommand = $this->getMockBuilder(DiffCommand::class)
             ->setConstructorArgs([$this->dependencyFactory])


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | #930 

#### Summary

Add warning when running diff command with executed unavalaible or non executed migrations.
