### PR TITLE
Fix typos

### DIFF
--- a/docs/en/reference/migration-classes.rst
+++ b/docs/en/reference/migration-classes.rst
@@ -176,7 +176,7 @@ addSql
 
 You can use the ``addSql`` method within the ``up`` and ``down`` methods. Internally the ``addSql`` calls are passed
 to the executeQuery method in the DBAL. This means that you can use the power of prepared statements easily and that
-you don't need to copy paste the same query with different parameters. You can just pass those differents parameters
+you don't need to copy paste the same query with different parameters. You can just pass those different parameters
 to the addSql method as parameters.
 
 .. code-block:: php

--- a/lib/Doctrine/Migrations/MigrationRepository.php
+++ b/lib/Doctrine/Migrations/MigrationRepository.php
@@ -17,7 +17,7 @@ use function class_exists;
 use function uasort;
 
 /**
- * The MigrationRepository class is responsible for retrieving migrations, determing what the current migration
+ * The MigrationRepository class is responsible for retrieving migrations, determining what the current migration
  * version, etc.
  *
  * @internal

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -19,7 +19,7 @@ use function strpos;
 
 /**
  * The DumpSchemaCommand class is responsible for dumping your current database schema to a migration class. This is
- * intended to be used in conjuction with the RollupCommand.
+ * intended to be used in conjunction with the RollupCommand.
  *
  * @see Doctrine\Migrations\Tools\Console\Command\RollupCommand
  */


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `docs/en/reference/migration-classes.rst`
- 1 typo in `lib/Doctrine/Migrations/MigrationRepository.php`
- 1 typo in `lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php`



Cheers! :robot: