### PR TITLE
Cast to integer to avoid Spanner GCP incompatibility

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -136,7 +136,7 @@ final class TableMetadataStorage implements MetadataStorage
             $this->connection->insert($this->configuration->getTableName(), [
                 $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
                 $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
-                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : round($result->getTime()*1000),
+                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : (int) round($result->getTime()*1000),
             ], [
                 Types::STRING,
                 Types::DATETIME_MUTABLE,


### PR DESCRIPTION
#### Summary

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | Avoid delegate to DB responsibility to cast `execution_time` and fix GCP Spanner issue

I am currently receiving error from GCP when trying to persist data using Spanner:

```
An exception occurred while executing 'INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUES (?, ?, ?)' with params ["oat\\generis\\migrations\\Version202009301828472348_generis", "2020-10-02T11:54:13.671062Z", 130]:  
                                                                                                                                                                                                                                                            
  {                                                                                                                                                                                                                                                         
      "message": "Invalid value for bind parameter param3: Expected INT64.",                                                                                                                                                                                
      "code": 3,                                                                                                                                                                                                                                            
      "status": "INVALID_ARGUMENT",                                                                                                                                                                                                                         
      "details": [                                                                                                                                                                                                                                          
          {                                                                                                                                                                                                                                                 
              "@type": "grpc-server-stats-bin",                                                                                                                                                                                                             
              "data": "<Unknown Binary Data>"                                                                                                                                                                                                               
          }                                                                                                                                                                                                                                                 
      ]                                                                                                                                                                                                                                                     
  }        
```
Cause the 130 is actually `130.0` (a float).

Since migrations always expects an integer here I would like to cast this value to avoid driver incompatibilities

The issue was reported here: https://github.com/doctrine/migrations/issues/1061