### PR TITLE
Replace composer/package-versions-deprecated with composer-runtime-api

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,10 +59,6 @@ jobs:
       - name: "Download box"
         run: "./download-box.sh"
 
-      - name: "Downgrade Composer"
-        run: "composer self-update --1"
-        if: "${{ matrix.deps == 'lowest' }}"
-
       - name: "Require the right DBAL version"
         run: "composer require doctrine/dbal:${{ matrix.dbal-version }} --no-update"
         if: "${{ matrix.dbal-version }}"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "composer/package-versions-deprecated": "^1.8",
+        "composer-runtime-api": "^2",
         "doctrine/dbal": "^2.11 || ^3.0",
         "doctrine/deprecations": "^0.5.3",
         "doctrine/event-manager": "^1.0",

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console;
 
+use Composer\InstalledVersions;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
 use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
@@ -24,11 +25,11 @@ use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
 use Doctrine\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
-use PackageVersions\Versions;
 use RuntimeException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 
+use function assert;
 use function file_exists;
 use function getcwd;
 use function is_readable;
@@ -99,7 +100,9 @@ class ConsoleRunner
     /** @param DoctrineCommand[] $commands */
     public static function createApplication(array $commands = [], ?DependencyFactory $dependencyFactory = null): Application
     {
-        $cli = new Application('Doctrine Migrations', Versions::getVersion('doctrine/migrations'));
+        $version = InstalledVersions::getVersion('doctrine/migrations');
+        assert($version !== null);
+        $cli = new Application('Doctrine Migrations', $version);
         $cli->setCatchExceptions(true);
         self::addCommands($cli, $dependencyFactory);
         $cli->addCommands($commands);

--- a/phpstan-common.neon.dist
+++ b/phpstan-common.neon.dist
@@ -23,7 +23,6 @@ parameters:
         -
             message: '~^Method Doctrine\\Migrations\\Tests\\Stub\\DoctrineRegistry::getService\(\) should return Doctrine\\Persistence\\ObjectManager but returns Doctrine\\DBAL\\Connection\|Doctrine\\ORM\\EntityManager~'
             path: tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
-        - '~Call to method getVersion\(\) of deprecated class PackageVersions\\Versions\:.*~'
 
 	# https://github.com/phpstan/phpstan/issues/5982
         -


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Composer 2.2 requires an opt-in for plugins. So depending on the legacy plugin adds some annoyance for all users of the package.
This is dropping support for Composer 1, which is why I submit it for 3.4.x-dev rather than 3.3.x-dev.

The same change is already merged in DBAL 3.3.x-dev and there is an open PR for the ORM.
See https://github.com/symfony/symfony/issues/44726 for a discussion about that package.
