### PR TITLE
Make compared tables order idempotent

### DIFF
--- a/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
@@ -7,8 +7,10 @@ namespace Doctrine\Migrations\Provider;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Provider\Exception\NoMappingFound;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
 use function count;
+use function usort;
 
 /**
  * The OrmSchemaProvider class is responsible for creating a Doctrine\DBAL\Schema\Schema instance from the mapping
@@ -37,6 +39,10 @@ final class OrmSchemaProvider implements SchemaProviderInterface
         if (count($metadata) === 0) {
             throw NoMappingFound::new();
         }
+
+        usort($metadata, static function (ClassMetadata $a, ClassMetadata $b) {
+            return $a->getTableName() <=> $b->getTableName();
+        });
 
         $tool = new SchemaTool($this->entityManager);
 

--- a/tests/Doctrine/Migrations/Tests/Provider/A.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/A.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Provider;
+
+class A
+{
+    /** @var int|null */
+    private $id;
+
+    public function getId() : ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Provider/B.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/B.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests\Provider;
 
-class SampleEntity
+class B
 {
     /** @var int|null */
     private $id;

--- a/tests/Doctrine/Migrations/Tests/Provider/C.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/C.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Provider;
+
+class C
+{
+    /** @var int|null */
+    private $id;
+
+    public function getId() : ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Provider/ClassMetadataFactory.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/ClassMetadataFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Provider;
+
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ClassMetadataFactory as BaseMetadataFactoryAlias;
+use function array_reverse;
+
+class ClassMetadataFactory extends BaseMetadataFactoryAlias
+{
+    /**
+     * @return ClassMetadata[]
+     */
+    public function getAllMetadata() : array
+    {
+        return array_reverse(parent::getAllMetadata());
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -34,9 +34,20 @@ class OrmSchemaProviderTest extends MigrationTestCase
     public function testCreateSchemaFetchesMetadataFromEntityManager() : void
     {
         $schema = $this->ormProvider->createSchema();
-        self::assertTrue($schema->hasTable('sample_entity'));
-        $table = $schema->getTable('sample_entity');
-        self::assertTrue($table->hasColumn('id'));
+
+        self::assertSame(
+            [
+                'public.a',
+                'public.b',
+                'public.c',
+            ],
+            $schema->getTableNames()
+        );
+
+        foreach (['a', 'b', 'c'] as $expectedTable) {
+            $table = $schema->getTable($expectedTable);
+            self::assertTrue($table->hasColumn('id'));
+        }
     }
 
     public function testEntityManagerWithoutMetadataCausesError() : void
@@ -50,8 +61,10 @@ class OrmSchemaProviderTest extends MigrationTestCase
 
     protected function setUp() : void
     {
+        $this->config = Setup::createXMLMetadataConfiguration([__DIR__ . '/_files'], true);
+        $this->config->setClassMetadataFactoryName(ClassMetadataFactory::class);
+
         $this->conn          = $this->getSqliteConnection();
-        $this->config        = Setup::createXMLMetadataConfiguration([__DIR__ . '/_files'], true);
         $this->entityManager = EntityManager::create($this->conn, $this->config);
         $this->ormProvider   = new OrmSchemaProvider($this->entityManager);
     }

--- a/tests/Doctrine/Migrations/Tests/Provider/_files/Doctrine.Migrations.Tests.Provider.A.dcm.xml
+++ b/tests/Doctrine/Migrations/Tests/Provider/_files/Doctrine.Migrations.Tests.Provider.A.dcm.xml
@@ -3,7 +3,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                    https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
 
-   <entity name="Doctrine\Migrations\Tests\Provider\SampleEntity" table="sample_entity">
+   <entity name="Doctrine\Migrations\Tests\Provider\A" table="a">
        <id name="id" type="integer" column="id">
            <generator strategy="AUTO" />
        </id>

--- a/tests/Doctrine/Migrations/Tests/Provider/_files/Doctrine.Migrations.Tests.Provider.B.dcm.xml
+++ b/tests/Doctrine/Migrations/Tests/Provider/_files/Doctrine.Migrations.Tests.Provider.B.dcm.xml
@@ -1,0 +1,12 @@
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+   <entity name="Doctrine\Migrations\Tests\Provider\B" table="b">
+       <id name="id" type="integer" column="id">
+           <generator strategy="AUTO" />
+       </id>
+   </entity>
+
+</doctrine-mapping>

--- a/tests/Doctrine/Migrations/Tests/Provider/_files/Doctrine.Migrations.Tests.Provider.C.dcm.xml
+++ b/tests/Doctrine/Migrations/Tests/Provider/_files/Doctrine.Migrations.Tests.Provider.C.dcm.xml
@@ -1,0 +1,12 @@
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                   https://raw.github.com/doctrine/doctrine2/master/doctrine-mapping.xsd">
+
+   <entity name="Doctrine\Migrations\Tests\Provider\C" table="c">
+       <id name="id" type="integer" column="id">
+           <generator strategy="AUTO" />
+       </id>
+   </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

This PR makes sure the schema generated from mapping (to be compared with the actual database) is always provided tables data in the same order.

This helps when you want to have only one migration per deployment: instead of creating several small migration versions, you create a single one that you remove and recreate each time you change the mapping. For some reasons I couldn't figure out, it happens that the order in which tables data are loaded can vary. In my case it was different from one developper setup to another (despite all using the same Docker setup). In such case, even adding a simple column can generate a completely different migration, which makes it hard to read in VCS history and code reviews.