### PR TITLE
fix for jsonb contains operator

### DIFF
--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -295,8 +295,7 @@ final class DbalExecutor implements Executor
             $this->outputSqlQuery($query);
 
             $stopwatchEvent = $this->stopwatch->start('query');
-            // executeQuery() must be used here because $query might return a result set, for instance REPAIR does
-            $this->connection->executeQuery($query->getStatement(), $query->getParameters(), $query->getTypes());
+            $this->connection->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
             $stopwatchEvent->stop();
 
             if (! $configuration->getTimeAllQueries()) {

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -295,7 +295,7 @@ final class DbalExecutor implements Executor
             $this->outputSqlQuery($query);
 
             $stopwatchEvent = $this->stopwatch->start('query');
-            $this->connection->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
+            $this->connection->executeUpdate($query->getStatement(), $query->getParameters(), $query->getTypes());
             $stopwatchEvent->stop();
 
             if (! $configuration->getTimeAllQueries()) {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1106 

#### Summary

Looking at the current code, the `executeQuery` usage mentions some case with a REPAIR returning a result set. It's unclear to my why this is important when the result is never returned, requested or in any other way important to a migration, except its success.

Usage of a static statement, instead of a prepared one, allows for simple JSONB contain queries again, like in 3.0.1.

As for testing, I'm unsure how to do it and I could not find any good approach to simulate a DBAL `executeQuery` vs `executeStatement` that would lead to this error to make it testable.