### PR TITLE
Use SymfonyStyle to output text in console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ cache:
 
 before_install:
   - mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini{,.disabled} || echo "xdebug not available"
+  - stty cols 120
+  - export COLUMNS=120
 
 install:
   - rm composer.lock

--- a/lib/Doctrine/Migrations/Tools/Console/Command/CurrentCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/CurrentCommand.php
@@ -42,8 +42,8 @@ final class CurrentCommand extends DoctrineCommand
             }
         }
 
-        $output->writeln(sprintf(
-            '<info>%s</info>%s',
+        $this->io->text(sprintf(
+            "<info>%s</info>%s\n",
             (string) $version,
             $description !== '' ? ' - ' . $description : ''
         ));

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -130,7 +130,7 @@ EOT
         $newMigrations                 = $statusCalculator->getNewMigrations();
 
         if (! $this->checkNewMigrationsOrExecutedUnavailable($newMigrations, $executedUnavailableMigrations, $input, $output)) {
-            $output->writeln('<error>Migration cancelled!</error>');
+            $this->io->error('Migration cancelled!');
 
             return 3;
         }
@@ -149,7 +149,7 @@ EOT
             );
         } catch (NoChangesDetected $exception) {
             if ($allowEmptyDiff) {
-                $output->writeln($exception->getMessage());
+                $this->io->error($exception->getMessage());
 
                 return 0;
             }
@@ -157,7 +157,7 @@ EOT
             throw $exception;
         }
 
