### PR TITLE
Leverage `getNativeConnection()` when checking the transaction state

### DIFF
--- a/lib/Doctrine/Migrations/Tools/TransactionHelper.php
+++ b/lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tools;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\Deprecations\Deprecation;
+use LogicException;
 use PDO;
 
 use function method_exists;
@@ -59,13 +60,30 @@ DEPRECATION
 
     private static function inTransaction(Connection $connection): bool
     {
+        $innermostConnection = self::getInnerConnection($connection);
+
+        /* Attempt to commit or rollback while no transaction is running
+           results in an exception since PHP 8 + pdo_mysql combination */
+        return ! $innermostConnection instanceof PDO || $innermostConnection->inTransaction();
+    }
+
+    /**
+     * @return object|resource|null
+     */
+    private static function getInnerConnection(Connection $connection)
+    {
+        if (method_exists($connection, 'getNativeConnection')) {
+            try {
+                return $connection->getNativeConnection();
+            } catch (LogicException $e) {
+            }
+        }
+
         $innermostConnection = $connection;
         while (method_exists($innermostConnection, 'getWrappedConnection')) {
             $innermostConnection = $innermostConnection->getWrappedConnection();
         }
 
-        /* Attempt to commit or rollback while no transaction is running
-           results in an exception since PHP 8 + pdo_mysql combination */
-        return ! $innermostConnection instanceof PDO || $innermostConnection->inTransaction();
+        return $innermostConnection;
     }
 }

--- a/phpstan-dbal-2.neon.dist
+++ b/phpstan-dbal-2.neon.dist
@@ -33,3 +33,5 @@ parameters:
                 - tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
                 - tests/Doctrine/Migrations/Tests/Provider/EmptySchemaProviderTest.php
                 - tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+
+        - '~Trying to mock an undefined method getNativeConnection\(\) on class Doctrine\\DBAL\\Connection~'

--- a/phpstan-dbal-3.neon.dist
+++ b/phpstan-dbal-3.neon.dist
@@ -37,7 +37,10 @@ parameters:
 
         -
             message: "~Call to function method_exists.*'getNativeConnection' will always evaluate to true.~"
-            path: tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+            paths:
+                - lib/Doctrine/Migrations/Tools/TransactionHelper.php
+                - tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+                - tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
 
         -
             message: "~Call to function method_exists.*'createComparator' will always evaluate to true.~"
@@ -52,5 +55,3 @@ parameters:
         -
             message: '~deprecated.*DebugStack~'
             path: tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
-
-        - "~Call to function method_exists\\(\\) with.*\\Connection.*and 'getNativeConnection' will always evaluate to true~"

--- a/phpstan-dbal-3.neon.dist
+++ b/phpstan-dbal-3.neon.dist
@@ -48,14 +48,9 @@ parameters:
                 - tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
                 - tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
 
-        # That method will no longer be static in the future
-        -
-            message: '~Dynamic call to static method Doctrine\\DBAL\\Schema\\Comparator\:\:compareSchemas\(\)\.~'
-            paths:
-                - lib/Doctrine/Migrations/Generator/DiffGenerator.php
-                - lib/Doctrine/Migrations/Provider/DBALSchemaDiffProvider.php
-
         # Switch to Logging\Connection after dropping compatibility with DBAL 2
         -
             message: '~deprecated.*DebugStack~'
             path: tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+
+        - "~Call to function method_exists\\(\\) with.*\\Connection.*and 'getNativeConnection' will always evaluate to true~"

--- a/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/TransactionHelperTest.php
@@ -10,6 +10,8 @@ use Doctrine\Migrations\Tools\TransactionHelper;
 use PDO;
 use PHPUnit\Framework\TestCase;
 
+use function method_exists;
+
 final class TransactionHelperTest extends TestCase
 {
     use VerifyDeprecations;
@@ -18,7 +20,13 @@ final class TransactionHelperTest extends TestCase
     {
         $connection        = $this->createStub(Connection::class);
         $wrappedConnection = $this->createStub(PDO::class);
-        $connection->method('getWrappedConnection')->willReturn($wrappedConnection);
+
+        if (method_exists(Connection::class, 'getNativeConnection')) {
+            $connection->method('getNativeConnection')->willReturn($wrappedConnection);
+        } else {
+            $connection->method('getWrappedConnection')->willReturn($wrappedConnection);
+        }
+
         $wrappedConnection->method('inTransaction')->willReturn(false);
 
         $this->expectDeprecationWithIdentifier(
@@ -36,7 +44,13 @@ final class TransactionHelperTest extends TestCase
     {
         $connection        = $this->createStub(Connection::class);
         $wrappedConnection = $this->createStub(PDO::class);
-        $connection->method('getWrappedConnection')->willReturn($wrappedConnection);
+
+        if (method_exists(Connection::class, 'getNativeConnection')) {
+            $connection->method('getNativeConnection')->willReturn($wrappedConnection);
+        } else {
+            $connection->method('getWrappedConnection')->willReturn($wrappedConnection);
+        }
+
         $wrappedConnection->method('inTransaction')->willReturn(true);
 
         $this->expectNoDeprecationWithIdentifier(


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1247

#### Summary

Fixes #1247 by using `getNativeConnection`
