### PR TITLE
[Doc] Fixed Syntax error in JSON Configuration File

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -107,13 +107,13 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
             },
 
             "migrations_paths": {
-               "MyProject\Migrations": "/data/doctrine/migrations/lib/MyProject/Migrations",
-               "MyProject\Component\Migrations": "./Component/MyProject/Migrations"
+               "MyProject\\Migrations": "/data/doctrine/migrations/lib/MyProject/Migrations",
+               "MyProject\\Component\\Migrations": "./Component/MyProject/Migrations"
             },
 
             "all_or_nothing": true,
             "check_database_platform": true,
-            "organize_migrations": "none"
+            "organize_migrations": "none",
 
             "connection": null,
             "em": null


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | 

#### Summary

There were syntax errors in the sample JSON configuration file:
1. a comma was missing
2. backslashes were not escaped