### PR TITLE
Add a schema_provider option that enables the diff command for DBAL

### DIFF
--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -246,10 +246,25 @@ class DependencyFactory
         });
     }
 
-    private function getSchemaProvider(): SchemaProvider
+    public function hasSchemaProvider(): bool
+    {
+        try {
+            $this->getSchemaProvider();
+        } catch (MissingDependency $exception) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getSchemaProvider(): SchemaProvider
     {
         return $this->getDependency(SchemaProvider::class, function (): SchemaProvider {
-            return new OrmSchemaProvider($this->getEntityManager());
+            if ($this->hasEntityManager()) {
+                return new OrmSchemaProvider($this->getEntityManager());
+            }
+
+            throw MissingDependency::noSchemaProvider();
         });
     }
 

--- a/lib/Doctrine/Migrations/Exception/MissingDependency.php
+++ b/lib/Doctrine/Migrations/Exception/MissingDependency.php
@@ -12,4 +12,9 @@ final class MissingDependency extends RuntimeException implements DependencyExce
     {
         return new self('The entity manager is not available.');
     }
+
+    public static function noSchemaProvider(): self
+    {
+        return new self('The schema provider is not available.');
+    }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
@@ -124,7 +124,7 @@ class ConsoleRunner
             new ListCommand($dependencyFactory),
         ]);
 
-        if ($dependencyFactory === null || ! $dependencyFactory->hasEntityManager()) {
+        if ($dependencyFactory === null || ! $dependencyFactory->hasSchemaProvider()) {
             return;
         }
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/ConsoleRunnerTest.php
@@ -224,7 +224,7 @@ class ConsoleRunnerTest extends TestCase
         $dependencyFactory = $this->createMock(DependencyFactory::class);
         $dependencyFactory
             ->expects(self::atLeastOnce())
-            ->method('hasEntityManager')
+            ->method('hasSchemaProvider')
             ->willReturn(true);
 
         ConsoleRunner::addCommands($this->application, $dependencyFactory);
@@ -248,12 +248,12 @@ class ConsoleRunnerTest extends TestCase
         self::assertCount(12, $commands);
     }
 
-    public function testCreateApplicationWithEntityManager(): void
+    public function testCreateApplicationWithSchemaProvider(): void
     {
         $dependencyFactory = $this->createMock(DependencyFactory::class);
         $dependencyFactory
             ->expects(self::atLeastOnce())
-            ->method('hasEntityManager')
+            ->method('hasSchemaProvider')
             ->willReturn(true);
 
         $application = ConsoleRunner::createApplication([], $dependencyFactory);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | #1047

#### Summary

This change makes it possible to configure a `schema_provider` that enables the diff command for doctrine DBAL as well.

Currently the PR allows you to do:

```php
$dependencyFactory = DependencyFactory::fromConnection(
    new ConfigurationArray([...]),
    new ExistingConnection($connection)
);
$dependencyFactory->setService(SchemaProvider::class, new MySchemaProvider());
MigrationsConsoleRunner::addCommands($application, $dependencyFactory);
```

In which, `MySchemaProvider` is a `Doctrine\Migrations\Provider\SchemaProvider`.