### PR TITLE
Rollback if and only if inside a transaction

### DIFF
--- a/lib/Doctrine/Migrations/Migrator.php
+++ b/lib/Doctrine/Migrations/Migrator.php
@@ -196,7 +196,7 @@ class Migrator
             $this->configuration->dispatchMigrationEvent(Events::onMigrationsMigrated, $direction, $dryRun);
         } catch (Throwable $e) {
             if ($allOrNothing) {
-                $connection->rollBack();
+                TransactionHelper::rollbackIfInTransaction($connection);
             }
 
             throw $e;

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -86,7 +86,7 @@ EOT
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Max line length of unformatted lines.',
-                120
+                '120'
             )
             ->addOption(
                 'check-database-platform',

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -61,7 +61,7 @@ EOT
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Max line length of unformatted lines.',
-                120
+                '120'
             );
     }
 

--- a/lib/Doctrine/Migrations/Tools/TransactionHelper.php
+++ b/lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -14,13 +14,28 @@ final class TransactionHelper
 {
     public static function commitIfInTransaction(Connection $connection): void
     {
-        $wrappedConnection = $connection->getWrappedConnection();
-
-        // Attempt to commit while no transaction is running results in exception since PHP 8 + pdo_mysql combination
-        if ($wrappedConnection instanceof PDO && ! $wrappedConnection->inTransaction()) {
+        if (! self::inTransaction($connection)) {
             return;
         }
 
         $connection->commit();
+    }
+
+    public static function rollbackIfInTransaction(Connection $connection): void
+    {
+        if (! self::inTransaction($connection)) {
+            return;
+        }
+
+        $connection->rollBack();
+    }
+
+    private static function inTransaction(Connection $connection): bool
+    {
+        $wrappedConnection = $connection->getWrappedConnection();
+
+        /* Attempt to commit or rollback while no transaction is running
+           results in an exception since PHP 8 + pdo_mysql combination */
+        return ! $wrappedConnection instanceof PDO || $wrappedConnection->inTransaction();
     }
 }

--- a/lib/Doctrine/Migrations/Tracking/TableUpdater.php
+++ b/lib/Doctrine/Migrations/Tracking/TableUpdater.php
@@ -62,7 +62,7 @@ class TableUpdater
                 $this->connection->executeQuery($query);
             }
         } catch (Throwable $e) {
-            $this->connection->rollBack();
+            TransactionHelper::rollbackIfInTransaction($this->connection);
 
             throw $e;
         }

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -298,7 +298,7 @@ final class Executor implements ExecutorInterface
     ): void {
         if ($migration->isTransactional()) {
             //only rollback transaction if in transactional mode
-            $this->connection->rollBack();
+            TransactionHelper::rollbackIfInTransaction($this->connection);
         }
 
         if (! $migratorConfiguration->isDryRun()) {
@@ -331,7 +331,7 @@ final class Executor implements ExecutorInterface
 
         if ($migration->isTransactional()) {
             //only rollback transaction if in transactional mode
-            $this->connection->rollBack();
+            TransactionHelper::rollbackIfInTransaction($this->connection);
         }
 
         $version->setState(State::NONE);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1139

#### Summary

Similarly to what happens when attempting to commit an already closed
connection when combining PHP 8 and pdo_mysql, an error is thrown when
attempting to rollback. We use the same solution as for commit(), that
is we check that we actually are inside a transaction when possible to do so.



Fixes #1139

# How can I test this?



```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/doctrine-migrations
composer require doctrine/migrations "dev-rollback-iff-in-transaction as 2.3.3"
```
