### PR TITLE
Fix --write-sql command option description

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -42,7 +42,7 @@ final class ExecuteCommand extends DoctrineCommand
                 'write-sql',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The path to output the migration SQL file instead of executing it. Defaults to current working directory.',
+                'The path to output the migration SQL file. Defaults to current working directory.',
                 false
             )
             ->addOption(
@@ -82,7 +82,7 @@ You can also execute the migration as a <comment>--dry-run</comment>:
 
     <info>%command.full_name% FQCN --dry-run</info>
 
-You can output the would be executed SQL statements to a file with <comment>--write-sql</comment>:
+You can output the prepared SQL statements to a file with <comment>--write-sql</comment>:
 
     <info>%command.full_name% FQCN --write-sql</info>
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -47,7 +47,7 @@ final class MigrateCommand extends DoctrineCommand
                 'write-sql',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The path to output the migration SQL file instead of executing it. Defaults to current working directory.',
+                'The path to output the migration SQL file. Defaults to current working directory.',
                 false
             )
             ->addOption(
@@ -97,7 +97,7 @@ You can also execute the migration as a <comment>--dry-run</comment>:
 
     <info>%command.full_name% FQCN --dry-run</info>
 
-You can output the would be executed SQL statements to a file with <comment>--write-sql</comment>:
+You can output the prepared SQL statements to a file with <comment>--write-sql</comment>:
 
     <info>%command.full_name% FQCN --write-sql</info>
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

I believe this fixes a small oversight from f3c7942c91272a8ce3b774182f8c882b42387294, which didn't update the command help descriptions with the new `--write-sql` behaviour.

Note: I'm not sure on the use of `prepared`, as I do not know at what stage the sql file is actually written.