### PR TITLE
Make the down() migration optional

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -205,6 +205,7 @@ Here is a list of the most important changes:
          use `Doctrine\Migrations\DependencyFactory` instead
  - Namespace `Doctrine\Migrations\AbstractMigration`       
      - CHANGED: The method `Doctrine\Migrations\AbstractMigration#__construct()` changed signature into `(Doctrine\DBAL\Connection $conn, PSR\Log\LoggerInterface $logger)`
+     - CHANGED: The method `Doctrine\Migrations\AbstractMigration#down()` is not abstract anymore, the default implementation will abort the migration process
      - REMOVED: Property `Doctrine\Migrations\AbstractMigration#$version` was removed 
  - Namespace `Doctrine\Migrations\Provider`
      - REMOVED: Class `Doctrine\Migrations\Provider\SchemaProviderInterface` has been deleted

--- a/lib/Doctrine/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/Migrations/AbstractMigration.php
@@ -15,6 +15,7 @@ use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Doctrine\Migrations\Query\Query;
 use Psr\Log\LoggerInterface;
+use function sprintf;
 
 /**
  * The AbstractMigration class is for end users to extend from when creating migrations. Extend this class
@@ -129,7 +130,10 @@ abstract class AbstractMigration
     /**
      * @throws MigrationException|DBALException
      */
-    abstract public function down(Schema $schema) : void;
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf(true, sprintf('No down() migration implemented for "%s"', static::class));
+    }
 
     /**
      * @param mixed[] $params

--- a/tests/Doctrine/Migrations/Tests/AbstractMigrationTest.php
+++ b/tests/Doctrine/Migrations/Tests/AbstractMigrationTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests;
 
+use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\AbortMigration;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Tests\Stub\AbstractMigrationStub;
+use Doctrine\Migrations\Tests\Stub\AbstractMigrationWithoutDownStub;
 
 class AbstractMigrationTest extends MigrationTestCase
 {
@@ -23,6 +25,16 @@ class AbstractMigrationTest extends MigrationTestCase
         $this->logger = new TestLogger();
 
         $this->migration = new AbstractMigrationStub($this->getSqliteConnection(), $this->logger);
+    }
+
+    public function testDownMigrationIsOptional() : void
+    {
+        $this->expectException(AbortMigration::class);
+        $this->expectExceptionMessage('No down() migration implemented for "Doctrine\Migrations\Tests\Stub\AbstractMigrationWithoutDownStub"');
+
+        $migration = new AbstractMigrationWithoutDownStub($this->getSqliteConnection(), $this->logger);
+        $schema    = $this->createStub(Schema::class);
+        $migration->down($schema);
     }
 
     public function testGetDescriptionReturnsEmptyString() : void

--- a/tests/Doctrine/Migrations/Tests/Stub/AbstractMigrationWithoutDownStub.php
+++ b/tests/Doctrine/Migrations/Tests/Stub/AbstractMigrationWithoutDownStub.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Stub;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class AbstractMigrationWithoutDownStub extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | -
| Fixed issues | -

#### Summary
Removing the `down()` migration is something that has been already proposed in https://github.com/doctrine/migrations/pull/162 , https://github.com/goetas/migrations/pull/2 . 
Each time the decision has been postponed as some people still use that feature while others don't.

This PR proposes to make it optional. It provides a default implementation in `AbstractMigration` but still allows its use as it was before (the default migration generation works as usual by generating the `down()` method as expected).


