### PR TITLE
Revert "Avoid Composer 2.1.0"

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,8 +46,6 @@ jobs:
           coverage: "pcov"
           extensions: "pdo_sqlite"
           ini-values: "zend.assertions=1"
-          # Remove this line when a fix for is available https://github.com/box-project/box/issues/555
-          tools: "composer:v2.0.14"
 
       - name: "Download box"
         run: "./download-box.sh"

--- a/download-box.sh
+++ b/download-box.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 if [ ! -f box.phar ]; then
-    wget https://github.com/box-project/box/releases/download/3.11.0/box.phar -O box.phar
+    wget https://github.com/box-project/box/releases/download/3.16.0/box.phar -O box.phar
 fi


### PR DESCRIPTION
This reverts commit 6cf77699469fc653ae5a3f9a0325b8f6281d814b, because a
fix has been merged.
