### PR TITLE
Fully address Comparator constructor deprecation

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -26,6 +26,7 @@ use InvalidArgumentException;
 
 use function array_change_key_case;
 use function floatval;
+use function method_exists;
 use function round;
 use function sprintf;
 use function strlen;
@@ -184,7 +185,9 @@ final class TableMetadataStorage implements MetadataStorage
             return null;
         }
 
-        $comparator   = new Comparator();
+        $comparator   = method_exists($this->schemaManager, 'createComparator') ?
+            $this->schemaManager->createComparator() :
+            new Comparator();
         $currentTable = $this->schemaManager->listTableDetails($this->configuration->getTableName());
         $diff         = $comparator->diffTable($currentTable, $expectedTable);
 

--- a/phpstan-common.neon.dist
+++ b/phpstan-common.neon.dist
@@ -24,7 +24,7 @@ parameters:
             message: '~^Method Doctrine\\Migrations\\Tests\\Stub\\DoctrineRegistry::getService\(\) should return Doctrine\\Persistence\\ObjectManager but returns Doctrine\\DBAL\\Connection\|Doctrine\\ORM\\EntityManager~'
             path: tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
 
-	# https://github.com/phpstan/phpstan/issues/5982
+        # https://github.com/phpstan/phpstan/issues/5982
         -
             message: '~^Cannot call method getWrappedConnection\(\) on class-string\|object\.~'
             path: lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -34,6 +34,7 @@ parameters:
             message: '~assert.*Reg~'
             paths:
                 - tests/Doctrine/Migrations/Tests/Generator/ClassNameGeneratorTest.php
+
 
     symfony:
             console_application_loader: %currentWorkingDirectory%/tests/Doctrine/Migrations/Tests/doctrine-migrations-phpstan-app.php

--- a/phpstan-dbal-3.neon.dist
+++ b/phpstan-dbal-3.neon.dist
@@ -31,6 +31,15 @@ parameters:
                 - lib/Doctrine/Migrations/Provider/DBALSchemaDiffProvider.php
 
         -
+            message: '~Call to deprecated method getWrappedConnection~'
+            paths:
+                - tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+
+        -
+            message: "~Call to function method_exists.*'getNativeConnection' will always evaluate to true.~"
+            path: tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+
+        -
             message: "~Call to function method_exists.*'createComparator' will always evaluate to true.~"
             paths:
                 - lib/Doctrine/Migrations/Generator/DiffGenerator.php

--- a/phpstan-dbal-3.neon.dist
+++ b/phpstan-dbal-3.neon.dist
@@ -44,7 +44,9 @@ parameters:
             paths:
                 - lib/Doctrine/Migrations/Generator/DiffGenerator.php
                 - lib/Doctrine/Migrations/Provider/DBALSchemaDiffProvider.php
+                - lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
                 - tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
+                - tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
 
         # That method will no longer be static in the future
         -

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -27,6 +27,7 @@ use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 
+use function method_exists;
 use function sprintf;
 
 class TableMetadataStorageTest extends TestCase
@@ -216,9 +217,14 @@ class TableMetadataStorageTest extends TestCase
         $config     = new TableMetadataStorageConfiguration();
         $executedAt = new DateTimeImmutable('2010-01-05 10:30:21');
 
+        $connection = $this->getSqliteConnection();
+        $pdo        = method_exists($connection, 'getNativeConnection')
+            ? $connection->getNativeConnection()
+            : $connection->getWrappedConnection();
+
         $connection = $this->getMockBuilder(Connection::class)
             ->setConstructorArgs([
-                ['pdo' => $this->getSqliteConnection()->getWrappedConnection()],
+                ['pdo' => $pdo],
                 new SQLiteDriver(),
             ])
             ->onlyMethods(['insert'])


### PR DESCRIPTION
[It seems that currently, this package is still not using platform-aware comparison](https://github.com/doctrine/migrations/issues/1191#issuecomment-1024518884).
I know this change is not sufficient for that to happen, since something needs to be done on the DBAL side,
and I don't know how necessary it is. One thing is for sure though, it addresses a deprecation.

Note that this is probably not worth releasing until a fix for https://github.com/doctrine/dbal/issues/5216 is released and there is a PR on this repository to take advantage of the new API.