### PR TITLE
Fix assert for configuration helper in AbstractCommand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "phpstan/phpstan-phpunit": "^0.12",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+        "symfony/cache": "^4.4. || ^5.3",
         "symfony/process": "^3.4||^4.0||^5.0",
         "symfony/yaml": "^3.4||^4.0||^5.0"
     },

--- a/lib/Doctrine/Migrations/Configuration/AbstractFileConfiguration.php
+++ b/lib/Doctrine/Migrations/Configuration/AbstractFileConfiguration.php
@@ -96,7 +96,7 @@ abstract class AbstractFileConfiguration extends Configuration
     {
         foreach ($config as $configurationKey => $configurationValue) {
             if (! in_array($configurationKey, self::ALLOWED_CONFIGURATION_KEYS, true)) {
-                throw InvalidConfigurationKey::new($configurationKey);
+                throw InvalidConfigurationKey::new((string) $configurationKey);
             }
         }
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/AbstractCommand.php
@@ -116,7 +116,7 @@ abstract class AbstractCommand extends Command
                 $helperSet = $this->getHelperSet();
                 assert($helperSet !== null);
                 $configHelper = $helperSet->get('configuration');
-                assert($configHelper instanceof ConfigurationHelper);
+                assert($configHelper instanceof ConfigurationHelperInterface);
             } else {
                 $configHelper = new ConfigurationHelper(
                     $this->getConnection($input),

--- a/tests/Doctrine/Migrations/Tests/Provider/ClassMetadataFactory.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/ClassMetadataFactory.php
@@ -12,7 +12,7 @@ use function array_reverse;
 class ClassMetadataFactory extends BaseMetadataFactoryAlias
 {
     /**
-     * @return ClassMetadata[]
+     * @return list<ClassMetadata<object>>
      */
     public function getAllMetadata(): array
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1115 

#### Summary

This fixes a problem introduced in ef842cfb1944606148159e724d8ae7e7845cf4b0 which made it impossible to use an own implementation of `ConfigurationHelperInterface`.
