### PR TITLE
Set dependencyFactory before configure is called in DoctrineCommand

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php
@@ -32,8 +32,8 @@ abstract class DoctrineCommand extends Command
 
     public function __construct(?DependencyFactory $dependencyFactory = null, ?string $name = null)
     {
-        parent::__construct($name);
         $this->dependencyFactory = $dependencyFactory;
+        parent::__construct($name);
     }
 
     protected function configure(): void

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DoctrineCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DoctrineCommandTest.php
@@ -73,4 +73,18 @@ class DoctrineCommandTest extends MigrationTestCase
             ['interactive' => false]
         );
     }
+
+    public function testDependencyFactoryIsSetFirst(): void
+    {
+        $dependencyFactory = $this->createMock(DependencyFactory::class);
+        $command           = new class ($dependencyFactory) extends DoctrineCommand
+        {
+            protected function configure(): void
+            {
+                $this->getDependencyFactory();
+            }
+        };
+
+        self::assertFalse($command->getDefinition()->hasOption('db-configuration'));
+    }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

While reading through the code I found [this piece here](https://github.com/doctrine/migrations/blob/b65eb7cc2cc0d569d21222ba343ee7298bb180d7/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php#L47-L49) and I figured, it would never actually do anything with the way things are set up. The constructor always sets the value for `$dependencyFactory` only [after calling its parent](https://github.com/doctrine/migrations/blob/b65eb7cc2cc0d569d21222ba343ee7298bb180d7/lib/Doctrine/Migrations/Tools/Console/Command/DoctrineCommand.php#L34-L35), so until then `$dependencyFactory` is considered `null`. The parent's constructor in turn calls the `configure` method which checks if `$dependencyFactory` is `null`.

I have switched the assignment of `$dependencyFactory` with the call to the parent's constructor, so that the condition in the `configure` method actually does something depending on the presence of a `$dependencyFactory`.

I consider this a breaking change, since this can potentially lead to one less input option for a doctrine command, thus changing the command definition and breaking scripts that provide this option.
