### PR TITLE
Bump symfony/cache to a safe version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpstan/phpstan-symfony": "^0.12",
         "phpunit/phpunit": "^8.5 || ^9.4",
-        "symfony/cache": "^3.4.26 || ~4.1.12 || ^4.2.7 || ^5.0 || ^6.0",
+        "symfony/cache": "^3.4.26 || ^4.2.12 || ^5.0 || ^6.0",
         "symfony/process": "^3.4 || ^4.0 || ^5.0 || ^6.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },


### PR DESCRIPTION
CVE-2019-18889 says versions ranging from 4.0.0 to 4.2.12 are
vulnerable.