### PR TITLE
Fix "transactional" configuration

### DIFF
--- a/lib/Doctrine/Migrations/Configuration/Migration/ConfigurationArray.php
+++ b/lib/Doctrine/Migrations/Configuration/Migration/ConfigurationArray.php
@@ -62,7 +62,7 @@ final class ConfigurationArray implements ConfigurationLoader
                 $configuration->setAllOrNothing(is_bool($value) ? $value : BooleanStringFormatter::toBoolean($value, false));
             },
             'transactional' => static function ($value, Configuration $configuration): void {
-                $configuration->setAllOrNothing(is_bool($value) ? $value : BooleanStringFormatter::toBoolean($value, true));
+                $configuration->setTransactional(is_bool($value) ? $value : BooleanStringFormatter::toBoolean($value, true));
             },
             'check_database_platform' =>  static function ($value, Configuration $configuration): void {
                 $configuration->setCheckDatabasePlatform(is_bool($value) ? $value : BooleanStringFormatter::toBoolean($value, false));

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,7 +11,7 @@ parameters:
             message: '~^Call to function in_array\(\) requires parameter #3 to be true\.$~'
             path: %currentWorkingDirectory%/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
         -
-            message: '~^Variable property access on mixed\.$~'
+            message: '~^Variable property access on SimpleXMLElement\.$~'
             path: %currentWorkingDirectory%/lib/Doctrine/Migrations/Configuration/Migration/XmlFile.php
         -
             message: '~^Call to function is_bool\(\) with bool will always evaluate to true\.$~'


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes but edge-case
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The PR https://github.com/doctrine/migrations/pull/1157 introduced the "transactional" configuration but it doesn't change the configuration correctly. `$configuration->isTransactional()` is always true.
