### PR TITLE
A whole slew of changes for 3.0.x!  See the summary.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,3 @@
-
 name: "Continuous Integration"
 
 on:
@@ -21,11 +20,14 @@ jobs:
   composer_normalize:
     name: "Composer Normalize"
     runs-on: "ubuntu-latest"
-    needs:
-      - "composer"
     steps:
-      - name: "Composer Normalize"
-        run: "composer normalize --dry-run"
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: "docker://ergebnis/composer-normalize-action:latest"
+        with:
+          args: "--dry-run"
 
   phpunit:
     name: "PHPUnit"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
 
   composer_normalize:
     name: "Composer Normalize"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,15 @@ jobs:
         with:
           args: --from=${{ github.event.pull_request.base.sha }}
 
+  composer_normalize:
+    name: "Composer Normalize"
+    runs-on: "ubuntu-latest"
+    needs:
+      - "composer"
+    steps:
+      - name: "Composer Normalize"
+        run: "composer normalize --dry-run"
+
   phpunit:
     name: "PHPUnit"
     runs-on: "ubuntu-20.04"

--- a/composer.json
+++ b/composer.json
@@ -1,81 +1,81 @@
 {
-  "name": "doctrine/migrations",
-  "type": "library",
-  "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
-  "keywords": [
-    "database",
-    "migrations",
-    "dbal"
-  ],
-  "homepage": "https://www.doctrine-project.org/projects/migrations.html",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Benjamin Eberlei",
-      "email": "kontakt@beberlei.de"
+    "name": "doctrine/migrations",
+    "type": "library",
+    "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
+    "keywords": [
+        "database",
+        "migrations",
+        "dbal"
+    ],
+    "homepage": "https://www.doctrine-project.org/projects/migrations.html",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Benjamin Eberlei",
+            "email": "kontakt@beberlei.de"
+        },
+        {
+            "name": "Jonathan Wage",
+            "email": "jonwage@gmail.com"
+        },
+        {
+            "name": "Michael Simonson",
+            "email": "contact@mikesimonson.com"
+        }
+    ],
+    "require": {
+        "php": "^7.2",
+        "composer/package-versions-deprecated": "^1.8",
+        "doctrine/dbal": "^2.10",
+        "doctrine/event-manager": "^1.0",
+        "ocramius/proxy-manager": "^2.0.2",
+        "psr/log": "^1.1.3",
+        "symfony/console": "^3.4 || ^4.4.16 || ^5.0",
+        "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0"
     },
