### PR TITLE
Look harder for a native connection

### DIFF
--- a/phpstan-common.neon.dist
+++ b/phpstan-common.neon.dist
@@ -25,6 +25,11 @@ parameters:
             path: tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
         - '~Call to method getVersion\(\) of deprecated class PackageVersions\\Versions\:.*~'
 
+	# https://github.com/phpstan/phpstan/issues/5982
+        -
+            message: '~^Cannot call method getWrappedConnection\(\) on class-string\|object\.~'
+            path: lib/Doctrine/Migrations/Tools/TransactionHelper.php
+
         # Requires PHPUnit 9
         -
             message: '~assert.*Reg~'

--- a/phpstan-common.neon.dist
+++ b/phpstan-common.neon.dist
@@ -1,28 +1,28 @@
 parameters:
     level: 7
     paths:
-        - %currentWorkingDirectory%/lib
-        - %currentWorkingDirectory%/tests
+        - lib
+        - tests
     excludePaths:
-        - %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTestSource/Migrations/Version123.php
+        - tests/Doctrine/Migrations/Tests/Configuration/ConfigurationTestSource/Migrations/Version123.php
     ignoreErrors:
         - '~Variable method call on Doctrine\\Migrations\\AbstractMigration~'
         -
             message: '~^Call to function in_array\(\) requires parameter #3 to be true\.$~'
-            path: %currentWorkingDirectory%/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
+            path: lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
         -
             message: '~^Variable property access on SimpleXMLElement\.$~'
-            path: %currentWorkingDirectory%/lib/Doctrine/Migrations/Configuration/Migration/XmlFile.php
+            path: lib/Doctrine/Migrations/Configuration/Migration/XmlFile.php
 
         -
             message: '~^Call to function is_bool\(\) with bool will always evaluate to true\.$~'
-            path: %currentWorkingDirectory%/lib/Doctrine/Migrations/InlineParameterFormatter.php
+            path: lib/Doctrine/Migrations/InlineParameterFormatter.php
         -
             message: '~^Call to an undefined method Symfony\\Component\\Console\\Output\\OutputInterface\:\:getErrorOutput\(\)\.$~'
-            path: %currentWorkingDirectory%/lib/Doctrine/Migrations/Tools/Console/ConsoleLogger.php
+            path: lib/Doctrine/Migrations/Tools/Console/ConsoleLogger.php
         -
             message: '~^Method Doctrine\\Migrations\\Tests\\Stub\\DoctrineRegistry::getService\(\) should return Doctrine\\Persistence\\ObjectManager but returns Doctrine\\DBAL\\Connection\|Doctrine\\ORM\\EntityManager~'
-            path: %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
+            path: tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
         - '~Call to method getVersion\(\) of deprecated class PackageVersions\\Versions\:.*~'
 
         # Requires PHPUnit 9

--- a/tests/Doctrine/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Event\Listeners;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\Migrations\Event\Listeners\AutoCommitListener;
 use Doctrine\Migrations\Event\MigrationsEventArgs;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
@@ -51,9 +52,9 @@ class AutoCommitListenerTest extends MigrationTestCase
 
     protected function setUp(): void
     {
-        $this->conn = $this->getMockBuilder(Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->conn       = $this->createStub(Connection::class);
+        $driverConnection = $this->createStub(DriverConnection::class);
+        $this->conn->method('getWrappedConnection')->willReturn($driverConnection);
 
         $this->listener = new AutoCommitListener();
     }

--- a/tests/Doctrine/Migrations/Tests/MigratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigratorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DbalMigrator;
 use Doctrine\Migrations\EventDispatcher;
@@ -54,7 +55,10 @@ class MigratorTest extends MigrationTestCase
 
     protected function setUp(): void
     {
-        $this->conn   = $this->createMock(Connection::class);
+        $this->conn       = $this->createMock(Connection::class);
+        $driverConnection = $this->createStub(DriverConnection::class);
+        $this->conn->method('getWrappedConnection')->willReturn($driverConnection);
+
         $this->config = new Configuration();
 
         $this->migratorConfiguration = new MigratorConfiguration();

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests\Version;
 
 use Doctrine\Common\EventManager;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
 use Doctrine\Migrations\EventDispatcher;
 use Doctrine\Migrations\Events;
 use Doctrine\Migrations\Metadata\MigrationPlan;
@@ -518,8 +519,10 @@ class ExecutorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->metadataStorage    = $this->createMock(MetadataStorage::class);
-        $this->connection         = $this->createMock(Connection::class);
+        $this->metadataStorage = $this->createMock(MetadataStorage::class);
+        $this->connection      = $this->createMock(Connection::class);
+        $driverConnection      = $this->createStub(DriverConnection::class);
+        $this->connection->method('getWrappedConnection')->willReturn($driverConnection);
         $this->schemaDiffProvider = $this->createMock(SchemaDiffProvider::class);
         $this->parameterFormatter = $this->createMock(ParameterFormatter::class);
 


### PR DESCRIPTION
doctrine/dbal 3 switches from inheritance to composition but still
provides an accessor for PDO, and it is named like the method in
Connection.
Unwrapping until that method no longer exists should give the innermost
connection regardless of the DBAL version

I hade to adapt some tests to ensure `getWrappedConnection` returns an object.

Fixes #1209

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/migrations
composer require doctrine/migrations "dev-fix-compat-with-dbal-3 as 3.3.0"
```
