### PR TITLE
Repeated $config value

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -322,10 +322,10 @@ Now update your ``cli-config.php`` in the root of your project to look like the 
     $paths = [__DIR__.'/lib/MyProject/Entities'];
     $isDevMode = true;
 
-    $config = Setup::createAnnotationMetadataConfiguration($paths, $isDevMode);
+    $ORMconfig = Setup::createAnnotationMetadataConfiguration($paths, $isDevMode);
     $entityManager = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $config);
 
-    return DependencyFactory::fromEntityManager($config, new ExistingEntityManager($entityManager));
+    return DependencyFactory::fromEntityManager($ORMconfig, new ExistingEntityManager($entityManager));
 
 Make sure to create the directory where your ORM entities will be located:
 

--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -323,9 +323,9 @@ Now update your ``cli-config.php`` in the root of your project to look like the 
     $isDevMode = true;
 
     $ORMconfig = Setup::createAnnotationMetadataConfiguration($paths, $isDevMode);
-    $entityManager = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+    $entityManager = EntityManager::create(['driver' => 'pdo_sqlite', 'memory' => true], $ORMconfig);
 
-    return DependencyFactory::fromEntityManager($ORMconfig, new ExistingEntityManager($entityManager));
+    return DependencyFactory::fromEntityManager($config, new ExistingEntityManager($entityManager));
 
 Make sure to create the directory where your ORM entities will be located:
 


### PR DESCRIPTION
There is a repeated value name at the end of this page in the last advanced configuration ($config). I have changed the name of one of them because it can create confusion and it wouldn't work anyways.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues |  none

#### Summary

URL where you can find the typo:
https://www.doctrine-project.org/projects/doctrine-migrations/en/3.0/reference/configuration.html#advanced