-    {
-      "name": "Jonathan Wage",
-      "email": "jonwage@gmail.com"
+    "require-dev": {
+        "ext-pdo_sqlite": "*",
+        "doctrine/coding-standard": "^8.0",
+        "doctrine/orm": "^2.6",
+        "doctrine/persistence": "^1.3 || ^2.0",
+        "doctrine/sql-formatter": "^1.0",
+        "ergebnis/composer-normalize": "^2.11",
+        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan-deprecation-rules": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan-symfony": "^0.12",
+        "phpunit/phpunit": "^8.5 || ^9.4",
+        "symfony/process": "^3.4 || ^4.0 || ^5.0",
+        "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
     },
-    {
-      "name": "Michael Simonson",
-      "email": "contact@mikesimonson.com"
-    }
-  ],
-  "require": {
-    "php": "^7.2",
-    "composer/package-versions-deprecated": "^1.8",
-    "doctrine/dbal": "^2.10",
-    "doctrine/event-manager": "^1.0",
-    "ocramius/proxy-manager": "^2.0.2",
-    "psr/log": "^1.1.3",
-    "symfony/console": "^3.4 || ^4.4.16 || ^5.0",
-    "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0"
-  },
-  "require-dev": {
-    "ext-pdo_sqlite": "*",
-    "doctrine/coding-standard": "^8.0",
-    "doctrine/orm": "^2.6",
-    "doctrine/persistence": "^1.3 || ^2.0",
-    "doctrine/sql-formatter": "^1.0",
-    "ergebnis/composer-normalize": "^2.11",
-    "phpstan/phpstan": "^0.12",
-    "phpstan/phpstan-deprecation-rules": "^0.12",
-    "phpstan/phpstan-phpunit": "^0.12",
-    "phpstan/phpstan-strict-rules": "^0.12",
-    "phpstan/phpstan-symfony": "^0.12",
-    "phpunit/phpunit": "^8.5 || ^9.4",
-    "symfony/process": "^3.4 || ^4.0 || ^5.0",
-    "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
-  },
-  "suggest": {
-    "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
-    "symfony/yaml": "Allows the use of yaml for migration configuration files."
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "3.0.x-dev"
+    "suggest": {
+        "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+        "symfony/yaml": "Allows the use of yaml for migration configuration files."
     },
-    "composer-normalize": {
-      "indent-size": 2,
-      "indent-style": "space"
-    }
-  },
-  "autoload": {
-    "psr-4": {
-      "Doctrine\\Migrations\\": "lib/Doctrine/Migrations"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Doctrine\\Migrations\\Tests\\": "tests/Doctrine/Migrations/Tests"
-    }
-  },
-  "bin": [
-    "bin/doctrine-migrations"
-  ]
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "3.0.x-dev"
+        },
+        "composer-normalize": {
+            "indent-size": 4,
+            "indent-style": "space"
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Doctrine\\Migrations\\": "lib/Doctrine/Migrations"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Doctrine\\Migrations\\Tests\\": "tests/Doctrine/Migrations/Tests"
+        }
+    },
+    "bin": [
+        "bin/doctrine-migrations"
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -25,32 +25,45 @@
   ],
   "require": {
     "php": "^7.2",
+    "composer/package-versions-deprecated": "^1.8",
     "doctrine/dbal": "^2.10",
     "doctrine/event-manager": "^1.0",
-    "composer/package-versions-deprecated": "^1.8",
     "ocramius/proxy-manager": "^2.0.2",
     "psr/log": "^1.1.3",
-    "symfony/console": "^3.4||^4.4.16||^5.0",
-    "symfony/stopwatch": "^3.4||^4.0||^5.0"
+    "symfony/console": "^3.4 || ^4.4.16 || ^5.0",
+    "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0"
   },
   "require-dev": {
     "ext-pdo_sqlite": "*",
     "doctrine/coding-standard": "^8.0",
     "doctrine/orm": "^2.6",
-    "doctrine/persistence": "^1.3||^2.0",
+    "doctrine/persistence": "^1.3 || ^2.0",
     "doctrine/sql-formatter": "^1.0",
+    "ergebnis/composer-normalize": "^2.11",
     "phpstan/phpstan": "^0.12",
     "phpstan/phpstan-deprecation-rules": "^0.12",
     "phpstan/phpstan-phpunit": "^0.12",
     "phpstan/phpstan-strict-rules": "^0.12",
     "phpstan/phpstan-symfony": "^0.12",
     "phpunit/phpunit": "^8.5 || ^9.4",
-    "symfony/process": "^3.4||^4.0||^5.0",
-    "symfony/yaml": "^3.4||^4.0||^5.0"
+    "symfony/process": "^3.4 || ^4.0 || ^5.0",
+    "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
   },
   "suggest": {
     "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
     "symfony/yaml": "Allows the use of yaml for migration configuration files."
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "3.0.x-dev"
+    },
+    "composer-normalize": {
+      "indent-size": 2,
+      "indent-style": "space"
+    }
   },
   "autoload": {
     "psr-4": {
@@ -60,14 +73,6 @@
   "autoload-dev": {
     "psr-4": {
       "Doctrine\\Migrations\\Tests\\": "tests/Doctrine/Migrations/Tests"
-    }
-  },
-  "config": {
-    "sort-packages": true
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "3.0.x-dev"
     }
   },
   "bin": [

--- a/composer.json
+++ b/composer.json
@@ -1,66 +1,76 @@
 {
-    "name": "doctrine/migrations",
-    "type": "library",
-    "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
-    "keywords": ["php", "database", "migrations", "dbal"],
-    "homepage": "https://www.doctrine-project.org/projects/migrations.html",
-    "license": "MIT",
-    "authors": [
-        {"name": "Benjamin Eberlei", "email": "kontakt@beberlei.de"},
-        {"name": "Jonathan Wage", "email": "jonwage@gmail.com"},
-        {"name": "Michael Simonson", "email": "contact@mikesimonson.com" }
-    ],
-    "require": {
-        "php": "^7.2",
-        "doctrine/dbal": "^2.10",
-        "doctrine/event-manager": "^1.0",
-        "composer/package-versions-deprecated": "^1.8",
-        "ocramius/proxy-manager": "^2.0.2",
-        "psr/log": "^1.1.3",
-        "symfony/console": "^3.4||^4.4.16||^5.0",
-        "symfony/stopwatch": "^3.4||^4.0||^5.0"
+  "name": "doctrine/migrations",
+  "type": "library",
+  "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
+  "keywords": [
+    "database",
+    "migrations",
+    "dbal"
+  ],
+  "homepage": "https://www.doctrine-project.org/projects/migrations.html",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Benjamin Eberlei",
+      "email": "kontakt@beberlei.de"
     },
-    "require-dev": {
-        "ext-pdo_sqlite": "*",
-        "doctrine/coding-standard": "^8.0",
-        "doctrine/orm": "^2.6",
-        "doctrine/persistence": "^1.3||^2.0",
-        "doctrine/sql-formatter": "^1.0",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-deprecation-rules": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
-        "phpstan/phpstan-strict-rules": "^0.12",
-        "phpstan/phpstan-symfony": "^0.12",
-        "phpunit/phpunit": "^8.5 || ^9.4",
-        "symfony/process": "^3.4||^4.0||^5.0",
-        "symfony/yaml": "^3.4||^4.0||^5.0"
+    {
+      "name": "Jonathan Wage",
+      "email": "jonwage@gmail.com"
     },
-    "suggest": {
-        "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
-        "symfony/yaml": "Allows the use of yaml for migration configuration files."
-    },
-    "autoload": {
-        "psr-4": {
-            "Doctrine\\Migrations\\": "lib/Doctrine/Migrations"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Doctrine\\Migrations\\Tests\\": "tests/Doctrine/Migrations/Tests"
-        }
-    },
-    "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.2.2"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.0.x-dev"
-        }
-    },
-    "bin": [
-        "bin/doctrine-migrations"
-    ]
+    {
+      "name": "Michael Simonson",
+      "email": "contact@mikesimonson.com"
+    }
+  ],
+  "require": {
+    "php": "^7.2",
+    "doctrine/dbal": "^2.10",
+    "doctrine/event-manager": "^1.0",
+    "composer/package-versions-deprecated": "^1.8",
+    "ocramius/proxy-manager": "^2.0.2",
+    "psr/log": "^1.1.3",
+    "symfony/console": "^3.4||^4.4.16||^5.0",
+    "symfony/stopwatch": "^3.4||^4.0||^5.0"
+  },
+  "require-dev": {
+    "ext-pdo_sqlite": "*",
+    "doctrine/coding-standard": "^8.0",
+    "doctrine/orm": "^2.6",
+    "doctrine/persistence": "^1.3||^2.0",
+    "doctrine/sql-formatter": "^1.0",
+    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan-deprecation-rules": "^0.12",
+    "phpstan/phpstan-phpunit": "^0.12",
+    "phpstan/phpstan-strict-rules": "^0.12",
+    "phpstan/phpstan-symfony": "^0.12",
+    "phpunit/phpunit": "^8.5 || ^9.4",
+    "symfony/process": "^3.4||^4.0||^5.0",
+    "symfony/yaml": "^3.4||^4.0||^5.0"
+  },
+  "suggest": {
+    "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+    "symfony/yaml": "Allows the use of yaml for migration configuration files."
+  },
+  "autoload": {
+    "psr-4": {
+      "Doctrine\\Migrations\\": "lib/Doctrine/Migrations"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Doctrine\\Migrations\\Tests\\": "tests/Doctrine/Migrations/Tests"
+    }
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "3.0.x-dev"
+    }
+  },
+  "bin": [
+    "bin/doctrine-migrations"
+  ]
 }

