### PR TITLE
Fetch previous commit before using CodeCov

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
-        with:
-          fetch-depth: 2
 
       - name: "Install PHP with XDebug"
         uses: "shivammathur/setup-php@v2"
@@ -83,6 +81,11 @@ jobs:
       - "phpunit"
 
     steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
       - name: "Download coverage files"
         uses: "actions/download-artifact@v2"
         with:


### PR DESCRIPTION
To do its job properly, CodeCov needs to know about the parent of the
commit being tested: the commit being tested is a merge commit between
the upstream branch and the last commit of the PR branch, when in the
case of a PR. When in the case of a push, this is useless but should not
be harmful.