### PR TITLE
Display more informative messages for migration aliases

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Helper/MigrationStatusInfosHelper.php
@@ -216,10 +216,6 @@ class MigrationStatusInfosHelper
             }
         }
 
-        if ($alias === 'latest' && $version!== null && $executedMigrations->hasMigration($version)) {
-            return 'Already at latest version';
-        }
-
         // Before first version "virtual" version number
         if ((string) $version === '0') {
             return '<comment>0</comment>';

--- a/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
+++ b/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
@@ -54,6 +54,10 @@ final class DefaultAliasResolver implements AliasResolver
      * - latest: The latest available version.
      *
      * If an existing version number is specified, it is returned verbatimly.
+     *
+     * @throws NoMigrationsToExecute
+     * @throws UnknownMigrationVersion
+     * @throws NoMigrationsFoundWithCriteria
      */
     public function resolveVersionAlias(string $alias) : Version
     {
@@ -93,7 +97,7 @@ final class DefaultAliasResolver implements AliasResolver
                 try {
                     return $availableMigrations->getLast()->getVersion();
                 } catch (NoMigrationsFoundWithCriteria $e) {
-                    throw NoMigrationsToExecute::new($e);
+                    return $this->resolveVersionAlias(self::ALIAS_CURRENT);
                 }
 
                 // no break because of return

--- a/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
+++ b/lib/Doctrine/Migrations/Version/DefaultAliasResolver.php
@@ -66,6 +66,7 @@ final class DefaultAliasResolver implements AliasResolver
 
         switch ($alias) {
             case self::ALIAS_FIRST:
+            case '0':
                 return new Version('0');
             case self::ALIAS_CURRENT:
                 try {

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
@@ -87,7 +87,7 @@ class StatusCommandTest extends MigrationTestCase
                 '| Versions             | Previous             | 1230                                                                   |',
                 '|                      | Current              | 1233                                                                   |',
                 '|                      | Next                 | Already at latest version                                              |',
-                '|                      | Latest               |                                                                        |',
+                '|                      | Latest               | 1233                                                                   |',
                 '|----------------------------------------------------------------------------------------------------------------------|',
                 '| Migrations           | Executed             | 2                                                                      |',
                 '|                      | Executed Unavailable | 2                                                                      |',

--- a/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AliasResolverTest.php
@@ -132,6 +132,7 @@ final class AliasResolverTest extends TestCase
             ['current-1', 'A'],
             ['current+1', 'C'],
             ['B', 'B'],
+            ['0', '0'],
             ['X', null, UnknownMigrationVersion::class],
         ];
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | -

This PR  does not perform any major functional change, it mainly adds some formatting to the error/warning when there are no migrations to migrate.

- https://github.com/doctrine/migrations/pull/978/commits/812a3c27ce10c733186824e823ae8f78d017436b does some minor code-improvements by simplifying how error messages are printed and aliases are resolved 
- https://github.com/doctrine/migrations/pull/978/commits/6592e8879287a830bd1608cc4bfda43b36a27596 displays correctly the latest migration on the status command
- https://github.com/doctrine/migrations/pull/978/commits/069eea0910785966eb63c7ac2025668a3ba72243 allows to resolve the migration `0` as first migration)