### PR TITLE
Address MasterSlaveConnection rename

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,8 @@ parameters:
         - '~^Parameter #1 \$files of method Doctrine\\Migrations\\Finder\\Finder::loadMigrationClasses\(\) expects array<string>, array<int, string\|false> given\.\z~'
         - '~^Class Doctrine\\Migrations\\Tests\\DoesNotExistAtAll not found\.\z~'
         - '~^Call to method getVersion\(\) of deprecated class PackageVersions\\Versions\.$~'
+        # Drop when bumping to doctrine/dbal 2.11+
+        - '~^.*PrimaryReadReplicaConnection.*$~'
 
 includes:
     - vendor/phpstan/phpstan-deprecation-rules/rules.neon


### PR DESCRIPTION


<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary

MasterSlaveConnection has been deprecated in favor of
PrimaryReadReplicaConnection, which it extends before being removed in
DBAL 3. This ensure both cases are handled when it comes to making sure
we connect to the primary, while not bumping the requirement to
doctrine/dbal 2.11 (which requires PHP 7.3, although subsequent version
might restore compatibility with 7.1).