-        $output->writeln([
+        $this->io->text([
             sprintf('Generated new migration class to "<info>%s</info>"', $path),
             '',
             sprintf(
@@ -169,6 +169,7 @@ EOT
                 'To revert the migration you can use <info>migrations:execute --down \'%s\'</info>',
                 addslashes($fqcn)
             ),
+            '',
         ]);
 
         return 0;
@@ -185,19 +186,19 @@ EOT
         }
 
         if (count($newMigrations) !== 0) {
-            $output->writeln(sprintf(
-                '<error>WARNING! You have %d available migrations to execute.</error>',
+            $this->io->warning(sprintf(
+                'You have %d available migrations to execute.',
                 count($newMigrations)
             ));
         }
 
         if (count($executedUnavailableMigrations) !== 0) {
-            $output->writeln(sprintf(
-                '<error>WARNING! You have %d previously executed migrations in the database that are not registered migrations.</error>',
+            $this->io->warning(sprintf(
+                'You have %d previously executed migrations in the database that are not registered migrations.',
                 count($executedUnavailableMigrations)
             ));
         }
 
-        return $this->canExecute('Are you sure you wish to continue? (y/n)', $input, $output);
+        return $this->canExecute('Are you sure you wish to continue?', $input);
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php
@@ -14,7 +14,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\StyleInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use function is_string;
 
 /**
@@ -24,6 +25,9 @@ abstract class DoctrineCommand extends Command
 {
     /** @var DependencyFactory|null */
     private $dependencyFactory;
+
+    /** @var StyleInterface */
+    protected $io;
 
     public function __construct(?DependencyFactory $dependencyFactory = null, ?string $name = null)
     {
@@ -55,6 +59,8 @@ abstract class DoctrineCommand extends Command
 
     protected function initialize(InputInterface $input, OutputInterface $output) : void
     {
+        $this->io = new SymfonyStyle($input, $output);
+
         $configurationParameter = $input->getOption('configuration');
         if ($this->dependencyFactory === null) {
             $configurationLoader     = new ConfigurationFileWithFallback(
@@ -87,23 +93,8 @@ abstract class DoctrineCommand extends Command
         return $this->dependencyFactory;
     }
 
-    protected function askConfirmation(
-        string $question,
-        InputInterface $input,
-        OutputInterface $output
-    ) : bool {
-        return $this->getHelper('question')->ask(
-            $input,
-            $output,
-            new ConfirmationQuestion($question)
-        );
-    }
-
-    protected function canExecute(
-        string $question,
-        InputInterface $input,
-        OutputInterface $output
-    ) : bool {
-        return ! $input->isInteractive() || $this->askConfirmation($question, $input, $output);
+    protected function canExecute(string $question, InputInterface $input) : bool
+    {
+        return ! $input->isInteractive() || $this->io->confirm($question);
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -111,7 +111,7 @@ EOT
             $lineLength
         );
 
-        $output->writeln([
+        $this->io->text([
             sprintf('Dumped your schema to a new migration class at "<info>%s</info>"', $path),
             '',
             sprintf(
@@ -125,6 +125,7 @@ EOT
             ),
             '',
             'To use this as a rollup migration you can use the <info>migrations:rollup</info> command.',
+            '',
         ]);
 
         return 0;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -123,7 +123,7 @@ EOT
             $path = is_string($path) ? $path : getcwd();
 
             if (! is_string($path) || ! is_writable($path)) {
-                $output->writeln('<error>Path not writeable!</error>');
+                $this->io->error('Path not writeable!');
 
                 return 1;
             }
@@ -134,10 +134,10 @@ EOT
             return 0;
         }
 
-        $question = 'WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue? (y/n)';
+        $question = 'WARNING! You are about to execute a database migration that could result in schema changes and data lost. Are you sure you wish to continue?';
 
-        if (! $migratorConfiguration->isDryRun() && ! $this->canExecute($question, $input, $output)) {
-            $output->writeln('<error>Migration cancelled!</error>');
+        if (! $migratorConfiguration->isDryRun() && ! $this->canExecute($question, $input)) {
+            $this->io->error('Migration cancelled!');
 
             return 1;
         }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -67,7 +67,7 @@ EOT
 
         $path = $migrationGenerator->generateMigration($fqcn);
 
-        $output->writeln([
+        $this->io->text([
             sprintf('Generated new migration class to "<info>%s</info>"', $path),
             '',
             sprintf(
@@ -79,6 +79,7 @@ EOT
                 'To revert the migration you can use <info>migrations:execute --down \'%s\'</info>',
                 $fqcn
             ),
+            '',
         ]);
 
         return 0;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
@@ -39,8 +39,8 @@ final class LatestCommand extends DoctrineCommand
             $description = '';
         }
 
-        $output->writeln(sprintf(
-            '<info>%s</info>%s',
+        $this->io->text(sprintf(
+            "<info>%s</info>%s\n",
             $version,
             $description !== '' ? ' - ' . $description : ''
         ));

--- a/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
@@ -37,10 +37,10 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $question = 'WARNING! You are about to execute a database migration that could result in schema changes and data loss. Are you sure you wish to continue? (y/n)';
+        $question = 'WARNING! You are about to execute a database migration that could result in schema changes and data loss. Are you sure you wish to continue?';
 
-        if (! $this->canExecute($question, $input, $output)) {
-            $output->writeln('<error>Migration cancelled!</error>');
+        if (! $this->canExecute($question, $input)) {
+            $this->io->error('Migration cancelled!');
 
             return 3;
         }
@@ -48,8 +48,8 @@ EOT
         $this->getDependencyFactory()->getMetadataStorage()->ensureInitialized();
         $version = $this->getDependencyFactory()->getRollup()->rollup();
 
-        $output->writeln(sprintf(
-            'Rolled up migrations to version <info>%s</info>',
+        $this->io->success(sprintf(
+            'Rolled up migrations to version %s',
             (string) $version
         ));
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/SyncMetadataCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/SyncMetadataCommand.php
@@ -33,7 +33,7 @@ EOT
     ) : int {
         $this->getDependencyFactory()->getMetadataStorage()->ensureInitialized();
 
-        $output->writeln('Metadata storage synchronized');
+        $this->io->success('Metadata storage synchronized');
 
         return 0;
     }

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -55,15 +55,15 @@ EOT
         $executedUnavailableMigrationsCount = count($executedUnavailableMigrations);
 
         if ($newMigrationsCount === 0 && $executedUnavailableMigrationsCount === 0) {
-            $output->writeln('<comment>Up-to-date! No migrations to execute.</comment>');
+            $this->io->success('Up-to-date! No migrations to execute.');
 
             return 0;
         }
 
         $exitCode = 0;
         if ($newMigrationsCount > 0) {
-            $output->writeln(sprintf(
-                '<error>Out-of-date! %u migration%s available to execute.</error>',
+            $this->io->error(sprintf(
+                'Out-of-date! %u migration%s available to execute.',
                 $newMigrationsCount,
                 $newMigrationsCount > 1 ? 's are' : ' is'
             ));
@@ -71,8 +71,8 @@ EOT
         }
 
         if ($executedUnavailableMigrationsCount > 0) {
-            $output->writeln(sprintf(
-                '<error>You have %1$u previously executed migration%3$s in the database that %2$s registered migration%3$s.</error>',
+            $this->io->error(sprintf(
+                'You have %1$u previously executed migration%3$s in the database that %2$s registered migration%3$s.',
                 $executedUnavailableMigrationsCount,
                 $executedUnavailableMigrationsCount > 1 ? 'are not' : 'is not a',
                 $executedUnavailableMigrationsCount > 1 ? 's' : ''
@@ -85,6 +85,8 @@ EOT
         if ($input->getOption('list-migrations')) {
             $versions = $this->getSortedVersions($newMigrations, $executedUnavailableMigrations);
             $this->getDependencyFactory()->getMigrationStatusInfosHelper()->listVersions($versions, $output);
+
+            $this->io->newLine();
         }
 
         return $exitCode;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -111,14 +111,14 @@ EOT
         $this->markMigrated = $input->getOption('add');
 
         if ($input->isInteractive()) {
-            $question = 'WARNING! You are about to add, delete or synchronize migration versions from the version table that could result in data lost. Are you sure you wish to continue? (y/n)';
+            $question = 'WARNING! You are about to add, delete or synchronize migration versions from the version table that could result in data lost. Are you sure you wish to continue?';
 
-            $confirmation = $this->askConfirmation($question, $input, $output);
+            $confirmation = $this->io->confirm($question);
 
             if ($confirmation) {
                 $this->markVersions($input, $output);
             } else {
-                $output->writeln('<error>Migration cancelled!</error>');
+                $this->io->error('Migration cancelled!');
             }
         } else {
             $this->markVersions($input, $output);
@@ -204,15 +204,15 @@ EOT
 
             $question =
                 'WARNING! You are about to delete a migration version from the version table that has no corresponding migration file.' .
-                'Do you want to delete this migration from the migrations table? (y/n)';
+                'Do you want to delete this migration from the migrations table?';
 
-            $confirmation = $this->askConfirmation($question, $input, $output);
+            $confirmation = $this->io->confirm($question);
 
             if ($confirmation) {
                 $migrationResult = new ExecutionResult($version, Direction::DOWN);
                 $storage->complete($migrationResult);
-                $output->writeln(sprintf(
-                    '<info>%s</info> deleted from the version table.',
+                $this->io->text(sprintf(
+                    "<info>%s</info> deleted from the version table.\n",
                     (string) $version
                 ));
 
@@ -246,16 +246,16 @@ EOT
             $migrationResult = new ExecutionResult($version, Direction::UP);
             $storage->complete($migrationResult);
 
-            $output->writeln(sprintf(
-                '<info>%s</info> added to the version table.',
+            $this->io->text(sprintf(
+                "<info>%s</info> added to the version table.\n",
                 (string) $version
             ));
         } else {
             $migrationResult = new ExecutionResult($version, Direction::DOWN);
             $storage->complete($migrationResult);
 
-            $output->writeln(sprintf(
-                '<info>%s</info> deleted from the version table.',
+            $this->io->text(sprintf(
+                "<info>%s</info> deleted from the version table.\n",
                 (string) $version
             ));
         }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
+use function array_map;
 use function explode;
 use function sys_get_temp_dir;
 use function trim;
@@ -84,7 +85,7 @@ final class DumpSchemaCommandTest extends TestCase
                 '',
                 'To use this as a rollup migration you can use the migrations:rollup command.',
             ],
-            explode("\n", trim($output))
+            array_map('trim', explode("\n", trim($output)))
         );
     }
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -21,8 +21,6 @@ use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\MigrationPlanCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Console\Helper\HelperSet;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 use function getcwd;
 use function sys_get_temp_dir;
@@ -47,9 +45,6 @@ class ExecuteCommandTest extends MigrationTestCase
 
     /** @var MigrationPlanCalculator|MockObject */
     private $planCalculator;
-
-    /** @var MockObject|QuestionHelper */
-    private $questions;
 
     /**
      * @param mixed $arg
@@ -93,9 +88,7 @@ class ExecuteCommandTest extends MigrationTestCase
 
     public function testExecute() : void
     {
-        $this->questions->expects(self::once())
-            ->method('ask')
-            ->willReturn(true);
+        $this->executeCommandTester->setInputs(['yes']);
 
         $this->migrator
             ->expects(self::once())
@@ -112,7 +105,7 @@ class ExecuteCommandTest extends MigrationTestCase
         ]);
 
         self::assertSame(0, $this->executeCommandTester->getStatusCode());
-        self::assertSame('[notice] Executing 1 up', trim($this->executeCommandTester->getDisplay(true)));
+        self::assertStringContainsString('[notice] Executing 1 up', trim($this->executeCommandTester->getDisplay(true)));
     }
 
     public function testExecuteMultiple() : void
@@ -127,9 +120,7 @@ class ExecuteCommandTest extends MigrationTestCase
             ->with([new Version('1'), new Version('2')])
             ->willReturn($pl);
 
-        $this->questions->expects(self::once())
-            ->method('ask')
-            ->willReturn(true);
+        $this->executeCommandTester->setInputs(['yes']);
 
         $this->migrator
             ->expects(self::once())
@@ -146,14 +137,12 @@ class ExecuteCommandTest extends MigrationTestCase
         ]);
 
         self::assertSame(0, $this->executeCommandTester->getStatusCode());
-        self::assertSame('[notice] Executing 1, 2 up', trim($this->executeCommandTester->getDisplay(true)));
+        self::assertStringContainsString('[notice] Executing 1, 2 up', trim($this->executeCommandTester->getDisplay(true)));
     }
 
     public function testExecuteCancel() : void
     {
-        $this->questions->expects(self::once())
-            ->method('ask')
-            ->willReturn(false);
+        $this->executeCommandTester->setInputs(['no']);
 
         $this->migrator
             ->expects(self::never())
@@ -200,9 +189,6 @@ class ExecuteCommandTest extends MigrationTestCase
         $this->dependencyFactory->setService(QueryWriter::class, $this->queryWriter);
 
         $this->executeCommand = new ExecuteCommand($this->dependencyFactory);
-
-        $this->questions = $this->createMock(QuestionHelper::class);
-        $this->executeCommand->setHelperSet(new HelperSet(['question' => $this->questions]));
 
         $this->executeCommandTester = new CommandTester($this->executeCommand);
     }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -12,6 +12,7 @@ use Doctrine\Migrations\Tools\Console\Command\GenerateCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
+use function array_map;
 use function explode;
 use function sys_get_temp_dir;
 use function trim;
@@ -49,7 +50,7 @@ final class GenerateCommandTest extends TestCase
             'To run just this migration for testing purposes, you can use migrations:execute --up \'FooNs\Version1234\'',
             '',
             'To revert the migration you can use migrations:execute --down \'FooNs\Version1234\'',
-        ], explode("\n", trim($output)));
+        ], array_map('trim', explode("\n", trim($output))));
     }
 
     protected function setUp() : void

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/SyncMetadataCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/SyncMetadataCommandTest.php
@@ -9,8 +9,7 @@ use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandTester;
 
 final class SyncMetadataCommandTest extends TestCase
 {
@@ -23,19 +22,19 @@ final class SyncMetadataCommandTest extends TestCase
     /** @var SyncMetadataCommand */
     private $storageCommand;
 
+    /** @var CommandTester */
+    private $storageCommandTester;
+
     public function testExecute() : void
     {
-        $input  = $this->createMock(InputInterface::class);
-        $output = $this->createMock(OutputInterface::class);
-
         $this->storage->expects(self::once())
             ->method('ensureInitialized');
 
-        $output->expects(self::once())
-            ->method('writeln')
-            ->with('Metadata storage synchronized');
+        $this->storageCommandTester->execute([]);
 
-        $this->storageCommand->execute($input, $output);
+        $output = $this->storageCommandTester->getDisplay(true);
+
+        self::assertStringContainsString('[OK] Metadata storage synchronized', $output);
     }
 
     protected function setUp() : void
@@ -49,5 +48,7 @@ final class SyncMetadataCommandTest extends TestCase
             ->willReturn($this->storage);
 
         $this->storageCommand = new SyncMetadataCommand($this->dependencyFactory);
+
+        $this->storageCommandTester = new CommandTester($this->storageCommand);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/UpToDateCommandTest.php
@@ -121,8 +121,10 @@ class UpToDateCommandTest extends MigrationTestCase
 
         self::assertSame(
             [
-                'Out-of-date! 1 migration is available to execute.',
-                'You have 1 previously executed migration in the database that is not a registered migration.',
+                '[ERROR] Out-of-date! 1 migration is available to execute.',
+                '',
+                '[ERROR] You have 1 previously executed migration in the database that is not a registered migration.',
+                '',
                 '+-----------+-------------------------+---------------------+----------------+-------------+',
                 '| Migration Versions                                                         |             |',
                 '+-----------+-------------------------+---------------------+----------------+-------------+',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

This adds a bit of style to console commands. Main visual differences are whitespaces, with occasional change in coloring.

I can add some example screenshots with before and after if needed.

Still needs tests.