### PR TITLE
Moved migration sorting from MigrationRepository to MigrationPlanCalculator

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -299,8 +299,7 @@ class DependencyFactory
                 $this->getConfiguration()->getMigrationClasses(),
                 $this->getConfiguration()->getMigrationDirectories(),
                 $this->getMigrationsFinder(),
-                $this->getMigrationFactory(),
-                $this->getVersionComparator()
+                $this->getMigrationFactory()
             );
         });
     }
@@ -362,7 +361,7 @@ class DependencyFactory
     {
         return $this->getDependency(AliasResolver::class, function () : AliasResolver {
             return new DefaultAliasResolver(
-                $this->getMigrationRepository(),
+                $this->getMigrationPlanCalculator(),
                 $this->getMetadataStorage(),
                 $this->getMigrationStatusCalculator()
             );
@@ -373,7 +372,7 @@ class DependencyFactory
     {
         return $this->getDependency(MigrationStatusCalculator::class, function () : MigrationStatusCalculator {
             return new CurrentMigrationStatusCalculator(
-                $this->getMigrationRepository(),
+                $this->getMigrationPlanCalculator(),
                 $this->getMetadataStorage()
             );
         });
@@ -384,7 +383,8 @@ class DependencyFactory
         return $this->getDependency(MigrationPlanCalculator::class, function () : MigrationPlanCalculator {
             return new SortedMigrationPlanCalculator(
                 $this->getMigrationRepository(),
-                $this->getMetadataStorage()
+                $this->getMetadataStorage(),
+                $this->getVersionComparator()
             );
         });
     }
@@ -422,7 +422,7 @@ class DependencyFactory
                 $this->getConfiguration(),
                 $this->getConnection(),
                 $this->getVersionAliasResolver(),
-                $this->getMigrationRepository(),
+                $this->getMigrationPlanCalculator(),
                 $this->getMigrationStatusCalculator(),
                 $this->getMetadataStorage()
             );

--- a/lib/Doctrine/Migrations/Metadata/AvailableMigration.php
+++ b/lib/Doctrine/Migrations/Metadata/AvailableMigration.php
@@ -7,6 +7,10 @@ namespace Doctrine\Migrations\Metadata;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Version\Version;
 
+/**
+ * Available migrations may or may not be already executed
+ * The migration might be already executed or not.
+ */
 final class AvailableMigration
 {
     /** @var Version */

--- a/lib/Doctrine/Migrations/Metadata/AvailableMigrationsList.php
+++ b/lib/Doctrine/Migrations/Metadata/AvailableMigrationsList.php
@@ -11,6 +11,9 @@ use Doctrine\Migrations\Version\Version;
 use function array_values;
 use function count;
 
+/**
+ * Represents a sorted list of migrations that may or maybe not be already executed.
+ */
 final class AvailableMigrationsList implements Countable
 {
     /** @var AvailableMigration[] */

--- a/lib/Doctrine/Migrations/Metadata/AvailableMigrationsSet.php
+++ b/lib/Doctrine/Migrations/Metadata/AvailableMigrationsSet.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Metadata;
+
+use Countable;
+use Doctrine\Migrations\Exception\MigrationNotAvailable;
+use Doctrine\Migrations\Version\Version;
+use function array_values;
+use function count;
+
+final class AvailableMigrationsSet implements Countable
+{
+    /** @var AvailableMigration[] */
+    private $items = [];
+
+    /**
+     * @param AvailableMigration[] $items
+     */
+    public function __construct(array $items)
+    {
+        $this->items = array_values($items);
+    }
+
+    /**
+     * @return AvailableMigration[]
+     */
+    public function getItems() : array
+    {
+        return $this->items;
+    }
+
+    public function count() : int
+    {
+        return count($this->items);
+    }
+
+    public function hasMigration(Version $version) : bool
+    {
+        foreach ($this->items as $migration) {
+            if ($migration->getVersion()->equals($version)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getMigration(Version $version) : AvailableMigration
+    {
+        foreach ($this->items as $migration) {
+            if ($migration->getVersion()->equals($version)) {
+                return $migration;
+            }
+        }
+
+        throw MigrationNotAvailable::forVersion($version);
+    }
+}

--- a/lib/Doctrine/Migrations/Metadata/AvailableMigrationsSet.php
+++ b/lib/Doctrine/Migrations/Metadata/AvailableMigrationsSet.php
@@ -10,6 +10,9 @@ use Doctrine\Migrations\Version\Version;
 use function array_values;
 use function count;
 
+/**
+ * Represents a non sorted list of migrations that may or may not be already executed.
+ */
 final class AvailableMigrationsSet implements Countable
 {
     /** @var AvailableMigration[] */

--- a/lib/Doctrine/Migrations/Metadata/ExecutedMigration.php
+++ b/lib/Doctrine/Migrations/Metadata/ExecutedMigration.php
@@ -7,6 +7,10 @@ namespace Doctrine\Migrations\Metadata;
 use DateTimeImmutable;
 use Doctrine\Migrations\Version\Version;
 
+/**
+ * Represents an already executed migration.
+ * The migration might be not available anymore.
+ */
 final class ExecutedMigration
 {
     /** @var Version */

--- a/lib/Doctrine/Migrations/Metadata/ExecutedMigrationsList.php
+++ b/lib/Doctrine/Migrations/Metadata/ExecutedMigrationsList.php
@@ -11,6 +11,10 @@ use Doctrine\Migrations\Version\Version;
 use function array_values;
 use function count;
 
+/**
+ * Represents a sorted list of executed migrations.
+ * The migrations in this set might be not available anymore.
+ */
 final class ExecutedMigrationsList implements Countable
 {
     /** @var ExecutedMigration[] */

--- a/lib/Doctrine/Migrations/Metadata/MigrationPlan.php
+++ b/lib/Doctrine/Migrations/Metadata/MigrationPlan.php
@@ -9,6 +9,9 @@ use Doctrine\Migrations\Exception\PlanAlreadyExecuted;
 use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 
+/**
+ * Represents an available migration to be executed in a specific direction.
+ */
 final class MigrationPlan
 {
     /** @var string */
@@ -17,7 +20,6 @@ final class MigrationPlan
     private $version;
     /** @var AbstractMigration */
     private $migration;
-
     /** @var ExecutionResult */
     public $result;
 

--- a/lib/Doctrine/Migrations/Metadata/MigrationPlanList.php
+++ b/lib/Doctrine/Migrations/Metadata/MigrationPlanList.php
@@ -10,6 +10,9 @@ use function count;
 use function end;
 use function reset;
 
+/**
+ * Represents a sorted list of MigrationPlan instances to execute.
+ */
 final class MigrationPlanList implements Countable
 {
     /** @var string */

--- a/lib/Doctrine/Migrations/MigrationsRepository.php
+++ b/lib/Doctrine/Migrations/MigrationsRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations;
 
 use Doctrine\Migrations\Metadata\AvailableMigration;
-use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
 use Doctrine\Migrations\Version\Version;
 
 interface MigrationsRepository
@@ -14,5 +14,5 @@ interface MigrationsRepository
 
     public function getMigration(Version $version) : AvailableMigration;
 
-    public function getMigrations() : AvailableMigrationsList;
+    public function getMigrations() : AvailableMigrationsSet;
 }

--- a/lib/Doctrine/Migrations/Rollup.php
+++ b/lib/Doctrine/Migrations/Rollup.php
@@ -49,7 +49,7 @@ class Rollup
 
         $this->metadataStorage->reset();
 
-        $result = new ExecutionResult($versions->getFirst()->getVersion());
+        $result = new ExecutionResult($versions->getItems()[0]->getVersion());
         $this->metadataStorage->complete($result);
 
         return $result->getVersion();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
@@ -42,7 +42,7 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
         $versions = $this->getSortedVersions(
-            $this->getDependencyFactory()->getMigrationRepository()->getMigrations(), // available migrations
+            $this->getDependencyFactory()->getMigrationPlanCalculator()->getMigrations(), // available migrations
             $this->getDependencyFactory()->getMetadataStorage()->getExecutedMigrations() // executed migrations
         );
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -150,7 +150,7 @@ EOT
         }
 
         $executedMigrations = $this->getDependencyFactory()->getMetadataStorage()->getExecutedMigrations();
-        $availableVersions  = $this->getDependencyFactory()->getMigrationRepository()->getMigrations();
+        $availableVersions  = $this->getDependencyFactory()->getMigrationPlanCalculator()->getMigrations();
         if ($allOption === true) {
             if ($input->getOption('delete') === true) {
                 foreach ($executedMigrations->getItems() as $availableMigration) {

--- a/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
@@ -10,8 +10,8 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
-use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\AliasResolver;
+use Doctrine\Migrations\Version\MigrationPlanCalculator;
 use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Console\Helper\Table;
@@ -46,8 +46,8 @@ class MigrationStatusInfosHelper
     /** @var MetadataStorage */
     private $metadataStorage;
 
-    /** @var MigrationsRepository */
-    private $migrationRepository;
+    /** @var MigrationPlanCalculator */
+    private $migrationPlanCalculator;
 
     /** @var MigrationStatusCalculator */
     private $statusCalculator;
@@ -56,16 +56,16 @@ class MigrationStatusInfosHelper
         Configuration $configuration,
         Connection $connection,
         AliasResolver $aliasResolver,
-        MigrationsRepository $migrationRepository,
+        MigrationPlanCalculator $migrationPlanCalculator,
         MigrationStatusCalculator $statusCalculator,
         MetadataStorage $metadataStorage
     ) {
-        $this->configuration       = $configuration;
-        $this->connection          = $connection;
-        $this->aliasResolver       = $aliasResolver;
-        $this->migrationRepository = $migrationRepository;
-        $this->metadataStorage     = $metadataStorage;
-        $this->statusCalculator    = $statusCalculator;
+        $this->configuration           = $configuration;
+        $this->connection              = $connection;
+        $this->aliasResolver           = $aliasResolver;
+        $this->migrationPlanCalculator = $migrationPlanCalculator;
+        $this->metadataStorage         = $metadataStorage;
+        $this->statusCalculator        = $statusCalculator;
     }
 
     /**
@@ -81,7 +81,7 @@ class MigrationStatusInfosHelper
             ]
         );
         $executedMigrations  = $this->metadataStorage->getExecutedMigrations();
-        $availableMigrations = $this->migrationRepository->getMigrations();
+        $availableMigrations = $this->migrationPlanCalculator->getMigrations();
 
         foreach ($versions as $version) {
             $description   = null;
@@ -123,7 +123,7 @@ class MigrationStatusInfosHelper
     public function showMigrationsInfo(OutputInterface $output) : void
     {
         $executedMigrations  = $this->metadataStorage->getExecutedMigrations();
-        $availableMigrations = $this->migrationRepository->getMigrations();
+        $availableMigrations = $this->migrationPlanCalculator->getMigrations();
 
         $newMigrations                 = $this->statusCalculator->getNewMigrations();
         $executedUnavailableMigrations = $this->statusCalculator->getExecutedUnavailableMigrations();

--- a/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
@@ -9,7 +9,6 @@ use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-use Doctrine\Migrations\MigrationsRepository;
 use function array_filter;
 
 /**
@@ -18,22 +17,24 @@ use function array_filter;
  */
 final class CurrentMigrationStatusCalculator implements MigrationStatusCalculator
 {
-    /** @var MigrationsRepository */
-    private $migrationRepository;
+    /** @var MigrationPlanCalculator */
+    private $migrationPlanCalculator;
 
     /** @var MetadataStorage */
     private $metadataStorage;
 
-    public function __construct(MigrationsRepository $migrationRepository, MetadataStorage $metadataStorage)
-    {
-        $this->migrationRepository = $migrationRepository;
-        $this->metadataStorage     = $metadataStorage;
+    public function __construct(
+        MigrationPlanCalculator $migrationPlanCalculator,
+        MetadataStorage $metadataStorage
+    ) {
+        $this->migrationPlanCalculator = $migrationPlanCalculator;
+        $this->metadataStorage         = $metadataStorage;
     }
 
     public function getExecutedUnavailableMigrations() : ExecutedMigrationsList
     {
         $executedMigrations = $this->metadataStorage->getExecutedMigrations();
-        $availableMigration = $this->migrationRepository->getMigrations();
+        $availableMigration = $this->migrationPlanCalculator->getMigrations();
 
         return new ExecutedMigrationsList(array_filter($executedMigrations->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigration) : bool {
             return ! $availableMigration->hasMigration($migrationInfo->getVersion());
@@ -43,7 +44,7 @@ final class CurrentMigrationStatusCalculator implements MigrationStatusCalculato
     public function getNewMigrations() : AvailableMigrationsList
     {
         $executedMigrations = $this->metadataStorage->getExecutedMigrations();
-        $availableMigration = $this->migrationRepository->getMigrations();
+        $availableMigration = $this->migrationPlanCalculator->getMigrations();
 
         return new AvailableMigrationsList(array_filter($availableMigration->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrations) : bool {
             return ! $executedMigrations->hasMigration($migrationInfo->getVersion());

--- a/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
+++ b/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
@@ -8,7 +8,6 @@ use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Exception\NoMigrationsToExecute;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-use Doctrine\Migrations\MigrationsRepository;
 use function substr;
 
 /**
@@ -24,8 +23,8 @@ final class DefaultAliasResolver implements AliasResolver
     private const ALIAS_NEXT    = 'next';
     private const ALIAS_LATEST  = 'latest';
 
-    /** @var MigrationsRepository */
-    private $migrationRepository;
+    /** @var MigrationPlanCalculator */
+    private $migrationPlanCalculator;
 
     /** @var MetadataStorage */
     private $metadataStorage;
@@ -34,11 +33,11 @@ final class DefaultAliasResolver implements AliasResolver
     private $migrationStatusCalculator;
 
     public function __construct(
-        MigrationsRepository $migrationRepository,
+        MigrationPlanCalculator $migrationPlanCalculator,
         MetadataStorage $metadataStorage,
         MigrationStatusCalculator $migrationStatusCalculator
     ) {
-        $this->migrationRepository       = $migrationRepository;
+        $this->migrationPlanCalculator   = $migrationPlanCalculator;
         $this->metadataStorage           = $metadataStorage;
         $this->migrationStatusCalculator = $migrationStatusCalculator;
     }
@@ -58,7 +57,7 @@ final class DefaultAliasResolver implements AliasResolver
      */
     public function resolveVersionAlias(string $alias) : Version
     {
-        $availableMigrations = $this->migrationRepository->getMigrations();
+        $availableMigrations = $this->migrationPlanCalculator->getMigrations();
         $executedMigrations  = $this->metadataStorage->getExecutedMigrations();
 
         switch ($alias) {

--- a/lib/Doctrine/Migrations/Version/MigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/Version/MigrationPlanCalculator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Version;
 
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
 
 /**
@@ -18,4 +19,9 @@ interface MigrationPlanCalculator
     public function getPlanForVersions(array $versions, string $direction) : MigrationPlanList;
 
     public function getPlanUntilVersion(Version $to) : MigrationPlanList;
+
+    /**
+     * Returns a sorted list of migrations.
+     */
+    public function getMigrations() : AvailableMigrationsList;
 }

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -57,8 +57,7 @@ class ExistingTableMetadataStorageTest extends TestCase
             [],
             [],
             new RecursiveRegexFinder('#.*\\.php$#i'),
-            $versionFactory,
-            new AlphabeticalComparator()
+            $versionFactory
         );
         Helper::registerMigrationInstance($this->migrationRepository, new Version('Foo\\5678'), $migration);
 

--- a/tests/Doctrine/Migrations/Tests/RollupTest.php
+++ b/tests/Doctrine/Migrations/Tests/RollupTest.php
@@ -8,7 +8,7 @@ use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Exception\RollupFailed;
 use Doctrine\Migrations\FilesystemMigrationsRepository;
 use Doctrine\Migrations\Metadata\AvailableMigration;
-use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Rollup;
@@ -47,7 +47,7 @@ class RollupTest extends TestCase
         $this->repository
            ->expects(self::once())
            ->method('getMigrations')
-           ->willReturn(new AvailableMigrationsList([$m1]));
+           ->willReturn(new AvailableMigrationsSet([$m1]));
 
         $this->storage
            ->expects(self::at(0))->method('reset')->with();
@@ -69,7 +69,7 @@ class RollupTest extends TestCase
         $this->repository
             ->expects(self::once())
             ->method('getMigrations')
-            ->willReturn(new AvailableMigrationsList([$m1, $m2]));
+            ->willReturn(new AvailableMigrationsSet([$m1, $m2]));
 
         $this->storage->expects(self::never())->method('reset');
         $this->storage->expects(self::never())->method('complete');
@@ -84,7 +84,7 @@ class RollupTest extends TestCase
         $this->repository
             ->expects(self::any())
             ->method('getMigrations')
-            ->willReturn(new AvailableMigrationsList([]));
+            ->willReturn(new AvailableMigrationsSet([]));
 
         $this->storage->expects(self::never())->method('reset');
         $this->storage->expects(self::never())->method('complete');

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\FilesystemMigrationsRepository;
 use Doctrine\Migrations\Generator\ClassNameGenerator;
 use Doctrine\Migrations\Metadata\AvailableMigration;
-use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
 use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\SchemaDumper;
 use Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand;
@@ -53,7 +53,7 @@ final class DumpSchemaCommandTest extends TestCase
 
         $this->migrationRepository->expects(self::once())
             ->method('getMigrations')
-            ->willReturn(new AvailableMigrationsList([$migration]));
+            ->willReturn(new AvailableMigrationsSet([$migration]));
 
         $this->dumpSchemaCommandTester->execute([]);
     }
@@ -62,7 +62,7 @@ final class DumpSchemaCommandTest extends TestCase
     {
         $this->migrationRepository->expects(self::once())
             ->method('getMigrations')
-            ->willReturn(new AvailableMigrationsList([]));
+            ->willReturn(new AvailableMigrationsSet([]));
 
         $this->schemaDumper->expects(self::once())
             ->method('dump')

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -37,7 +37,6 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 use function getcwd;
 use function strpos;
-use function sys_get_temp_dir;
 use function trim;
 
 class MigrateCommandTest extends MigrationTestCase
@@ -357,8 +356,6 @@ class MigrateCommandTest extends MigrationTestCase
         $this->configuration = new Configuration();
         $this->configuration->setMetadataStorageConfiguration($this->metadataConfiguration);
 
-        $this->configuration->addMigrationsDirectory('FooNs', sys_get_temp_dir());
-
         $this->connection = $this->getSqliteConnection();
 
         $this->dependencyFactory = DependencyFactory::fromConnection(new ExistingConfiguration($this->configuration), new ExistingConnection($this->connection));
@@ -368,7 +365,7 @@ class MigrateCommandTest extends MigrationTestCase
 
         $finder                    = $this->createMock(Finder::class);
         $factory                   = $this->createMock(MigrationFactory::class);
-        $this->migrationRepository = new FilesystemMigrationsRepository([], [], $finder, $factory, new AlphabeticalComparator());
+        $this->migrationRepository = new FilesystemMigrationsRepository([], [], $finder, $factory);
 
         $migration = $this->createMock(AbstractMigration::class);
         Helper::registerMigrationInstance($this->migrationRepository, new Version('A'), $migration);

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Version;
 
 use Doctrine\Migrations\AbstractMigration;
-use Doctrine\Migrations\FilesystemMigrationsRepository;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
+use Doctrine\Migrations\Version\MigrationPlanCalculator;
 use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,8 +22,8 @@ final class MigrationStatusCalculatorTest extends TestCase
     /** @var MigrationStatusCalculator */
     private $migrationStatusCalculator;
 
-    /** @var MockObject|MigrationsRepository */
-    private $migrationRepository;
+    /** @var MockObject|MigrationPlanCalculator */
+    private $migrationPlanCalculator;
 
     /** @var MockObject|MetadataStorage */
     private $metadataStorage;
@@ -34,11 +33,11 @@ final class MigrationStatusCalculatorTest extends TestCase
 
     protected function setUp() : void
     {
-        $this->abstractMigration = $this->createMock(AbstractMigration::class);
+        $this->abstractMigration       = $this->createMock(AbstractMigration::class);
+        $this->metadataStorage         = $this->createMock(MetadataStorage::class);
+        $this->migrationPlanCalculator = $this->createMock(MigrationPlanCalculator::class);
 
-        $this->migrationRepository       = $this->createMock(FilesystemMigrationsRepository::class);
-        $this->metadataStorage           = $this->createMock(MetadataStorage::class);
-        $this->migrationStatusCalculator = new CurrentMigrationStatusCalculator($this->migrationRepository, $this->metadataStorage);
+        $this->migrationStatusCalculator = new CurrentMigrationStatusCalculator($this->migrationPlanCalculator, $this->metadataStorage);
     }
 
     public function testGetNewMigrations() : void
@@ -49,7 +48,7 @@ final class MigrationStatusCalculatorTest extends TestCase
 
         $e1 = new ExecutedMigration(new Version('A'));
 
-        $this->migrationRepository
+        $this->migrationPlanCalculator
             ->expects(self::any())
             ->method('getMigrations')
             ->willReturn(new AvailableMigrationsList([$m1, $m2, $m3]));
@@ -72,7 +71,7 @@ final class MigrationStatusCalculatorTest extends TestCase
         $e2 = new ExecutedMigration(new Version('B'));
         $e3 = new ExecutedMigration(new Version('C'));
 
-        $this->migrationRepository
+        $this->migrationPlanCalculator
             ->expects(self::any())
             ->method('getMigrations')
             ->willReturn(new AvailableMigrationsList([$a1]));


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | - 
| Fixed issues | -

This change will allow to define sorting by looking into the available migrations array. Before this change was not possible as the same object responsible for sorting migrations, was responsible also for locating migrations (this the circular dependency..).
