### PR TITLE
Update configuration.rst

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -147,7 +147,7 @@ Here are details about what each configuration option does:
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 | check_database_platform    | no         | true                         | Whether to add a database platform check at the beginning of the generated code. |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| organize_migrations        | no         | ``none``                     | Whether to organize migration classes under year (``year``) or year and month (``year_and_month``) subdirectories. |
+| organize_migrations        | no         | ``none``                     | Whether to organize migration classes under year (``BY_YEAR``) or year and month (``BY_YEAR_AND_MONTH``) subdirectories. |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 | connection                 | no         | null                         | The named connection to use (available only when ConnectionRegistryConnection is used). |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+


### PR DESCRIPTION
fix possioble option values for organize_migrations when organizing under year or year and month.
See https://symfony.com/bundles/DoctrineMigrationsBundle/current/index.html
```
    # Possible values: "BY_YEAR", "BY_YEAR_AND_MONTH", false
    organize_migrations: false
```


When using `year_and_month` or `year` option, I've got   'Invalid organize migrations mode value "year_and_month"' error.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->

fix possioble option values for organize_migrations when organizing under year or year and month.
See https://symfony.com/bundles/DoctrineMigrationsBundle/current/index.html
```
    # Possible values: "BY_YEAR", "BY_YEAR_AND_MONTH", false
    organize_migrations: false
```
