### PR TITLE
Deprecate silencing transaction-related errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "php": "^7.2 || ^8.0",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/dbal": "^2.11",
+        "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "psr/log": "^1.1.3",

--- a/lib/Doctrine/Migrations/Tools/TransactionHelper.php
+++ b/lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tools;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\Deprecations\Deprecation;
 use PDO;
 
 /**
@@ -15,6 +16,18 @@ final class TransactionHelper
     public static function commitIfInTransaction(Connection $connection): void
     {
         if (! self::inTransaction($connection)) {
+            Deprecation::trigger(
+                'doctrine/migrations',
+                'https://github.com/doctrine/migrations/issues/1169',
+                <<<'DEPRECATION'
+Context: trying to commit a transaction
+Problem: the transaction is already committed, relying on silencing is deprecated.
+Solution: override `AbstractMigration::isTransactional()` so that it returns false.
+Automate that by setting `transactional` to false in the configuration.
+More details at https://www.doctrine-project.org/projects/doctrine-migrations/en/3.2/explanation/implicit-commits.html
+DEPRECATION
+            );
+
             return;
         }
 
@@ -24,6 +37,18 @@ final class TransactionHelper
     public static function rollbackIfInTransaction(Connection $connection): void
     {
         if (! self::inTransaction($connection)) {
+            Deprecation::trigger(
+                'doctrine/migrations',
+                'https://github.com/doctrine/migrations/issues/1169',
+                <<<'DEPRECATION'
+Context: trying to rollback a transaction
+Problem: the transaction is already rolled back, relying on silencing is deprecated.
+Solution: override `AbstractMigration::isTransactional()` so that it returns false.
+Automate that by setting `transactional` to false in the configuration.
+More details at https://www.doctrine-project.org/projects/doctrine-migrations/en/3.2/explanation/implicit-commits.html
+DEPRECATION
+            );
+
             return;
         }
 

--- a/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Tools;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use Doctrine\Migrations\Tools\TransactionHelper;
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+final class TransactionHelperTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testItTriggersADeprecationWhenUseful(): void
+    {
+        $connection        = $this->createStub(Connection::class);
+        $wrappedConnection = $this->createStub(PDO::class);
+        $connection->method('getWrappedConnection')->willReturn($wrappedConnection);
+        $wrappedConnection->method('inTransaction')->willReturn(false);
+
+        $this->expectDeprecationWithIdentifier(
+            'https://github.com/doctrine/migrations/issues/1169'
+        );
+        TransactionHelper::commitIfInTransaction($connection);
+
+        $this->expectDeprecationWithIdentifier(
+            'https://github.com/doctrine/migrations/issues/1169'
+        );
+        TransactionHelper::rollbackIfInTransaction($connection);
+    }
+
+    public function testItDoesNotTriggerADeprecationWhenUseless(): void
+    {
+        $connection        = $this->createStub(Connection::class);
+        $wrappedConnection = $this->createStub(PDO::class);
+        $connection->method('getWrappedConnection')->willReturn($wrappedConnection);
+        $wrappedConnection->method('inTransaction')->willReturn(true);
+
+        $this->expectNoDeprecationWithIdentifier(
+            'https://github.com/doctrine/migrations/issues/1169'
+        );
+        TransactionHelper::commitIfInTransaction($connection);
+
+        $this->expectNoDeprecationWithIdentifier(
+            'https://github.com/doctrine/migrations/issues/1169'
+        );
+        TransactionHelper::rollbackIfInTransaction($connection);
+    }
+}


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #1169 

#### Summary

Some platforms do not support transactions for DDL statements, and
doctrine/migrations historically swipes the issue under the rug by not
letting uninformed users know about it. Since PHP 8, we even silence the
issue suddenly made visible by PDO. Let's stop doing that.

MySQL users should typically set transactional to false in their
configuration and manually edit the isTransactional method override
generated in their migrations to return true (or drop it entirely) if
they run DDL migrations and want those to be transactional.
