### PR TITLE
#996: Add verbosity notice to command help

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -74,6 +74,11 @@ The <info>%command.name%</info> command executes migration versions up or down m
 
     <info>%command.full_name% FQCN</info>
 
+You can show more information about the process by increasing the verbosity level. To see the
+executed queries, set the level to debug with <comment>-vv</comment>:
+
+    <info>%command.full_name% FQCN -vv</info>
+
 If no <comment>--up</comment> or <comment>--down</comment> option is specified it defaults to up:
 
     <info>%command.full_name% FQCN --down</info>
@@ -92,6 +97,7 @@ Or you can also execute the migration without a warning message which you need t
 
 All the previous commands accept multiple migration versions, allowing you run execute more than
 one migration at once:
+
     <info>%command.full_name% FQCN-1 FQCN-2 ...FQCN-n </info>
 
 EOT

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -80,6 +80,11 @@ The <info>%command.name%</info> command executes a migration to a specified vers
 
     <info>%command.full_name%</info>
 
+You can show more information about the process by increasing the verbosity level. To see the
+executed queries, set the level to debug with <comment>-vv</comment>:
+
+    <info>%command.full_name% -vv</info>
+
 You can optionally manually specify the version you wish to migrate to:
 
     <info>%command.full_name% FQCN</info>
@@ -110,6 +115,7 @@ You can also time all the different queries if you wanna know which one is takin
     <info>%command.full_name% --query-time</info>
 
 Use the --all-or-nothing option to wrap the entire migration in a transaction.
+
 EOT
             );
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #996

#### Summary

As discussed in #996, add some help text for the verbosity levels in the `execute` and `migrate` commands.
