### PR TITLE
Allow organize_migrations to be set to false which is the default val…

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/Migrations/Configuration/Configuration.php
@@ -201,9 +201,19 @@ final class Configuration
         return $this->checkDbPlatform;
     }
 
-    public function setMigrationOrganization(string $migrationOrganization) : void
+    public function setMigrationOrganization($migrationOrganization) : void
     {
         $this->assertNotFrozen();
+        if ($migrationOrganization === false) {
+            $this->setMigrationsAreOrganizedByYearAndMonth(false);
+
+            return;
+        }
+
+        if (! is_string($migrationOrganization)) {
+            throw UnknownConfigurationValue::new('organize_migrations', $migrationOrganization);
+        }
+
         if (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR) === 0) {
             $this->setMigrationsAreOrganizedByYear();
         } elseif (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH) === 0) {

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -74,6 +74,33 @@ class ConfigurationTest extends TestCase
         self::assertTrue($config->areMigrationsOrganizedByYear());
     }
 
+    public function testMigrationOrganizationCanBeResetToFalse() : void
+    {
+        $config = new Configuration();
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        $config->setMigrationOrganization(false);
+
+        self::assertFalse($config->areMigrationsOrganizedByYearAndMonth());
+        self::assertFalse($config->areMigrationsOrganizedByYear());
+    }
+
+    public function testMigrationOrganizationMustBeSetToFalseOrStringTestTrue() : void
+    {
+        $this->expectException(UnknownConfigurationValue::class);
+        $config = new Configuration();
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        $config->setMigrationOrganization(true);
+
+    }
+
+    public function testMigrationOrganizationMustBeSetToFalseOrStringTestNumber() : void
+    {
+        $this->expectException(UnknownConfigurationValue::class);
+        $config = new Configuration();
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        $config->setMigrationOrganization(123);
+    }
+
     public function testMigrationOrganizationWithWrongValue() : void
     {
         $this->expectException(UnknownConfigurationValue::class);


### PR DESCRIPTION
…ue.  This allows organize_migrations to be reset to default in case a previous configuration value set it to year or year_and_month

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Allow organize_migrations to be set to false which is the default value.  This allows organize_migrations to be reset to default in case a previous configuration value set it to year or year_and_month
