### PR TITLE
implementing newSubset and unavailableSubset for migration lists

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/AvailableMigrationsList.php
+++ b/lib/Doctrine/Migrations/Metadata/AvailableMigrationsList.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\Exception\MigrationNotAvailable;
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Version\Version;
 
+use function array_filter;
 use function array_values;
 use function count;
 
@@ -80,5 +81,12 @@ final class AvailableMigrationsList implements Countable
         }
 
         throw MigrationNotAvailable::forVersion($version);
+    }
+
+    public function newSubset(ExecutedMigrationsList $executedMigrations): self
+    {
+        return new self(array_filter($this->getItems(), static function (AvailableMigration $migration) use ($executedMigrations): bool {
+            return ! $executedMigrations->hasMigration($migration->getVersion());
+        }));
     }
 }

--- a/lib/Doctrine/Migrations/Metadata/ExecutedMigrationsList.php
+++ b/lib/Doctrine/Migrations/Metadata/ExecutedMigrationsList.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\Exception\MigrationNotExecuted;
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Version\Version;
 
+use function array_filter;
 use function array_values;
 use function count;
 
@@ -81,5 +82,12 @@ final class ExecutedMigrationsList implements Countable
         }
 
         throw MigrationNotExecuted::new((string) $version);
+    }
+
+    public function unavailableSubset(AvailableMigrationsList $availableMigrations): self
+    {
+        return new self(array_filter($this->getItems(), static function (ExecutedMigration $migration) use ($availableMigrations): bool {
+            return ! $availableMigrations->hasMigration($migration->getVersion());
+        }));
     }
 }

--- a/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
+++ b/lib/Doctrine/Migrations/Version/CurrentMigrationStatusCalculator.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Version;
 
-use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
-use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
-
-use function array_filter;
 
 /**
  * The MigrationPlanCalculator is responsible for calculating the plan for migrating from the current
@@ -37,9 +33,7 @@ final class CurrentMigrationStatusCalculator implements MigrationStatusCalculato
         $executedMigrations = $this->metadataStorage->getExecutedMigrations();
         $availableMigration = $this->migrationPlanCalculator->getMigrations();
 
-        return new ExecutedMigrationsList(array_filter($executedMigrations->getItems(), static function (ExecutedMigration $migrationInfo) use ($availableMigration): bool {
-            return ! $availableMigration->hasMigration($migrationInfo->getVersion());
-        }));
+        return $executedMigrations->unavailableSubset($availableMigration);
     }
 
     public function getNewMigrations(): AvailableMigrationsList
@@ -47,8 +41,6 @@ final class CurrentMigrationStatusCalculator implements MigrationStatusCalculato
         $executedMigrations = $this->metadataStorage->getExecutedMigrations();
         $availableMigration = $this->migrationPlanCalculator->getMigrations();
 
-        return new AvailableMigrationsList(array_filter($availableMigration->getItems(), static function (AvailableMigration $migrationInfo) use ($executedMigrations): bool {
-            return ! $executedMigrations->hasMigration($migrationInfo->getVersion());
-        }));
+        return $availableMigration->newSubset($executedMigrations);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Metadata/AvailableMigrationListTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/AvailableMigrationListTest.php
@@ -9,6 +9,8 @@ use Doctrine\Migrations\Exception\MigrationNotAvailable;
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsList;
+use Doctrine\Migrations\Metadata\ExecutedMigration;
+use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 
@@ -118,5 +120,22 @@ class AvailableMigrationListTest extends TestCase
 
         self::assertEquals(new Version('A'), $m1->getVersion());
         self::assertSame($this->abstractMigration, $m1->getMigration());
+    }
+
+    public function testNewSubset(): void
+    {
+        $m1           = new AvailableMigration(new Version('A'), $this->abstractMigration);
+        $m2           = new AvailableMigration(new Version('B'), $this->abstractMigration);
+        $m3           = new AvailableMigration(new Version('C'), $this->abstractMigration);
+        $availableSet = new AvailableMigrationsList([$m1, $m2, $m3]);
+
+        $executedSet = new ExecutedMigrationsList([
+            new ExecutedMigration(new Version('A')),
+            new ExecutedMigration(new Version('B')),
+        ]);
+
+        $newSubset = $availableSet->newSubset($executedSet);
+        self::assertCount(1, $newSubset);
+        self::assertTrue($newSubset->hasMigration(new Version('C')));
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/doctrine/DoctrineMigrationsBundle/pull/421#discussion_r662788109

#### Summary

As as result of @greg0ire review in https://github.com/doctrine/DoctrineMigrationsBundle/pull/421 I added
* ExecutedMigrationList->unavailableSubset(AvailableMigrationList)
* AvailableMigrationList->newSubset(ExecutedMigrationList)

Includes tests and refactoring of CurrentMigrationStatusCalculator