### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpstan/phpstan-symfony": "^0.12",
         "phpunit/phpunit": "^8.5 || ^9.4",
-        "symfony/cache": "^5.3",
+        "symfony/cache": "^3.4 || ^4.0 || ^5.0",
         "symfony/process": "^3.4 || ^4.0 || ^5.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0"
     },


### PR DESCRIPTION
Hello, i'm not sure but i think we should use `symfony/cache` version like other dependencies ?

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

I think we should also use symfony/cache version in 3.4 and 4 version, but i'm not sure.
WDYT @greg0ire ?
