### PR TITLE
Use composer v1 when running the low deps CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,8 +69,12 @@ jobs:
         uses: "actions/cache@v2"
         with:
           path: "~/.composer/cache"
-          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          key: "php-${{ matrix.php-version }}-composer-${{ matrix.deps }}-locked-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+      - name: "Downgrade Composer"
+        run: "composer self-update --1"
+        if: "${{ matrix.deps == 'low' }}"
 
       - name: "Install dependencies with composer"
         run: "composer update --no-interaction --prefer-dist --no-progress"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/orm": "^2.6",
         "doctrine/persistence": "^1.3 || ^2.0",
         "doctrine/sql-formatter": "^1.0",
-        "ergebnis/composer-normalize": "^2.11",
+        "ergebnis/composer-normalize": "^2.9",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-deprecation-rules": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

In https://github.com/doctrine/migrations/pull/1079, some dev deps were compatible only with composer v1, with this we run the builds using both composer versions