### PR TITLE
Check PHP_OS_FAMILY for Windows in Tests

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Finder/RecursiveRegexFinderTest.php
@@ -9,8 +9,7 @@ use InvalidArgumentException;
 use function count;
 use function in_array;
 use function sort;
-use function stripos;
-use const PHP_OS;
+use const PHP_OS_FAMILY;
 
 class RecursiveRegexFinderTest extends FinderTestCase
 {
@@ -42,7 +41,7 @@ class RecursiveRegexFinderTest extends FinderTestCase
             'TestMigrations\\DifferentNamingSchema',
         ];
 
-        if (stripos(PHP_OS, 'Win') === false) {
+        if (PHP_OS_FAMILY !== 'Windows') {
             $tests[] = 'TestMigrations\\Version1SymlinkedFile';
         }
 


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1037 

#### Summary

Instead of checking `PHP_OS` for `Win`. The old version was matching
`Darwin` on OSX and causing a false negative.

