### PR TITLE
#998: Show query and time information when using --query-time

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -140,9 +140,9 @@ class ExecutorTest extends TestCase
         self::assertSame([
             0 => '++ migrating test',
             1 => 'SELECT 1 ',
-            2 => '100ms',
+            2 => 'Query took 100ms',
             3 => 'SELECT 2 ',
-            4 => '100ms',
+            4 => 'Query took 100ms',
             5 => 'Migration test migrated (took 100ms, used 100 memory)',
         ], $this->logger->logs);
     }
@@ -223,9 +223,9 @@ class ExecutorTest extends TestCase
         self::assertSame([
             0 => '++ reverting test',
             1 => 'SELECT 3 ',
-            2 => '100ms',
+            2 => 'Query took 100ms',
             3 => 'SELECT 4 ',
-            4 => '100ms',
+            4 => 'Query took 100ms',
             5 => 'Migration test reverted (took 100ms, used 100 memory)',
         ], $this->logger->logs);
     }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/improvement
| BC Break     | no
| Fixed issues |  #998

#### Summary

Always show the queries and their timing when supplying the `--query-time` option
