### PR TITLE
Try create directory for migrations namespace before it checks if it exists

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Exception/DirectoryDoesNotExistAndCouldNotBeCreated.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Exception/DirectoryDoesNotExistAndCouldNotBeCreated.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tools\Console\Exception;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class DirectoryDoesNotExistAndCouldNotBeCreated extends InvalidArgumentException implements ConsoleException
+{
+    public static function new(string $directory, string $couldNotBeCreatedError): self
+    {
+        return new self(sprintf('Migrations directory "%s" does not exist and could not be created: "%s"', $directory, $couldNotBeCreatedError));
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 

#### Summary

With the update to version 3.x and the support for multiple namespace migration locations - command to generate a migration file with a mapped namespace location is failing as the migrations directory has not yet been created.

In our use case this is causing issues when trying to generate a migration file for a new mapped location where the migrations directory has not yet been created. In our codebase based off Symfony, we now make use of the multiple namespace migration locations - these mappings are based on each bundle that is loaded (bundle namespace & bundle directory location) - some bundles have no migrations and don't require a migrations directory

### **Steps to replicate current:**
Use _doctrine/migrations_ & _doctrine/doctrine-migrations-bundle_ version 3.0.2 - update config file if necessary

Add a _doctrine_migrations.migrations_paths_ mapping to an existing or dummy namespace & directory (_**ensure the namespace folder exists, but not the migrations folder in it**_). e.g:
```
doctrine_migrations:
  migrations_paths:
    'Simple\Bundle\Namespace\Migrations': '/var/www/vendor/simple/src/Migrations'
```

Try generate a migration:
```
bin/console doctrine:migrations:generate --namespace "Simple\\\Bundle\\\Namespace\\\Migrations"
```