### PR TITLE
Skipped migration should not generate an error log

### DIFF
--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -270,7 +270,7 @@ final class DbalExecutor implements Executor
     private function logResult(Throwable $e, ExecutionResult $result, MigrationPlan $plan): void
     {
         if ($result->isSkipped()) {
-            $this->logger->error(
+            $this->logger->notice(
                 'Migration {version} skipped during {state}. Reason: "{reason}"',
                 [
                     'version' => (string) $plan->getVersion(),


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #1164 <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
Changed the log level to `NOTICE` for skipped migrations, according to #1164