### PR TITLE
Bugfix: all-or-nothing from configuration must not be ignored

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,6 +50,8 @@ jobs:
           coverage: "pcov"
           extensions: "pdo_sqlite"
           ini-values: "zend.assertions=1"
+          # Remove this line when a fix for is available https://github.com/box-project/box/issues/555
+          tools: "composer:v2.0.14"
 
       - name: "Download box"
         run: "./download-box.sh"

--- a/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
@@ -35,7 +35,7 @@ final class OrmSchemaProvider implements SchemaProvider
      */
     public function createSchema(): Schema
     {
-        /** @var array<int, ClassMetadata> $metadata */
+        /** @var array<int, ClassMetadata<object>> $metadata */
         $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
 
         if (count($metadata) === 0) {

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -73,8 +73,7 @@ final class MigrateCommand extends DoctrineCommand
                 'all-or-nothing',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Wrap the entire migration in a transaction.',
-                false
+                'Wrap the entire migration in a transaction.'
             )
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command executes a migration to a specified version or the latest available version:

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -22,7 +22,8 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
     {
         $timeAllQueries = $input->hasOption('query-time') ? (bool) $input->getOption('query-time') : false;
         $dryRun         = $input->hasOption('dry-run') ? (bool) $input->getOption('dry-run') : false;
-        $allOrNothing   = $input->hasOption('all-or-nothing') ? (bool) $input->getOption('all-or-nothing') : $this->configuration->isAllOrNothing();
+        $allOrNothing   = $input->hasOption('all-or-nothing') ? $input->getOption('all-or-nothing') : null;
+        $allOrNothing   = (bool) ($allOrNothing ?? $this->configuration->isAllOrNothing());
 
         return (new MigratorConfiguration())
             ->setDryRun($dryRun)

--- a/tests/Doctrine/Migrations/Tests/Provider/ClassMetadataFactory.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/ClassMetadataFactory.php
@@ -12,7 +12,7 @@ use function array_reverse;
 class ClassMetadataFactory extends BaseMetadataFactoryAlias
 {
     /**
-     * @return ClassMetadata[]
+     * @psalm-return list<ClassMetadata<object>>
      */
     public function getAllMetadata(): array
     {


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

all-or-nothing from config always replaced by default options from command