--- a/download-box.sh
+++ b/download-box.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 if [ ! -f box.phar ]; then
-    wget https://github.com/box-project/box/releases/download/3.9.0/box.phar -O box.phar
+    wget https://github.com/box-project/box/releases/download/3.9.1/box.phar -O box.phar
 fi

--- a/lib/Doctrine/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/Migrations/Configuration/Configuration.php
@@ -9,8 +9,7 @@ use Doctrine\Migrations\Configuration\Exception\UnknownConfigurationValue;
 use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorageConfiguration;
 
-use function is_string;
-use function strcasecmp;
+use function strtolower;
 
 /**
  * The Configuration class is responsible for defining migration configuration information.

--- a/lib/Doctrine/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/Migrations/Configuration/Configuration.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\Configuration\Exception\UnknownConfigurationValue;
 use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorageConfiguration;
 
+use function is_string;
 use function strcasecmp;
 
 /**
@@ -174,9 +175,23 @@ final class Configuration
         return $this->checkDbPlatform;
     }
 
-    public function setMigrationOrganization(string $migrationOrganization): void
+    /**
+     * @param string | bool $migrationOrganization
+     */
+    public function setMigrationOrganization($migrationOrganization): void
     {
         $this->assertNotFrozen();
+
+        if ($migrationOrganization === false) {
+            $this->setMigrationsAreOrganizedByYearAndMonth(false);
+
+            return;
+        }
+
+        if (! is_string($migrationOrganization)) {
+            throw UnknownConfigurationValue::new('organize_migrations', $migrationOrganization);
+        }
+
         if (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR) === 0) {
             $this->setMigrationsAreOrganizedByYear();
         } elseif (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH) === 0) {

--- a/lib/Doctrine/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/Migrations/Configuration/Configuration.php
@@ -17,6 +17,7 @@ use function strcasecmp;
  */
 final class Configuration
 {
+    public const VERSIONS_ORGANIZATION_NONE              = 'none';
     public const VERSIONS_ORGANIZATION_BY_YEAR           = 'year';
     public const VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH = 'year_and_month';
 
@@ -175,29 +176,22 @@ final class Configuration
         return $this->checkDbPlatform;
     }
 
-    /**
-     * @param string | bool $migrationOrganization
-     */
-    public function setMigrationOrganization($migrationOrganization): void
+    public function setMigrationOrganization(string $migrationOrganization): void
     {
         $this->assertNotFrozen();
 
-        if ($migrationOrganization === false) {
-            $this->setMigrationsAreOrganizedByYearAndMonth(false);
-
-            return;
-        }
-
-        if (! is_string($migrationOrganization)) {
-            throw UnknownConfigurationValue::new('organize_migrations', $migrationOrganization);
-        }
-
-        if (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR) === 0) {
-            $this->setMigrationsAreOrganizedByYear();
-        } elseif (strcasecmp($migrationOrganization, self::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH) === 0) {
-            $this->setMigrationsAreOrganizedByYearAndMonth();
-        } else {
-            throw UnknownConfigurationValue::new('organize_migrations', $migrationOrganization);
+        switch (strtolower($migrationOrganization)) {
+            case self::VERSIONS_ORGANIZATION_NONE:
+                $this->setMigrationsAreOrganizedByYearAndMonth(false);
+                break;
+            case self::VERSIONS_ORGANIZATION_BY_YEAR:
+                $this->setMigrationsAreOrganizedByYear();
+                break;
+            case self::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH:
+                $this->setMigrationsAreOrganizedByYearAndMonth();
+                break;
+            default:
+                throw UnknownConfigurationValue::new('organize_migrations', $migrationOrganization);
         }
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -80,4 +80,30 @@ class ConfigurationTest extends TestCase
         $config = new Configuration();
         $config->setMigrationOrganization('foo');
     }
+
+    public function testMigrationOrganizationCanBeResetToFalse(): void
+    {
+        $config = new Configuration();
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        $config->setMigrationOrganization(false);
+
+        self::assertFalse($config->areMigrationsOrganizedByYearAndMonth());
+        self::assertFalse($config->areMigrationsOrganizedByYear());
+    }
+
+    public function testMigrationOrganizationMustBeSetToFalseOrStringTestTrue(): void
+    {
+        $this->expectException(UnknownConfigurationValue::class);
+        $config = new Configuration();
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        $config->setMigrationOrganization(true);
+    }
+
+    public function testMigrationOrganizationMustBeSetToFalseOrStringTestNumber(): void
+    {
+        $this->expectException(UnknownConfigurationValue::class);
+        $config = new Configuration();
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        $config->setMigrationOrganization(123);
+    }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -98,12 +98,4 @@ class ConfigurationTest extends TestCase
         $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
         $config->setMigrationOrganization(true);
     }
