### PR TITLE
Fix PhpFile FQCN in Advanced Configuration example

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -321,8 +321,8 @@ out of the root of your project.
     require 'vendor/autoload.php';
 
     use Doctrine\DBAL\DriverManager;
-    use Doctrine\Migrations\Configuration\Configuration\PhpFile;
     use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
+    use Doctrine\Migrations\Configuration\Migration\PhpFile;
     use Doctrine\Migrations\DependencyFactory;
 
     $config = new PhpFile('migrations.php'); // Or use one of the Doctrine\Migrations\Configuration\Configuration\* loaders


### PR DESCRIPTION
Last namespace segment should be Migration rather than Configuration.