### PR TITLE
Always use the `inTransaction()` method when possible in `TransactionHelper`

### DIFF
--- a/lib/Doctrine/Migrations/Tools/TransactionHelper.php
+++ b/lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tools;
 
 use Doctrine\DBAL\Connection;
-use PDO;
+
+use function method_exists;
 
 /**
  * @internal
@@ -36,6 +37,10 @@ final class TransactionHelper
 
         /* Attempt to commit or rollback while no transaction is running
            results in an exception since PHP 8 + pdo_mysql combination */
-        return ! $wrappedConnection instanceof PDO || $wrappedConnection->inTransaction();
+        if (method_exists($wrappedConnection, 'inTransaction')) {
+            return $wrappedConnection->inTransaction();
+        }
+
+        return true;
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Event\Listeners;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Event\Listeners\AutoCommitListener;
 use Doctrine\Migrations\Event\MigrationsEventArgs;
@@ -39,8 +40,13 @@ class AutoCommitListenerTest extends MigrationTestCase
     public function testListenerDoesFinalCommitWhenAutoCommitIsOff(): void
     {
         $this->conn->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
+        $this->conn->expects(self::once())
             ->method('isAutoCommit')
             ->willReturn(false);
+
         $this->conn->expects(self::once())
             ->method('commit');
 

--- a/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Tools;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\PDO\Connection as PDOConnection;
+use Doctrine\Migrations\Tools\TransactionHelper;
+use PHPUnit\Framework\TestCase;
+
+final class TransactionHelperTest extends TestCase
+{
+    /**
+     * @dataProvider getDriverConnectionClassesImplementingInTransactionMethod
+     */
+    public function testCommitIfInTransactionWithConnectionImplementingInTransactionMethod(string $driverConnectionFqcn, bool $commitExpected): void
+    {
+        $wrappedConnection = $this->createMock($driverConnectionFqcn);
+        $wrappedConnection->expects($this->once())
+            ->method('inTransaction')
+            ->willReturn($commitExpected);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($wrappedConnection);
+
+        $connection->expects($commitExpected ? $this->once() : $this->never())
+            ->method('commit');
+
+        TransactionHelper::commitIfInTransaction($connection);
+    }
+
+    public function testCommitIfInTransactionWithConnectionNotImplementingInTransactionMethod(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
+        $connection->expects($this->once())
+            ->method('commit');
+
+        TransactionHelper::commitIfInTransaction($connection);
+    }
+
+    /**
+     * @dataProvider getDriverConnectionClassesImplementingInTransactionMethod
+     */
+    public function testRollbackIfInTransactionWithConnectionImplementingInTransactionMethod(string $driverConnectionFqcn, bool $commitExpected): void
+    {
+        $wrappedConnection = $this->createMock($driverConnectionFqcn);
+        $wrappedConnection->expects($this->once())
+            ->method('inTransaction')
+            ->willReturn($commitExpected);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($wrappedConnection);
+
+        $connection->expects($commitExpected ? $this->once() : $this->never())
+            ->method('rollback');
+
+        TransactionHelper::rollbackIfInTransaction($connection);
+    }
+
+    public function testRollbackIfInTransactionWithConnectionNotImplementingInTransactionMethod(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
+        $connection->expects($this->once())
+            ->method('rollback');
+
+        TransactionHelper::rollbackIfInTransaction($connection);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getDriverConnectionClassesImplementingInTransactionMethod(): array
+    {
+        return [
+            [PDOConnection::class, true],
+            [PDOConnection::class, false],
+        ];
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
@@ -13,21 +13,23 @@ use PHPUnit\Framework\TestCase;
 final class TransactionHelperTest extends TestCase
 {
     /**
+     * @param class-string $driverConnectionFqcn
+     *
      * @dataProvider getDriverConnectionClassesImplementingInTransactionMethod
      */
     public function testCommitIfInTransactionWithConnectionImplementingInTransactionMethod(string $driverConnectionFqcn, bool $commitExpected): void
     {
         $wrappedConnection = $this->createMock($driverConnectionFqcn);
-        $wrappedConnection->expects($this->once())
+        $wrappedConnection->expects(self::once())
             ->method('inTransaction')
             ->willReturn($commitExpected);
 
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getWrappedConnection')
             ->willReturn($wrappedConnection);
 
-        $connection->expects($commitExpected ? $this->once() : $this->never())
+        $connection->expects($commitExpected ? self::once() : self::never())
             ->method('commit');
 
         TransactionHelper::commitIfInTransaction($connection);
@@ -36,32 +38,34 @@ final class TransactionHelperTest extends TestCase
     public function testCommitIfInTransactionWithConnectionNotImplementingInTransactionMethod(): void
     {
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getWrappedConnection')
             ->willReturn($this->createMock(DriverConnection::class));
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('commit');
 
         TransactionHelper::commitIfInTransaction($connection);
     }
 
     /**
+     * @param class-string $driverConnectionFqcn
+     *
      * @dataProvider getDriverConnectionClassesImplementingInTransactionMethod
      */
     public function testRollbackIfInTransactionWithConnectionImplementingInTransactionMethod(string $driverConnectionFqcn, bool $commitExpected): void
     {
         $wrappedConnection = $this->createMock($driverConnectionFqcn);
-        $wrappedConnection->expects($this->once())
+        $wrappedConnection->expects(self::once())
             ->method('inTransaction')
             ->willReturn($commitExpected);
 
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getWrappedConnection')
             ->willReturn($wrappedConnection);
 
-        $connection->expects($commitExpected ? $this->once() : $this->never())
+        $connection->expects($commitExpected ? self::once() : self::never())
             ->method('rollback');
 
         TransactionHelper::rollbackIfInTransaction($connection);
@@ -70,11 +74,11 @@ final class TransactionHelperTest extends TestCase
     public function testRollbackIfInTransactionWithConnectionNotImplementingInTransactionMethod(): void
     {
         $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('getWrappedConnection')
             ->willReturn($this->createMock(DriverConnection::class));
 
-        $connection->expects($this->once())
+        $connection->expects(self::once())
             ->method('rollback');
 
         TransactionHelper::rollbackIfInTransaction($connection);

--- a/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
@@ -85,7 +85,7 @@ final class TransactionHelperTest extends TestCase
     }
 
     /**
-     * @return mixed[]
+     * @return list<array{class-string<DriverConnection>, bool}>
      */
     public function getDriverConnectionClassesImplementingInTransactionMethod(): array
     {

--- a/tests/Doctrine/Migrations/Tests/Tracking/TableUpdaterTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tracking/TableUpdaterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Tracking;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
@@ -97,6 +98,10 @@ class TableUpdaterTest extends TestCase
             ->willReturn(['ALTER TABLE table_name ADD COLUMN executed_at DATETIME DEFAULT NULL']);
 
         $this->connection->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
+        $this->connection->expects(self::once())
             ->method('beginTransaction');
 
         $this->connection->expects(self::once())
@@ -172,6 +177,10 @@ class TableUpdaterTest extends TestCase
             ->method('getMigrateToSql')
             ->with($toSchema, $this->platform)
             ->willReturn(['ALTER TABLE table_name ADD COLUMN executed_at DATETIME DEFAULT NULL']);
+
+        $this->connection->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
 
         $this->connection->expects(self::once())
             ->method('beginTransaction');

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Version;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -63,6 +64,10 @@ class ExecutorTest extends TestCase
 
     public function testExecuteUp(): void
     {
+        $this->connection->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
         $this->outputWriter->expects(self::at(0))
             ->method('write')
             ->with("\n  <info>++</info> migrating <comment>001</comment>\n");
@@ -113,6 +118,10 @@ class ExecutorTest extends TestCase
      */
     public function executeUpShouldAppendDescriptionWhenItIsNotEmpty(): void
     {
+        $this->connection->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
         $this->outputWriter->expects(self::at(0))
             ->method('write')
             ->with("\n  <info>++</info> migrating <comment>001 (testing)</comment>\n");
@@ -130,6 +139,10 @@ class ExecutorTest extends TestCase
 
     public function testExecuteDown(): void
     {
+        $this->connection->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
         $this->outputWriter->expects(self::at(0))
             ->method('write')
             ->with("\n  <info>--</info> reverting <comment>001</comment>\n");
@@ -180,6 +193,10 @@ class ExecutorTest extends TestCase
      */
     public function executeDownShouldAppendDescriptionWhenItIsNotEmpty(): void
     {
+        $this->connection->expects(self::once())
+            ->method('getWrappedConnection')
+            ->willReturn($this->createMock(DriverConnection::class));
+
         $this->outputWriter->expects(self::at(0))
             ->method('write')
             ->with("\n  <info>--</info> reverting <comment>001 (testing)</comment>\n");


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement (or bug, it depends on the POV)
| BC Break     | no
| Fixed issues | -

#### Summary

As reported in getsentry/sentry-symfony#488, the check that has been introduced in #1104 and #1143 is assuming that if the driver connection is not an instance of `PDO` then the transaction should always be committed/rolled back. However, if the connection is decorated, the check will always fail and consequently the error that the check was meant to avoid will happen again. There has been a little discussion if the `Doctrine\DBAL\Driver\Connection::inTransaction()` method should be implemented so that it is the driver itself to define if a transaction is active and not the consumer and doctrine/dbal#4616 got opened. However, taking for granted that it will take some time to see it implemented, if it ever happens, this little workaround will solve the issue in the meanwhile.