### PR TITLE
Run roave-bc-check on PRs only

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -1,0 +1,19 @@
+
+name: "Backward Compatibility Check"
+
+on:
+  pull_request:
+
+jobs:
+  roave_bc_check:
+    name: "Roave BC Check"
+    runs-on: "ubuntu-20.04"
+    steps:
+      - uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 0
+
+      - name: "Roave BC Check"
+        uses: "docker://nyholm/roave-bc-check-ga"
+        with:
+          args: "--from=${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,19 +8,6 @@ on:
       - "*.x"
 
 jobs:
-  roave_bc_check:
-    name: "Roave BC Check"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Roave BC Check
-        uses: docker://nyholm/roave-bc-check-ga
-        with:
-          args: --from=${{ github.event.pull_request.base.sha }}
-
   phpunit:
     name: "PHPUnit"
     runs-on: "ubuntu-20.04"


### PR DESCRIPTION
`github.event.pull_request.base.sha` is not defined when pushing a branch,
which means that job will always be failing for pushes.