### PR TITLE
Do not pass connection name to `PrimaryReadReplicaConnection::connect()`

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -198,7 +198,7 @@ final class TableMetadataStorage implements MetadataStorage
         }
 
         if ($this->connection instanceof PrimaryReadReplicaConnection) {
-            $this->connection->connect('master');
+            $this->connection->connect();
         }
 
         return $this->schemaManager->tablesExist([$this->configuration->getTableName()]);

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -198,7 +198,7 @@ final class TableMetadataStorage implements MetadataStorage
         }
 
         if ($this->connection instanceof PrimaryReadReplicaConnection) {
-            $this->connection->connect();
+            $this->connection->ensureConnectedToPrimary();
         }
 
         return $this->schemaManager->tablesExist([$this->configuration->getTableName()]);

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -83,8 +83,7 @@ class ExistingTableMetadataStorageTest extends TestCase
         $connection = $this->createMock(PrimaryReadReplicaConnection::class);
         $connection
             ->expects(self::atLeastOnce())
-            ->method('connect')
-            ->with('master');
+            ->method('connect');
 
         $connection
             ->expects(self::atLeastOnce())

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/ExistingTableMetadataStorageTest.php
@@ -83,7 +83,7 @@ class ExistingTableMetadataStorageTest extends TestCase
         $connection = $this->createMock(PrimaryReadReplicaConnection::class);
         $connection
             ->expects(self::atLeastOnce())
-            ->method('connect');
+            ->method('ensureConnectedToPrimary');
 
         $connection
             ->expects(self::atLeastOnce())


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1154 #1155 

#### Summary

Passing a connection name to `PrimaryReadReplicaConnection::connect()` will result in an exception being thrown.
This change will remove the `master` name from `TableMetadataStorage::isInitialized()` to prevent that exception.