-
-    public function testMigrationOrganizationMustBeSetToFalseOrStringTestNumber(): void
-    {
-        $this->expectException(UnknownConfigurationValue::class);
-        $config = new Configuration();
-        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
-        $config->setMigrationOrganization(123);
-    }
 }

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -81,21 +81,16 @@ class ConfigurationTest extends TestCase
         $config->setMigrationOrganization('foo');
     }
 
-    public function testMigrationOrganizationCanBeResetToFalse(): void
+    public function testMigrationOrganizationCanBeReset(): void
     {
         $config = new Configuration();
-        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
-        $config->setMigrationOrganization(false);
 
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
+        self::assertTrue($config->areMigrationsOrganizedByYearAndMonth());
+        self::assertTrue($config->areMigrationsOrganizedByYear());
+
+        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_NONE);
         self::assertFalse($config->areMigrationsOrganizedByYearAndMonth());
         self::assertFalse($config->areMigrationsOrganizedByYear());
-    }
-
-    public function testMigrationOrganizationMustBeSetToFalseOrStringTestTrue(): void
-    {
-        $this->expectException(UnknownConfigurationValue::class);
-        $config = new Configuration();
-        $config->setMigrationOrganization(Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH);
-        $config->setMigrationOrganization(true);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
@@ -13,6 +13,6 @@ class ClassNameGeneratorTest extends TestCase
     {
         $generator = new ClassNameGenerator();
         $fqcn      = $generator->generateClassName('Foo');
-        self::assertRegExp('/^Foo\\\\Version[0-9]{14}$/', $fqcn);
+        $this->assertMatchesRegularExpression('/^Foo\\\\Version[0-9]{14}$/', $fqcn);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
@@ -7,6 +7,8 @@ namespace Doctrine\Migrations\Tests\Generator;
 use Doctrine\Migrations\Generator\ClassNameGenerator;
 use PHPUnit\Framework\TestCase;
 
+use function method_exists;
+
 class ClassNameGeneratorTest extends TestCase
 {
     public function testName(): void

--- a/tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
@@ -13,6 +13,11 @@ class ClassNameGeneratorTest extends TestCase
     {
         $generator = new ClassNameGenerator();
         $fqcn      = $generator->generateClassName('Foo');
-        $this->assertMatchesRegularExpression('/^Foo\\\\Version[0-9]{14}$/', $fqcn);
+
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            $this->assertMatchesRegularExpression('/^Foo\\\\Version[0-9]{14}$/', $fqcn);
+        } else {
+            self::assertRegExp('/^Foo\\\\Version[0-9]{14}$/', $fqcn);
+        }
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
@@ -88,9 +88,9 @@ class DiffGeneratorTest extends TestCase
             ->method('createSchema')
             ->willReturn($toSchema);
 
-        $toSchema->expects($this->exactly(2))
+        $toSchema->expects(self::exactly(2))
             ->method('dropTable')
-            ->will($this->onConsecutiveCalls('schema.table_name2', 'schema.table_name3'));
+            ->will(self::onConsecutiveCalls('schema.table_name2', 'schema.table_name3'));
 
         $fromSchema->expects(self::once())
             ->method('getMigrateToSql')
@@ -102,13 +102,13 @@ class DiffGeneratorTest extends TestCase
             ->with($toSchema, $this->platform)
             ->willReturn(['UPDATE table SET value = 1']);
 
-        $this->migrationSqlGenerator->expects($this->exactly(2))
+        $this->migrationSqlGenerator->expects(self::exactly(2))
             ->method('generate')
-            ->with($this->logicalOr(
-                $this->equalTo(['UPDATE table SET value = 2']),
-                $this->equalTo(['UPDATE table SET value = 1'])
+            ->with(self::logicalOr(
+                self::equalTo(['UPDATE table SET value = 2']),
+                self::equalTo(['UPDATE table SET value = 1'])
             ), true, 80)
-            ->will($this->onConsecutiveCalls('test1', 'test2'));
+            ->will(self::onConsecutiveCalls('test1', 'test2'));
 
         $this->migrationGenerator->expects(self::once())
             ->method('generateMigration')
@@ -157,13 +157,13 @@ class DiffGeneratorTest extends TestCase
             ->with($toSchema, $this->platform)
             ->willReturn(['DROP TABLE table_name']);
 
-        $this->migrationSqlGenerator->expects($this->exactly(2))
+        $this->migrationSqlGenerator->expects(self::exactly(2))
             ->method('generate')
-            ->with($this->logicalOr(
-                $this->equalTo(['CREATE TABLE table_name']),
-                $this->equalTo(['DROP TABLE table_name'])
+            ->with(self::logicalOr(
+                self::equalTo(['CREATE TABLE table_name']),
+                self::equalTo(['DROP TABLE table_name'])
             ), false, 120, true)
-            ->will($this->onConsecutiveCalls('test up', 'test down'));
+            ->will(self::onConsecutiveCalls('test up', 'test down'));
 
         $this->migrationGenerator->expects(self::once())
             ->method('generateMigration')

--- a/tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
@@ -105,9 +105,9 @@ class DiffGeneratorTest extends TestCase
         $this->migrationSqlGenerator->expects($this->exactly(2))
             ->method('generate')
             ->with($this->logicalOr(
-                 $this->equalTo(['UPDATE table SET value = 2']),
-                 $this->equalTo(['UPDATE table SET value = 1'])
-             ), true, 80)
+                $this->equalTo(['UPDATE table SET value = 2']),
+                $this->equalTo(['UPDATE table SET value = 1'])
+            ), true, 80)
             ->will($this->onConsecutiveCalls('test1', 'test2'));
 
         $this->migrationGenerator->expects(self::once())
@@ -160,9 +160,9 @@ class DiffGeneratorTest extends TestCase
         $this->migrationSqlGenerator->expects($this->exactly(2))
             ->method('generate')
             ->with($this->logicalOr(
-                 $this->equalTo(['CREATE TABLE table_name']),
-                 $this->equalTo(['DROP TABLE table_name'])
-             ), false, 120, true)
+                $this->equalTo(['CREATE TABLE table_name']),
+                $this->equalTo(['DROP TABLE table_name'])
+            ), false, 120, true)
             ->will($this->onConsecutiveCalls('test up', 'test down'));
 
         $this->migrationGenerator->expects(self::once())

--- a/tests/Doctrine/Migrations/Tests/RollupTest.php
+++ b/tests/Doctrine/Migrations/Tests/RollupTest.php
@@ -50,9 +50,12 @@ class RollupTest extends TestCase
            ->willReturn(new AvailableMigrationsSet([$m1]));
 
         $this->storage
-           ->expects(self::at(0))->method('reset')->with();
+           ->expects(self::exactly(1))
+           ->method('reset')
+           ->with();
+
         $this->storage
-           ->expects(self::at(1))
+           ->expects(self::exactly(1))
            ->method('complete')
            ->willReturnCallback(static function (ExecutionResult $result): void {
               self::assertEquals(new Version('A'), $result->getVersion());

--- a/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+++ b/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
@@ -76,15 +76,13 @@ class SchemaDumperTest extends TestCase
             ->method('getDropTableSQL')
             ->willReturn('DROP TABLE test');
 
-        $this->migrationSqlGenerator->expects(self::at(0))
+        $this->migrationSqlGenerator->expects($this->exactly(2))
             ->method('generate')
-            ->with(['CREATE TABLE test'])
-            ->willReturn('up');
-
-        $this->migrationSqlGenerator->expects(self::at(1))
-            ->method('generate')
-            ->with(['DROP TABLE test'])
-            ->willReturn('down');
+            ->with($this->logicalOr(
+                 $this->equalTo(['CREATE TABLE test']),
+                 $this->equalTo(['DROP TABLE test'])
+             ))
+            ->will($this->onConsecutiveCalls('up', 'down'));
 
         $this->migrationGenerator->expects(self::once())
             ->method('generateMigration')

--- a/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+++ b/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
@@ -76,13 +76,13 @@ class SchemaDumperTest extends TestCase
             ->method('getDropTableSQL')
             ->willReturn('DROP TABLE test');
 
-        $this->migrationSqlGenerator->expects($this->exactly(2))
+        $this->migrationSqlGenerator->expects(self::exactly(2))
             ->method('generate')
-            ->with($this->logicalOr(
-                $this->equalTo(['CREATE TABLE test']),
-                $this->equalTo(['DROP TABLE test'])
+            ->with(self::logicalOr(
+                self::equalTo(['CREATE TABLE test']),
+                self::equalTo(['DROP TABLE test'])
             ))
-            ->will($this->onConsecutiveCalls('up', 'down'));
+            ->will(self::onConsecutiveCalls('up', 'down'));
 
         $this->migrationGenerator->expects(self::once())
             ->method('generateMigration')

--- a/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+++ b/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
@@ -79,9 +79,9 @@ class SchemaDumperTest extends TestCase
         $this->migrationSqlGenerator->expects($this->exactly(2))
             ->method('generate')
             ->with($this->logicalOr(
-                 $this->equalTo(['CREATE TABLE test']),
-                 $this->equalTo(['DROP TABLE test'])
-             ))
+                $this->equalTo(['CREATE TABLE test']),
+                $this->equalTo(['DROP TABLE test'])
+            ))
             ->will($this->onConsecutiveCalls('up', 'down'));
 
         $this->migrationGenerator->expects(self::once())

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Tools\Console\Command;
 
 use DateTimeImmutable;
+use Doctrine\DBAL\Version as DBALVersion;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
 use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
@@ -73,6 +74,12 @@ class StatusCommandTest extends MigrationTestCase
 
         $lines = array_map('trim', explode("\n", trim($this->commandTester->getDisplay(true))));
 
+        if (DBALVersion::compare('2.11.0') > 0) {
+            $databaseDriver = 'Doctrine\DBAL\Driver\PDOSqlite\Driver '; // Trailing space bufferes outout assertion
+        } else {
+            $databaseDriver = 'Doctrine\DBAL\Driver\PDO\SQLite\Driver';
+        }
+
         self::assertSame(
             [
                 '+----------------------+----------------------+------------------------------------------------------------------------+',
@@ -82,7 +89,7 @@ class StatusCommandTest extends MigrationTestCase
                 '|                      | Table Name           | doctrine_migration_versions                                            |',
                 '|                      | Column Name          | version                                                                |',
                 '|----------------------------------------------------------------------------------------------------------------------|',
-                '| Database             | Driver               | Doctrine\DBAL\Driver\PDOSqlite\Driver                                  |',
+                '| Database             | Driver               | ' . $databaseDriver . '                                 |',
                 '|                      | Name                 |                                                                        |',
                 '|----------------------------------------------------------------------------------------------------------------------|',
                 '| Versions             | Previous             | 1230                                                                   |',

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/StatusCommandTest.php
@@ -75,7 +75,8 @@ class StatusCommandTest extends MigrationTestCase
         $lines = array_map('trim', explode("\n", trim($this->commandTester->getDisplay(true))));
 
         if (DBALVersion::compare('2.11.0') > 0) {
-            $databaseDriver = 'Doctrine\DBAL\Driver\PDOSqlite\Driver '; // Trailing space bufferes outout assertion
+            // Trailing space is necessary to pad size to match `...\PDO\SQLite\Driver` namespace length
+            $databaseDriver = 'Doctrine\DBAL\Driver\PDOSqlite\Driver ';
         } else {
             $databaseDriver = 'Doctrine\DBAL\Driver\PDO\SQLite\Driver';
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

* Updated box to 3.9.1
* Allow for PDO namespace changes after DBAL 2.11
* Reformatted composer.json and removed config platform of 7.2
* Fixed at() calls in tests
* Allow organize_migrations to be set to false with a new 'none' value
* Add composer-normalize

Please note the branch name is now out of sync with this PR.