### PR TITLE
Stop maintaining 2.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -38,7 +38,8 @@
         {
             "name": "2.3",
             "branchName": "2.3.x",
-            "slug": "2.3"
+            "slug": "2.3",
+            "maintained": false
         },
         {
             "name": "2.2",


### PR DESCRIPTION
It's time.

![Screenshot 2022-01-12 at 22-15-54 Install Statistics - doctrine migrations - Packagist](https://user-images.githubusercontent.com/657779/149222616-d27a1bbb-1bd1-47a6-90d7-1a4aedc86b7f.png)

The last 2.x release was this summer, I think it's fair to say it's stable now.