### PR TITLE
Fixed metadata comparison on MariaDB 10.3.25

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -206,8 +206,8 @@ final class TableMetadataStorage implements MetadataStorage
             'string',
             ['notnull' => true, 'length' => $this->configuration->getVersionColumnLength()]
         );
-        $schemaChangelog->addColumn($this->configuration->getExecutedAtColumnName(), 'datetime', ['notnull' => false]);
-        $schemaChangelog->addColumn($this->configuration->getExecutionTimeColumnName(), 'integer', ['notnull' => false]);
+        $schemaChangelog->addColumn($this->configuration->getExecutedAtColumnName(), 'datetime', ['notnull' => false, 'default' => 'NULL']);
+        $schemaChangelog->addColumn($this->configuration->getExecutionTimeColumnName(), 'integer', ['notnull' => false, 'default' => 'NULL']);
 
         $schemaChangelog->setPrimaryKey([$this->configuration->getVersionColumnName()]);
 


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no

#### Summary

Currently if you run `./bin/console doctrine:migrations:sync-metadata-storage`  on MariaDB 10.3.25 it will fail, because `null !== 'NULL'`. 

How to reproduce: 
1. ensure the metadata table doesn't exist
2. run `./bin/console doctrine:migrations:sync-metadata-storage` -> table will be created
3. run the command again, you'll get the following error: `The metadata storage is not up to date, please run the sync-metadata-storage command to fix this issue.`