### PR TITLE
Migrate returns 0 as exit codes for empty plans as in 2.x

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,9 +13,6 @@ please refer to the [Code BC breaks](#code-bc-breaks) section.
   use `migrations:list` instead.
 - The `--write-sql` option for `migrations:migrate` and `migrations:execute` does not imply dry-run anymore,  
 use the `--dry-run` parameter instead.  
-- The `migrations:migrate` command will return a non-zero exit code if there are no migrations to execute, 
-use the `--allow-no-migration` parameter to have a zero exit code.
-
 
 ## Migrations table
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -218,11 +218,20 @@ EOT
         if (in_array($versionAlias, ['first', 'next', 'latest'], true) || strpos($versionAlias, 'current') === 0) {
             $version = $this->getDependencyFactory()->getVersionAliasResolver()->resolveVersionAlias('current');
 
-            $message = sprintf(
-                'The version "%s" couldn\'t be reached, you are at version "%s"',
-                $versionAlias,
-                (string) $version
-            );
+            // Allow meaningful message when latest version already reached.
+            if ($versionAlias === 'next' || $versionAlias === 'latest') {
+                $message = sprintf(
+                    'Already at "%s" version ("%s")',
+                    $versionAlias,
+                    (string) $version
+                );
+            } else {
+                $message = sprintf(
+                    'The version "%s" couldn\'t be reached, you are at version "%s"',
+                    $versionAlias,
+                    (string) $version
+                );
+            }
 
             if ($allowNoMigration) {
                 $this->io->warning($message);

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -85,23 +85,23 @@ class MigrateCommandTest extends MigrationTestCase
     }
 
     /**
-     * @return bool[][]
+     * @return array<array<int, bool|int>>
      */
     public function getMigrateWithMigrationsOrWithout() : array
     {
         return [
-            // migrations available, allow-no-migrations
-            [false, false],
-            [true, false],
-            [false, true],
-            [true, true],
+            // migrations available, allow-no-migrations, expected exit code
+            [false, false, 1],
+            [true, false, 0],
+            [false, true, 0],
+            [true, true, 0],
         ];
     }
 
     /**
      * @dataProvider getMigrateWithMigrationsOrWithout
      */
-    public function testMigrateWhenNoMigrationsAvailable(bool $hasMigrations, bool $allowNoMigration) : void
+    public function testMigrateWhenNoMigrationsAvailable(bool $hasMigrations, bool $allowNoMigration, int $expectedExitCode) : void
     {
         $finder                    = $this->createMock(Finder::class);
         $factory                   = $this->createMock(MigrationFactory::class);
@@ -129,7 +129,7 @@ class MigrateCommandTest extends MigrationTestCase
             );
         }
 
-        self::assertSame($hasMigrations || $allowNoMigration ? 0 : 1, $this->migrateCommandTester->getStatusCode());
+        self::assertSame($expectedExitCode, $this->migrateCommandTester->getStatusCode());
     }
 
     /**

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 use function getcwd;
+use function in_array;
 use function sprintf;
 use function strpos;
 use function trim;
@@ -121,15 +122,25 @@ class MigrateCommandTest extends MigrationTestCase
             ['interactive' => false]
         );
 
+        $display = trim($this->migrateCommandTester->getDisplay(true));
+        $aliases = ['next', 'latest'];
+
+        if (in_array($targetAlias, $aliases, true)) {
+            $message = '[%s] Already at "%s" version ("%s")';
+        } else {
+            $message = '[%s] The version "%s" couldn\'t be reached, you are at version "%s"';
+        }
+
         self::assertStringContainsString(
-            trim($this->migrateCommandTester->getDisplay(true)),
+            $display,
             sprintf(
-                '[%s] The version "%s" couldn\'t be reached, you are at version "%s"',
+                $message,
                 ($allowNoMigration ? 'WARNING' : 'ERROR'),
                 $targetAlias,
                 ($executedMigration ?? '0')
             )
         );
+
         self::assertSame($allowNoMigration ? 0 : 1, $this->migrateCommandTester->getStatusCode());
     }
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | -
| Fixed issues | 

#### Summary

In doctrine 2.x the migration command throws an exception if there
are not migrations to execute (unless the --allow-no-migrations
parameter is passed). In 3.0.0 this was misunderstood and the exception
was thrown even if there are registered migrations but there are no migrations to
execute for the current migration plan.
With this commit we are back to the 2.x strategy.

This commit also improves the error messages when the various aliases
can not be reached or are already reached.
