### PR TITLE
Cast to int the execution time

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -136,7 +136,7 @@ final class TableMetadataStorage implements MetadataStorage
             $this->connection->insert($this->configuration->getTableName(), [
                 $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
                 $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
-                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : round($result->getTime()*1000),
+                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : (int) round($result->getTime()*1000),
             ], [
                 Types::STRING,
                 Types::DATETIME_MUTABLE,

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -7,12 +7,14 @@ namespace Doctrine\Migrations\Tests\Metadata\Storage;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOSqlite\Driver as SQLiteDriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\Exception\MetadataStorageError;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
@@ -51,6 +53,47 @@ class TableMetadataStorageTest extends TestCase
 
         $this->config  = new TableMetadataStorageConfiguration();
         $this->storage = new TableMetadataStorage($this->connection, new AlphabeticalComparator(), $this->config);
+    }
+
+    public function testCompleteWillAlwaysCastTimeToInteger() : void
+    {
+        $config     = new TableMetadataStorageConfiguration();
+        $executedAt = new DateTimeImmutable('2010-01-05 10:30:21');
+
+        $connection = $this->getMockBuilder(Connection::class)
+            ->setConstructorArgs([
+                ['pdo' => $this->getSqliteConnection()->getWrappedConnection()],
+                new SQLiteDriver(),
+            ])
+            ->onlyMethods(['insert'])
+            ->getMock();
+
+        $connection
+            ->expects(self::once())
+            ->method('insert')
+            ->willReturnCallback(static function ($table, $params, $types) use ($config, $executedAt) : int {
+                self::assertSame($config->getTableName(), $table);
+                self::assertSame([
+                    $config->getVersionColumnName() => '1230',
+                    $config->getExecutedAtColumnName() => $executedAt,
+                    $config->getExecutionTimeColumnName() => 31000,
+                ], $params);
+                self::assertSame([
+                    Types::STRING,
+                    Types::DATETIME_MUTABLE,
+                    Types::INTEGER,
+                ], $types);
+
+                return 1;
+            });
+
+        $storage = new TableMetadataStorage($connection, new AlphabeticalComparator(), $config);
+        $storage->ensureInitialized();
+
+        $result = new ExecutionResult(new Version('1230'), Direction::UP, $executedAt);
+        $result->setTime(31.0);
+
+        $storage->complete($result);
     }
 
     public function testDifferentTableNotUpdatedOnRead() : void


### PR DESCRIPTION
Cast to int the execution time (to avoid incompatibilities with RDBMS as Google Spanner)

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/migrations/issues/1061
| Alternative to  | https://github.com/doctrine/migrations/pull/1060

