### PR TITLE
Allow to use --write-sql to save the migration execution log to file

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -10,7 +10,9 @@ please refer to the [Code BC breaks](#code-bc-breaks) section.
   Console output is not covered by the BC promise, so please try not to rely on specific a output.
   Different levels of verbosity are available now (`-v`, `-vv` and `-vvv` ).
 - The `--show-versions` option from `migrations:status` command has been removed, 
-  use `migrations:list` instead. 
+  use `migrations:list` instead.
+- The `--write-sql` option for `migrations:migrate` and `migrations:execute` does not imply dry-run anymore,  
+use the `--dry-run` parameter instead.  
 
 ## Migrations table
 

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -22,11 +22,10 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
     {
         $timeAllQueries = $input->hasOption('query-time') ? (bool) $input->getOption('query-time') : false;
         $dryRun         = $input->hasOption('dry-run') ? (bool) $input->getOption('dry-run') : false;
-        $writeSql       = $input->hasOption('write-sql') ? $input->getOption('write-sql') : false;
         $allOrNothing   = $input->hasOption('all-or-nothing') ? (bool) $input->getOption('all-or-nothing') : $this->configuration->isAllOrNothing();
 
         return (new MigratorConfiguration())
-            ->setDryRun($dryRun || $writeSql !== false)
+            ->setDryRun($dryRun)
             ->setTimeAllQueries($timeAllQueries)
             ->setAllOrNothing($allOrNothing);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | -
| Fixed issues | -

#### Summary

In the 2.x version, passing `--write-sql` implied `--dry-run`. 
This PR decouples the two, so is possible to run:
- `--dry-run` without writing the result to file
- `--dry-run` and `--write-sql`
- `--write-sql` to have a "log" of executed queries
