### PR TITLE
Warn users about transactions and DDL statements 

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -180,7 +180,7 @@ All or Nothing Transaction
 
 .. note::
 
-    This is only works if your database supports transactions for DDL statements.
+    This only works if your database supports transactions for DDL statements.
 
 When using the ``all_or_nothing`` option, multiple migrations ran at the same time will be wrapped in a single
 transaction. If one migration fails, all migrations will be rolled back

--- a/docs/en/reference/migration-classes.rst
+++ b/docs/en/reference/migration-classes.rst
@@ -67,6 +67,16 @@ Override this method if you want to disable transactions in a migration. It defa
         return false;
     }
 
+.. note::
+
+    Some database platforms like MySQL or Oracle do not support DDL
+    statements in transactions and may or may not implicitly commit the
+    transaction opened by this library as soon as they encounter such a
+    statement, and before running it. Make sure to read the manual of
+    your database platform to know what is actually happening.
+    ``isTransactional()`` does not guarantee that statements are wrapped
+    in a single transaction.
+
 getDescription
 ~~~~~~~~~~~~~~
 

--- a/lib/Doctrine/Migrations/Version/Factory.php
+++ b/lib/Doctrine/Migrations/Version/Factory.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\Configuration\Configuration;
  * The Factory class is responsible for creating instances of the Version class for a version number
  * and a migration class name.
  *
- * @var internal
+ * @internal
  */
 class Factory
 {


### PR DESCRIPTION
#### Summary

Users should be aware that there is no guarantee all statements are
wrapped inside a transaction.
