### PR TITLE
Allow legacy cli-config.php configurations

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-dbal/cli-config.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-dbal/cli-config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Symfony\Component\Console\Helper\HelperSet;
+
+$conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+return new HelperSet([
+    'db' => new ConnectionHelper($conn),
+]);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-dbal/migrations.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-dbal/migrations.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return [];

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-orm/cli-config.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-orm/cli-config.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Doctrine\Persistence\Mapping\Driver\PHPDriver;
+use Symfony\Component\Console\Helper\HelperSet;
+
+$conf = new Configuration();
+$conf->setProxyDir(__DIR__);
+$conf->setProxyNamespace('Foo');
+$conf->setMetadataDriverImpl(new PHPDriver(''));
+
+$conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+$em = EntityManager::create($conn, $conf);
+
+return new HelperSet([
+    'em' => new EntityManagerHelper($em),
+]);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-orm/migrations.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-orm/migrations.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return [];

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-wrong/cli-config.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-wrong/cli-config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Symfony\Component\Console\Helper\HelperSet;
+
+$conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+return new HelperSet([
+    'abc' => new ConnectionHelper($conn),
+]);


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues |https://github.com/doctrine/migrations/issues/986

#### Summary
Allow legacy configurations to improve interoperability with other doctrine cli tools.

This will read the helpersets and try to create from them the dependency factory