### PR TITLE
Remove superfluous parameters check on executeUpdate 

### DIFF
--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -295,11 +295,7 @@ final class DbalExecutor implements Executor
 
             $this->outputSqlQuery($query);
 
-            if (count($query->getParameters()) === 0) {
-                $this->connection->executeUpdate($query->getStatement());
-            } else {
-                $this->connection->executeUpdate($query->getStatement(), $query->getParameters(), $query->getTypes());
-            }
+            $this->connection->executeUpdate($query->getStatement(), $query->getParameters(), $query->getTypes());
 
             $stopwatchEvent->stop();
 

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -291,12 +291,10 @@ final class DbalExecutor implements Executor
     private function executeResult(MigratorConfiguration $configuration) : void
     {
         foreach ($this->sql as $key => $query) {
-            $stopwatchEvent = $this->stopwatch->start('query');
-
             $this->outputSqlQuery($query);
 
+            $stopwatchEvent = $this->stopwatch->start('query');
             $this->connection->executeUpdate($query->getStatement(), $query->getParameters(), $query->getTypes());
-
             $stopwatchEvent->stop();
 
             if (! $configuration->getTimeAllQueries()) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

- `executeUpdate` internally checks the `$parameters` count, no need to do it here
- more precise query timing, by skipping console query output