### PR TITLE
Add dev dependency on symfony/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpstan/phpstan-symfony": "^0.12",
         "phpunit/phpunit": "^8.5 || ^9.4",
+        "symfony/cache": "^5.3",
         "symfony/process": "^3.4 || ^4.0 || ^5.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION


<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | n/a

#### Summary
`doctrine/cache` is being sunset in favor of `psr/cache`, which
`symfony/cache` implements.
