### PR TITLE
Check for all-or-nothing conflict in migrations

### DIFF
--- a/lib/Doctrine/Migrations/DbalMigrator.php
+++ b/lib/Doctrine/Migrations/DbalMigrator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\Exception\MigrationConfigurationConflict;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
 use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Tools\BytesFormatter;
@@ -65,6 +66,7 @@ class DbalMigrator implements Migrator
         $allOrNothing = $migratorConfiguration->isAllOrNothing();
 
         if ($allOrNothing) {
+            $this->assertAllMigrationsAreTransactional($migrationsPlan);
             $this->connection->beginTransaction();
         }
 
@@ -87,6 +89,15 @@ class DbalMigrator implements Migrator
         }
 
         return $sql;
+    }
+
+    private function assertAllMigrationsAreTransactional(MigrationPlanList $migrationsPlan): void
+    {
+        foreach ($migrationsPlan->getItems() as $plan) {
+            if (! $plan->getMigration()->isTransactional()) {
+                throw MigrationConfigurationConflict::migrationIsNotTransactional($plan->getMigration());
+            }
+        }
     }
 
     /**

--- a/lib/Doctrine/Migrations/Exception/MigrationConfigurationConflict.php
+++ b/lib/Doctrine/Migrations/Exception/MigrationConfigurationConflict.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Exception;
+
+use Doctrine\Migrations\AbstractMigration;
+use UnexpectedValueException;
+
+use function get_class;
+use function sprintf;
+
+final class MigrationConfigurationConflict extends UnexpectedValueException implements MigrationException
+{
+    public static function migrationIsNotTransactional(AbstractMigration $migration): self
+    {
+        return new self(sprintf(
+            <<<'EXCEPTION'
+Context: attempting to execute migrations with all-or-nothing enabled
+Problem: migration %s is marked as non-transactional
+Solution: disable all-or-nothing in configuration or by command-line option, or enable transactions for all migrations
+EXCEPTION
+                ,
+            get_class($migration)
+        ));
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Stub/NonTransactional/MigrationNonTransactional.php
+++ b/tests/Doctrine/Migrations/Tests/Stub/NonTransactional/MigrationNonTransactional.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Stub\NonTransactional;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class MigrationNonTransactional extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1166

#### Summary

Creates a new `MigrationConfigurationConflict` exception that is thrown when `all-or-nothing` is enabled but a migration uses `isTransactional() => false`.
