### PR TITLE
Allow PHP 8 on branch 3.0.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,6 +32,7 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+          - "8.0"
         deps:
           - "normal"
         include:

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/dbal": "^2.10",
         "doctrine/event-manager": "^1.0",
-        "ocramius/proxy-manager": "^2.0.2",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "psr/log": "^1.1.3",
         "symfony/console": "^3.4 || ^4.4.16 || ^5.0",
         "symfony/stopwatch": "^3.4 || ^4.0 || ^5.0"

--- a/download-box.sh
+++ b/download-box.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 if [ ! -f box.phar ]; then
-    wget https://github.com/box-project/box/releases/download/3.9.1/box.phar -O box.phar
+    wget https://github.com/box-project/box/releases/download/$(php -r 'echo PHP_VERSION_ID >= 70300 ? "3.11.0" : "3.9.1";')/box.phar -O box.phar
 fi

--- a/lib/Doctrine/Migrations/SchemaDumper.php
+++ b/lib/Doctrine/Migrations/SchemaDumper.php
@@ -158,7 +158,7 @@ class SchemaDumper
     {
         try {
             $errorMessages = [];
-            set_error_handler(static function (int $severity, string $message, string $file, int $line, array $params) use (&$errorMessages): bool {
+            set_error_handler(static function (int $severity, string $message, string $file, int $line) use (&$errorMessages): bool {
                 $errorMessages[] = $message;
 
                 return true;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,8 +9,6 @@ parameters:
     excludes_analyse:
         - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTestSource/Migrations/Version123.php
     ignoreErrors:
-        # Ignore proxy manager magic
-        - '~ProxyManager\\Proxy\\VirtualProxyInterface~'
         - '~Variable method call on Doctrine\\Migrations\\AbstractMigration~'
         -
             message: '~^Call to function in_array\(\) requires parameter #3 to be true\.$~'


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

This PR allows installing doctrine/migrations v3 on PHP 8.

For branch 2.3.x, there is more work, and it already started, see https://github.com/doctrine/migrations/pull/980

