### PR TITLE
Whitelist Composer plugins used in this repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,11 @@
         "symfony/yaml": "Allows the use of yaml for migration configuration files."
     },
     "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "ergebnis/composer-normalize": true
+        },
         "sort-packages": true
     },
     "extra": {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

Composer 2.2 will ask us to enable Composer plugins when running `composer install`. This PR suggests to explicitly whitelist all plugins that are currently listed as dependencies in composer.json. This should make contributing to this repository less annoying.
