### PR TITLE
Drop deprecated phpstan configuration options

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,14 +4,6 @@ parameters:
     paths:
         - %currentWorkingDirectory%/lib
         - %currentWorkingDirectory%/tests
-    autoload_directories:
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Finder/_features
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Finder/_files
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Finder/_regression
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Functional/_files
-    autoload_files:
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTestSource/Migrations/Version123.php
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/realpath.php
     ignoreErrors:
         - '~Unable to resolve the template type T in call to method static method Doctrine\\DBAL\\DriverManager\:\:getConnection\(\)~'
         - '~Call to method getVersion\(\) of deprecated class PackageVersions\\Versions\:.*~'


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | n/a

#### Summary
PHPStan warns about them, says they are probably no longer required.

```
⚠️  You're using a deprecated config option autoload_files. ⚠️️

You might not need it anymore - try removing it from your
configuration file and run PHPStan again.

If the analysis fails, there are now two distinct options
to choose from to replace autoload_files:
1) scanFiles - PHPStan will scan those for classes and functions
   definitions. PHPStan will not execute those files.
2) bootstrapFiles - PHPStan will execute these files to prepare
   the PHP runtime environment for the analysis.

Read more about this in PHPStan's documentation:
https://phpstan.org/user-guide/discovering-symbols

⚠️  You're using a deprecated config option autoload_directories. ⚠️️

You might not need it anymore - try removing it from your
configuration file and run PHPStan again.

If the analysis fails, replace it with scanDirectories.

```