### PR TITLE
Sort executed migrations

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -320,6 +320,7 @@ class DependencyFactory
         return $this->getDependency(MetadataStorage::class, function () : MetadataStorage {
             return new TableMetadataStorage(
                 $this->getConnection(),
+                $this->getVersionComparator(),
                 $this->getConfiguration()->getMetadataStorageConfiguration(),
                 $this->getMigrationRepository()
             );

--- a/lib/Doctrine/Migrations/Metadata/ExecutedMigrationsList.php
+++ b/lib/Doctrine/Migrations/Metadata/ExecutedMigrationsList.php
@@ -11,7 +11,7 @@ use Doctrine\Migrations\Version\Version;
 use function array_values;
 use function count;
 
-final class ExecutedMigrationsSet implements Countable
+final class ExecutedMigrationsList implements Countable
 {
     /** @var ExecutedMigration[] */
     private $items = [];

--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Metadata\Storage;
 
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Version\ExecutionResult;
 
 interface MetadataStorage
 {
     public function ensureInitialized() : void;
 
-    public function getExecutedMigrations() : ExecutedMigrationsSet;
+    public function getExecutedMigrations() : ExecutedMigrationsList;
 
     public function complete(ExecutionResult $migration) : void;
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -6,7 +6,7 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 
 use Doctrine\Migrations\Generator\Exception\NoChangesDetected;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use Doctrine\SqlFormatter\SqlFormatter;
 use OutOfBoundsException;
@@ -178,7 +178,7 @@ EOT
 
     private function checkNewMigrationsOrExecutedUnavailable(
         AvailableMigrationsList $newMigrations,
-        ExecutedMigrationsSet $executedUnavailableMigrations,
+        ExecutedMigrationsList $executedUnavailableMigrations,
         InputInterface $input,
         OutputInterface $output
     ) : bool {

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
@@ -7,7 +7,7 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -54,7 +54,7 @@ EOT
     /**
      * @return Version[]
      */
-    private function getSortedVersions(AvailableMigrationsList $availableMigrations, ExecutedMigrationsSet $executedMigrations) : array
+    private function getSortedVersions(AvailableMigrationsList $availableMigrations, ExecutedMigrationsList $executedMigrations) : array
     {
         $availableVersions = array_map(static function (AvailableMigration $availableMigration) : Version {
             return $availableMigration->getVersion();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -6,7 +6,7 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -196,7 +196,7 @@ EOT
     }
 
     private function checkExecutedUnavailableMigrations(
-        ExecutedMigrationsSet $executedUnavailableMigrations,
+        ExecutedMigrationsList $executedUnavailableMigrations,
         InputInterface $input
     ) : bool {
         if (count($executedUnavailableMigrations) !== 0) {

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -7,7 +7,7 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -95,7 +95,7 @@ EOT
     /**
      * @return Version[]
      */
-    private function getSortedVersions(AvailableMigrationsList $newMigrations, ExecutedMigrationsSet $executedUnavailableMigrations) : array
+    private function getSortedVersions(AvailableMigrationsList $newMigrations, ExecutedMigrationsList $executedUnavailableMigrations) : array
     {
         $executedUnavailableVersion = array_map(static function (ExecutedMigration $executedMigration) : Version {
             return $executedMigration->getVersion();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -6,7 +6,7 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use Doctrine\Migrations\Tools\Console\Exception\VersionAlreadyExists;
 use Doctrine\Migrations\Tools\Console\Exception\VersionDoesNotExist;
@@ -188,7 +188,7 @@ EOT
      * @throws VersionDoesNotExist
      * @throws UnknownMigrationVersion
      */
-    private function mark(InputInterface $input, OutputInterface $output, Version $version, bool $all, ExecutedMigrationsSet $executedMigrations) : void
+    private function mark(InputInterface $input, OutputInterface $output, Version $version, bool $all, ExecutedMigrationsList $executedMigrations) : void
     {
         try {
             $availableMigration = $this->getDependencyFactory()->getMigrationRepository()->getMigration($version);

--- a/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
@@ -8,7 +8,7 @@ use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\MigrationsRepository;
@@ -118,9 +118,9 @@ class MigrationStatusInfosHelper
     public function showMigrationsInfo(
         OutputInterface $output,
         AvailableMigrationsList $availableMigrations,
-        ExecutedMigrationsSet $executedMigrations,
+        ExecutedMigrationsList $executedMigrations,
         AvailableMigrationsList $newMigrations,
-        ExecutedMigrationsSet $executedUnavailableMigrations
+        ExecutedMigrationsList $executedUnavailableMigrations
     ) : void {
         $storage = $this->configuration->getMetadataStorageConfiguration();
 
@@ -191,7 +191,7 @@ class MigrationStatusInfosHelper
         $table->render();
     }
 
-    private function getFormattedVersionAlias(string $alias, ExecutedMigrationsSet $executedMigrationsSet) : string
+    private function getFormattedVersionAlias(string $alias, ExecutedMigrationsList $executedMigrations) : string
     {
         try {
             $version = $this->aliasResolver->resolveVersionAlias($alias);
@@ -210,7 +210,7 @@ class MigrationStatusInfosHelper
             }
         }
 
-        if ($alias === 'latest' && $version!== null && $executedMigrationsSet->hasMigration($version)) {
+        if ($alias === 'latest' && $version!== null && $executedMigrations->hasMigration($version)) {
             return 'Already at latest version';
         }
 

--- a/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
@@ -7,7 +7,7 @@ namespace Doctrine\Migrations\Version;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationsRepository;
 use function array_filter;
@@ -30,23 +30,23 @@ final class CurrentMigrationStatusCalculator implements MigrationStatusCalculato
         $this->metadataStorage     = $metadataStorage;
     }
 
-    public function getExecutedUnavailableMigrations() : ExecutedMigrationsSet
+    public function getExecutedUnavailableMigrations() : ExecutedMigrationsList
     {
-        $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
-        $availableMigrationsSet = $this->migrationRepository->getMigrations();
+        $executedMigrations = $this->metadataStorage->getExecutedMigrations();
+        $availableMigration = $this->migrationRepository->getMigrations();
 
-        return new ExecutedMigrationsSet(array_filter($executedMigrationsSet->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigrationsSet) : bool {
-            return ! $availableMigrationsSet->hasMigration($migrationInfo->getVersion());
+        return new ExecutedMigrationsList(array_filter($executedMigrations->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigration) : bool {
+            return ! $availableMigration->hasMigration($migrationInfo->getVersion());
         }));
     }
 
     public function getNewMigrations() : AvailableMigrationsList
     {
-        $executedMigrationsSet  = $this->metadataStorage->getExecutedMigrations();
-        $availableMigrationsSet = $this->migrationRepository->getMigrations();
+        $executedMigrations = $this->metadataStorage->getExecutedMigrations();
+        $availableMigration = $this->migrationRepository->getMigrations();
 
-        return new AvailableMigrationsList(array_filter($availableMigrationsSet->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrationsSet) : bool {
-            return ! $executedMigrationsSet->hasMigration($migrationInfo->getVersion());
+        return new AvailableMigrationsList(array_filter($availableMigration->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrations) : bool {
+            return ! $executedMigrations->hasMigration($migrationInfo->getVersion());
         }));
     }
 }

--- a/lib/Doctrine/Migrations/Version/MigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/MigrationStatusCalculator.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Version;
 
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 
 /**
  * The MigrationStatusCalculator is responsible for calculating the current status of
@@ -13,7 +13,7 @@ use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
  */
 interface MigrationStatusCalculator
 {
-    public function getExecutedUnavailableMigrations() : ExecutedMigrationsSet;
+    public function getExecutedUnavailableMigrations() : ExecutedMigrationsList;
 
     public function getNewMigrations() : AvailableMigrationsList;
 }

--- a/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
@@ -86,7 +86,7 @@ final class SortedMigrationPlanCalculator implements MigrationPlanCalculator
         }, $toExecute), $direction);
     }
 
-    private function findDirection(Version $to, Metadata\ExecutedMigrationsSet $executedMigrations) : string
+    private function findDirection(Version $to, Metadata\ExecutedMigrationsList $executedMigrations) : string
     {
         if ((string) $to === '0' || ($executedMigrations->hasMigration($to) && ! $executedMigrations->getLast()->getVersion()->equals($to))) {
             return Direction::DOWN;
@@ -108,7 +108,7 @@ final class SortedMigrationPlanCalculator implements MigrationPlanCalculator
      *
      * @return AvailableMigration[]
      */
-    private function findMigrationsToExecute(Version $to, array $migrationsToCheck, string $direction, Metadata\ExecutedMigrationsSet $executedMigrations) : array
+    private function findMigrationsToExecute(Version $to, array $migrationsToCheck, string $direction, Metadata\ExecutedMigrationsList $executedMigrations) : array
     {
         $toExecute = [];
         foreach ($migrationsToCheck as $availableMigration) {

--- a/tests/Doctrine/Migrations/Tests/Metadata/ExecutedMigrationSetTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/ExecutedMigrationSetTest.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use Doctrine\Migrations\Exception\MigrationNotExecuted;
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +18,7 @@ class ExecutedMigrationSetTest extends TestCase
     {
         $this->expectException(NoMigrationsFoundWithCriteria::class);
         $this->expectExceptionMessage('Could not find any migrations matching your criteria (first).');
-        $set = new ExecutedMigrationsSet([]);
+        $set = new ExecutedMigrationsList([]);
         $set->getFirst();
     }
 
@@ -26,7 +26,7 @@ class ExecutedMigrationSetTest extends TestCase
     {
         $this->expectException(NoMigrationsFoundWithCriteria::class);
         $this->expectExceptionMessage('Could not find any migrations matching your criteria (last).');
-        $set = new ExecutedMigrationsSet([]);
+        $set = new ExecutedMigrationsList([]);
         $set->getLast();
     }
 
@@ -36,7 +36,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         self::assertSame($m1, $set->getFirst());
         self::assertSame($m2, $set->getFirst(1));
     }
@@ -47,7 +47,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         self::assertSame($m3, $set->getLast());
         self::assertSame($m2, $set->getLast(-1));
     }
@@ -58,7 +58,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         self::assertSame([$m1, $m2, $m3], $set->getItems());
     }
 
@@ -68,7 +68,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         self::assertCount(3, $set);
     }
 
@@ -78,7 +78,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         self::assertSame($m2, $set->getMigration(new Version('B')));
     }
 
@@ -89,7 +89,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         $set->getMigration(new Version('D'));
     }
 
@@ -99,7 +99,7 @@ class ExecutedMigrationSetTest extends TestCase
         $m2 = new ExecutedMigration(new Version('B'));
         $m3 = new ExecutedMigration(new Version('C'));
 
-        $set = new ExecutedMigrationsSet([$m1, $m2, $m3]);
+        $set = new ExecutedMigrationsList([$m1, $m2, $m3]);
         self::assertTrue($set->hasMigration(new Version('B')));
         self::assertFalse($set->hasMigration(new Version('D')));
     }

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -64,7 +64,12 @@ class ExistingTableMetadataStorageTest extends TestCase
 
         $this->config = new TableMetadataStorageConfiguration();
 
-        $this->storage = new TableMetadataStorage($this->connection, $this->config, $this->migrationRepository);
+        $this->storage = new TableMetadataStorage(
+            $this->connection,
+            new AlphabeticalComparator(),
+            $this->config,
+            $this->migrationRepository
+        );
 
         // create partial table
         $table = new Table($this->config->getTableName());
@@ -91,7 +96,7 @@ class ExistingTableMetadataStorageTest extends TestCase
             ->method('getDatabasePlatform')
             ->willReturn($this->connection->getDatabasePlatform());
 
-        $storage = new TableMetadataStorage($connection, $this->config);
+        $storage = new TableMetadataStorage($connection, new AlphabeticalComparator(), $this->config);
         $storage->ensureInitialized();
     }
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -12,7 +12,7 @@ use Doctrine\Migrations\Generator\DiffGenerator;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use Doctrine\Migrations\Version\MigrationStatusCalculator;
 use Doctrine\Migrations\Version\Version;
@@ -55,7 +55,7 @@ final class DiffCommandTest extends TestCase
 
         $this->migrationStatusCalculator
             ->method('getExecutedUnavailableMigrations')
-            ->willReturn(new ExecutedMigrationsSet([]));
+            ->willReturn(new ExecutedMigrationsList([]));
 
         $this->classNameGenerator->expects(self::once())
             ->method('generateClassName')
@@ -97,7 +97,7 @@ final class DiffCommandTest extends TestCase
 
         $this->migrationStatusCalculator
             ->method('getExecutedUnavailableMigrations')
-            ->willReturn(new ExecutedMigrationsSet([]));
+            ->willReturn(new ExecutedMigrationsList([]));
 
         $this->diffCommandTester->setInputs(['no']);
 
@@ -124,7 +124,7 @@ final class DiffCommandTest extends TestCase
 
         $this->migrationStatusCalculator
             ->method('getExecutedUnavailableMigrations')
-            ->willReturn(new ExecutedMigrationsSet([$e1]));
+            ->willReturn(new ExecutedMigrationsList([$e1]));
 
         $this->diffCommandTester->setInputs(['no']);
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -382,7 +382,12 @@ class MigrateCommandTest extends MigrationTestCase
 
         $this->migrateCommandTester = new CommandTester($this->migrateCommand);
 
-        $this->storage = new TableMetadataStorage($this->connection, $this->metadataConfiguration, $this->migrationRepository);
+        $this->storage = new TableMetadataStorage(
+            $this->connection,
+            new AlphabeticalComparator(),
+            $this->metadataConfiguration,
+            $this->migrationRepository
+        );
         $this->storage->ensureInitialized();
 
         $this->dependencyFactory->setService(MetadataStorage::class, $this->storage);

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -148,7 +148,8 @@ final class AliasResolverTest extends TestCase
             $versionFactory,
             new AlphabeticalComparator()
         );
-        $this->metadataStorage     = new TableMetadataStorage($conn);
+
+        $this->metadataStorage = new TableMetadataStorage($conn, new AlphabeticalComparator());
         $this->metadataStorage->ensureInitialized();
 
         $this->statusCalculator     = new CurrentMigrationStatusCalculator($this->migrationRepository, $this->metadataStorage);

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationPlanCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationPlanCalculatorTest.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\FilesystemMigrationsRepository;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\Direction;
@@ -123,7 +123,7 @@ final class MigrationPlanCalculatorTest extends TestCase
         $this->metadataStorage
             ->expects(self::atLeastOnce())
             ->method('getExecutedMigrations')
-            ->willReturn(new ExecutedMigrationsSet([]));
+            ->willReturn(new ExecutedMigrationsList([]));
 
         $plan = $this->migrationPlanCalculator->getPlanUntilVersion(new Version($to));
 
@@ -161,7 +161,7 @@ final class MigrationPlanCalculatorTest extends TestCase
         $this->metadataStorage
             ->expects(self::atLeastOnce())
             ->method('getExecutedMigrations')
-            ->willReturn(new ExecutedMigrationsSet([$e1, $e2]));
+            ->willReturn(new ExecutedMigrationsList([$e1, $e2]));
 
         $plan = $this->migrationPlanCalculator->getPlanUntilVersion(new Version($to));
 

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
@@ -9,7 +9,7 @@ use Doctrine\Migrations\FilesystemMigrationsRepository;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
-use Doctrine\Migrations\Metadata\ExecutedMigrationsSet;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
@@ -57,7 +57,7 @@ final class MigrationStatusCalculatorTest extends TestCase
         $this->metadataStorage
             ->expects(self::atLeastOnce())
             ->method('getExecutedMigrations')
-            ->willReturn(new ExecutedMigrationsSet([$e1]));
+            ->willReturn(new ExecutedMigrationsList([$e1]));
 
         $newSet = $this->migrationStatusCalculator->getNewMigrations();
 
@@ -80,7 +80,7 @@ final class MigrationStatusCalculatorTest extends TestCase
         $this->metadataStorage
             ->expects(self::atLeastOnce())
             ->method('getExecutedMigrations')
-            ->willReturn(new ExecutedMigrationsSet([$e1, $e2, $e3]));
+            ->willReturn(new ExecutedMigrationsList([$e1, $e2, $e3]));
 
         $newSet = $this->migrationStatusCalculator->getExecutedUnavailableMigrations();
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | -
| Fixed issues | -

#### Summary
In the current master executed migrations are not sorted in any way and the returned order depends on the RDBMS.

This pull requests sorts the executed migrations with the same logic as available migrations by using their dependencies.

I think that this is the sorting mode with less side effects, but for completeness, other possibilities are:

- sort by executed_at: this will tell us the time based execution order, but might have issues with databases that do not support microseconds
- sort by some autoincrement, beside database compatibility it requires a new column to be added
