### PR TITLE
Re-enable alpha1 meaningful message when "latest" already reached.

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -218,11 +218,16 @@ EOT
         if (in_array($versionAlias, ['first', 'next', 'latest'], true) || strpos($versionAlias, 'current') === 0) {
             $version = $this->getDependencyFactory()->getVersionAliasResolver()->resolveVersionAlias('current');
 
-            $message = sprintf(
-                'The version "%s" couldn\'t be reached, you are at version "%s"',
-                $versionAlias,
-                (string) $version
-            );
+            // Allow meaningful message when latest version already reached.
+            if ($versionAlias === 'next' || $versionAlias === 'latest') {
+                $message = 'Already at latest version';
+            } else {
+                $message = sprintf(
+                    'The version "%s" couldn\'t be reached, you are at version "%s"',
+                    $versionAlias,
+                    (string) $version
+                );
+            }
 
             if ($allowNoMigration) {
                 $this->io->warning($message);

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -220,7 +220,11 @@ EOT
 
             // Allow meaningful message when latest version already reached.
             if ($versionAlias === 'next' || $versionAlias === 'latest') {
-                $message = 'Already at latest version';
+                $message = sprintf(
+                    'Already at "%s" version ("%s")',
+                    $versionAlias,
+                    (string) $version
+                );
             } else {
                 $message = sprintf(
                     'The version "%s" couldn\'t be reached, you are at version "%s"',

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -124,7 +124,7 @@ class MigrateCommandTest extends MigrationTestCase
         $display = trim($this->migrateCommandTester->getDisplay(true));
         $aliases = ['next', 'latest'];
 
-        if (in_array($targetAlias, $aliases)) {
+        if (in_array($targetAlias, $aliases, false)) {
             $message = '[%s] Already at latest version';
         } else {
             $message = '[%s] The version "%s" couldn\'t be reached, you are at version "%s"';

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -121,15 +121,24 @@ class MigrateCommandTest extends MigrationTestCase
             ['interactive' => false]
         );
 
+        $display = trim($this->migrateCommandTester->getDisplay(true));
+
+        if (in_array($targetAlias, ['next', 'latest'])) {
+            $message = '[%s] Already at latest version';
+        } else {
+            $message = '[%s] The version "%s" couldn\'t be reached, you are at version "%s"';
+        }
+
         self::assertStringContainsString(
-            trim($this->migrateCommandTester->getDisplay(true)),
+            $display,
             sprintf(
-                '[%s] The version "%s" couldn\'t be reached, you are at version "%s"',
+                $message,
                 ($allowNoMigration ? 'WARNING' : 'ERROR'),
                 $targetAlias,
                 ($executedMigration ?? '0')
             )
         );
+
         self::assertSame($allowNoMigration ? 0 : 1, $this->migrateCommandTester->getStatusCode());
     }
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -122,8 +122,9 @@ class MigrateCommandTest extends MigrationTestCase
         );
 
         $display = trim($this->migrateCommandTester->getDisplay(true));
+        $aliases = ['next', 'latest'];
 
-        if (in_array($targetAlias, ['next', 'latest'])) {
+        if (in_array($targetAlias, $aliases)) {
             $message = '[%s] Already at latest version';
         } else {
             $message = '[%s] The version "%s" couldn\'t be reached, you are at version "%s"';

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -126,7 +126,7 @@ class MigrateCommandTest extends MigrationTestCase
         $aliases = ['next', 'latest'];
 
         if (in_array($targetAlias, $aliases, true)) {
-            $message = '[%s] Already at latest version';
+            $message = '[%s] Already at "%s" version ("%s")';
         } else {
             $message = '[%s] The version "%s" couldn\'t be reached, you are at version "%s"';
         }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -125,7 +125,7 @@ class MigrateCommandTest extends MigrationTestCase
         $display = trim($this->migrateCommandTester->getDisplay(true));
         $aliases = ['next', 'latest'];
 
-        if (in_array($targetAlias, $aliases, false)) {
+        if (in_array($targetAlias, $aliases, true)) {
             $message = '[%s] Already at latest version';
         } else {
             $message = '[%s] The version "%s" couldn\'t be reached, you are at version "%s"';

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -39,6 +39,7 @@ use function getcwd;
 use function sprintf;
 use function strpos;
 use function trim;
+use function in_array;
 
 class MigrateCommandTest extends MigrationTestCase
 {

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -36,10 +36,10 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 use function getcwd;
+use function in_array;
 use function sprintf;
 use function strpos;
 use function trim;
-use function in_array;
 
 class MigrateCommandTest extends MigrationTestCase
 {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #987 

#### Summary

Tries to fix the issue described in issue #987. To summarize, it is a proposal to get back the nice and clean `"[WARNING] Already at latest version"` when trying to perform a migration on a platform already at "latest" version. 
