### PR TITLE
POC: config version comparator

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/Configuration.php
+++ b/lib/Doctrine/Migrations/Configuration/Configuration.php
@@ -14,6 +14,7 @@ use Doctrine\Migrations\Version\Comparator;
 use function class_exists;
 use function class_implements;
 use function in_array;
+use function is_array;
 use function strtolower;
 
 /**
@@ -251,7 +252,13 @@ final class Configuration
             throw UnknownConfigurationValue::new('version_comparator', $this->versionComparator);
         }
 
-        if (! in_array(Comparator::class, class_implements($this->versionComparator))) {
+        $classImplements = class_implements($this->versionComparator);
+
+        if (! is_array($classImplements)) {
+            throw UnknownConfigurationValue::new('version_comparator', $this->versionComparator);
+        }
+
+        if (! in_array(Comparator::class, $classImplements)) {
             throw UnknownConfigurationValue::new('version_comparator', $this->versionComparator);
         }
 

--- a/lib/Doctrine/Migrations/Configuration/Migration/ConfigurationArray.php
+++ b/lib/Doctrine/Migrations/Configuration/Migration/ConfigurationArray.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Migration\Exception\InvalidConfigurationKey;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\Tools\BooleanStringFormatter;
+use Doctrine\Migrations\Version\AlphabeticalComparator;
 
 use function assert;
 use function call_user_func;
@@ -58,6 +59,7 @@ final class ConfigurationArray implements ConfigurationLoader
 
             'organize_migrations' => 'setMigrationOrganization',
             'custom_template' => 'setCustomTemplate',
+            'version_comparator' => AlphabeticalComparator::class,
             'all_or_nothing' => static function ($value, Configuration $configuration): void {
                 $configuration->setAllOrNothing(is_bool($value) ? $value : BooleanStringFormatter::toBoolean($value, false));
             },

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -33,7 +33,6 @@ use Doctrine\Migrations\Tools\Console\ConsoleInputMigratorConfigurationFactory;
 use Doctrine\Migrations\Tools\Console\Helper\MigrationStatusInfosHelper;
 use Doctrine\Migrations\Tools\Console\MigratorConfigurationFactory;
 use Doctrine\Migrations\Version\AliasResolver;
-use Doctrine\Migrations\Version\AlphabeticalComparator;
 use Doctrine\Migrations\Version\Comparator;
 use Doctrine\Migrations\Version\CurrentMigrationStatusCalculator;
 use Doctrine\Migrations\Version\DbalExecutor;
@@ -190,8 +189,8 @@ class DependencyFactory
 
     public function getVersionComparator(): Comparator
     {
-        return $this->getDependency(Comparator::class, static function (): AlphabeticalComparator {
-            return new AlphabeticalComparator();
+        return $this->getDependency(Comparator::class, function (): Comparator {
+            return $this->getConfiguration()->getVersionComparator();
         });
     }
 

--- a/lib/Doctrine/Migrations/Version/AlphabeticalWithoutNamespaceComparator.php
+++ b/lib/Doctrine/Migrations/Version/AlphabeticalWithoutNamespaceComparator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Version;
+
+use function array_pop;
+use function explode;
+use function strcmp;
+
+class AlphabeticalWithoutNamespaceComparator implements Comparator
+{
+    public function compare(Version $a, Version $b): int
+    {
+        return strcmp($this->withoutNamespace($a), $this->withoutNamespace($b));
+    }
+
+    private function withoutNamespace(Version $version): string
+    {
+        $path = explode('\\', (string) $version);
+
+        return array_pop($path);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTest.php
@@ -8,6 +8,7 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Exception\FrozenConfiguration;
 use Doctrine\Migrations\Configuration\Exception\UnknownConfigurationValue;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorageConfiguration;
+use Doctrine\Migrations\Version\AlphabeticalComparator;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
@@ -43,6 +44,7 @@ class ConfigurationTest extends TestCase
 
         self::assertFalse($config->areMigrationsOrganizedByYearAndMonth());
         self::assertFalse($config->areMigrationsOrganizedByYear());
+        self::assertInstanceOf(AlphabeticalComparator::class, $config->getVersionComparator());
     }
 
     public function testFreezeConfiguration(): void

--- a/tests/Doctrine/Migrations/Tests/Version/AlphabeticalWithoutNamespaceComparatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AlphabeticalWithoutNamespaceComparatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Version;
+
+use Doctrine\Migrations\Version\AlphabeticalWithoutNamespaceComparator;
+use Doctrine\Migrations\Version\Version;
+use PHPUnit\Framework\TestCase;
+
+final class AlphabeticalWithoutNamespaceComparatorTest extends TestCase
+{
+    /**
+     * @return iterable[]
+     */
+    public function provideVersion(): iterable
+    {
+        yield [new Version('a'), new Version('b'), -1];
+        yield [new Version('b'), new Version('a'), 1];
+        yield [new Version('a\b'), new Version('b\a'), 1];
+        yield [new Version('b\a'), new Version('a\b'), -1];
+    }
+
+    /** @dataProvider provideVersion */
+    public function testOrder(Version $a, Version $b, int $expected): void
+    {
+        $sUT = new AlphabeticalWithoutNamespaceComparator();
+
+        self::assertSame($expected, $sUT->compare($a, $b));
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Version/AlphabeticalWithoutNamespaceComparatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/AlphabeticalWithoutNamespaceComparatorTest.php
@@ -10,9 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 final class AlphabeticalWithoutNamespaceComparatorTest extends TestCase
 {
-    /**
-     * @return iterable[]
-     */
+    /** @return array<Version, Version, int> */
     public function provideVersion(): iterable
     {
         yield [new Version('a'), new Version('b'), -1];


### PR DESCRIPTION
Allow config version comparator + adding version comparator without namespace

|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

#### Summary

Hello,

This is a POC, because I'm not sure that the implementation is correct.

the default versionComparator is duplicate twice (in Configuration and ConfigurationArray).

Thanks in advance for review :)