### PR TITLE
Always update migrated versions

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -158,11 +158,10 @@ final class TableMetadataStorage implements MetadataStorage
 
         $expectedSchemaChangelog = $this->getExpectedTable();
         $diff                    = $this->needsUpdate($expectedSchemaChangelog);
-        if ($diff === null) {
-            return;
+        if ($diff !== null) {
+            $this->schemaManager->alterTable($diff);
         }
 
-        $this->schemaManager->alterTable($diff);
         $this->updateMigratedVersionsFromV1orV2toV3();
     }
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

When migrating from v2 to v3 in a big project (with different migration classes in different branches) metadata sync becomes very cumbersome when you already have executed migrations from other branches than you are currently on, since the version names are only migrates once along with the table structure. At the moment the workaround we use is dropping the `execution_time` column before running `doctrine:migrations:migrate`, to ensure the names are always updated when you're in a branch with already executed, but not yet synced version names.

This change will make the names always update, no matter if there are structural changes to the table needed or not.

If this is not preferred - I could add a new flag to enable this behavior only when needed.
