### PR TITLE
Reduce primary key max length to 191 chars

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorageConfiguration.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorageConfiguration.php
@@ -13,7 +13,7 @@ final class TableMetadataStorageConfiguration implements MetadataStorageConfigur
     private $versionColumnName = 'version';
 
     /** @var int */
-    private $versionColumnLength = 1024;
+    private $versionColumnLength = 191;
 
     /** @var string */
     private $executedAtColumnName = 'executed_at';

--- a/tests/Doctrine/Migrations/Tests/Configuration/Migration/LoaderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/Migration/LoaderTest.php
@@ -48,7 +48,7 @@ abstract class LoaderTest extends TestCase
 
         self::assertSame('doctrine_migration_versions', $storage->getTableName());
         self::assertSame('version', $storage->getVersionColumnName());
-        self::assertSame(1024, $storage->getVersionColumnLength());
+        self::assertSame(191, $storage->getVersionColumnLength());
         self::assertSame('execution_time', $storage->getExecutionTimeColumnName());
         self::assertSame('executed_at', $storage->getExecutedAtColumnName());
     }

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageConfigurationTest.php
@@ -15,7 +15,7 @@ class TableMetadataStorageConfigurationTest extends TestCase
 
         self::assertSame('doctrine_migration_versions', $config->getTableName());
         self::assertSame('version', $config->getVersionColumnName());
-        self::assertSame(1024, $config->getVersionColumnLength());
+        self::assertSame(191, $config->getVersionColumnLength());
         self::assertSame('executed_at', $config->getExecutedAtColumnName());
         self::assertSame('execution_time', $config->getExecutionTimeColumnName());
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
| Fixed issues | https://github.com/doctrine/migrations/issues/958

#### Summary

MariaDB and MySQL have a limit of 767 bytes for a primary key. Considering UTF-8 encoding (up to 4 bytes per char), the maximum string length is 191 chars.

See https://dev.mysql.com/doc/refman/5.7/en/innodb-limits.html
