### PR TITLE
Stop throwing exceptions on commit in PHP8+pdo_mysql combo 

### DIFF
--- a/lib/Doctrine/Migrations/Event/Listeners/AutoCommitListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/AutoCommitListener.php
@@ -7,6 +7,7 @@ namespace Doctrine\Migrations\Event\Listeners;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Migrations\Event\MigrationsEventArgs;
 use Doctrine\Migrations\Events;
+use Doctrine\Migrations\Tools\TransactionHelper;
 
 /**
  * Listens for `onMigrationsMigrated` and, if the connection has autocommit
@@ -24,7 +25,7 @@ final class AutoCommitListener implements EventSubscriber
             return;
         }
 
-        $conn->commit();
+        TransactionHelper::commitIfInTransaction($conn);
     }
 
     /** {@inheritdoc} */

--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\Exception\MigrationException;
 use Doctrine\Migrations\Exception\NoMigrationsToExecute;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
 use Doctrine\Migrations\Tools\BytesFormatter;
+use Doctrine\Migrations\Tools\TransactionHelper;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Stopwatch\StopwatchEvent;
@@ -202,7 +203,7 @@ class Migrator
         }
 
         if ($allOrNothing) {
-            $connection->commit();
+            TransactionHelper::commitIfInTransaction($connection);
         }
 
         return $sql;

--- a/lib/Doctrine/Migrations/Tools/TransactionHelper.php
+++ b/lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tools;
+
+use Doctrine\DBAL\Connection;
+use PDO;
+
+/**
+ * @internal
+ */
+final class TransactionHelper
+{
+    public static function commitIfInTransaction(Connection $connection): void
+    {
+        $wrappedConnection = $connection->getWrappedConnection();
+
+        // Attempt to commit while no transaction is running results in exception since PHP 8 + pdo_mysql combination
+        if ($wrappedConnection instanceof PDO && ! $wrappedConnection->inTransaction()) {
+            return;
+        }
+
+        $connection->commit();
+    }
+}

--- a/lib/Doctrine/Migrations/Tracking/TableUpdater.php
+++ b/lib/Doctrine/Migrations/Tracking/TableUpdater.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\Tools\TransactionHelper;
 use Throwable;
 
 use function in_array;
@@ -66,7 +67,7 @@ class TableUpdater
             throw $e;
         }
 
-        $this->connection->commit();
+        TransactionHelper::commitIfInTransaction($this->connection);
     }
 
     /**

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -16,6 +16,7 @@ use Doctrine\Migrations\ParameterFormatterInterface;
 use Doctrine\Migrations\Provider\SchemaDiffProviderInterface;
 use Doctrine\Migrations\Stopwatch;
 use Doctrine\Migrations\Tools\BytesFormatter;
+use Doctrine\Migrations\Tools\TransactionHelper;
 use Throwable;
 
 use function count;
@@ -257,8 +258,7 @@ final class Executor implements ExecutorInterface
         }
 
         if ($migration->isTransactional()) {
-            //commit only if running in transactional mode
-            $this->connection->commit();
+            TransactionHelper::commitIfInTransaction($this->connection);
         }
 
         $version->setState(State::NONE);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1104

#### Summary

I didn't go with exception swallowing after all, because it turned out PDO has `inTransaction()` which works here.
