### PR TITLE
Fix tests for Persistence 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-pdo_sqlite": "*",
         "doctrine/coding-standard": "^9",
         "doctrine/orm": "^2.6",
-        "doctrine/persistence": "^2.0",
+        "doctrine/persistence": "^2 || ^3",
         "doctrine/sql-formatter": "^1.0",
         "ergebnis/composer-normalize": "^2.9",
         "phpstan/phpstan": "^1.5",

--- a/tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
+++ b/tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
@@ -7,11 +7,11 @@ namespace Doctrine\Migrations\Tests\Stub;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\AbstractManagerRegistry;
+use Doctrine\Persistence\Proxy;
 use Exception;
 
 use function array_combine;
 use function array_keys;
-use function key;
 
 class DoctrineRegistry extends AbstractManagerRegistry
 {
@@ -27,21 +27,16 @@ class DoctrineRegistry extends AbstractManagerRegistry
      */
     public function __construct(array $connections = [], array $realEntityManagers = [])
     {
-        /**
-         * @var string[] $connectionNames
-         */
-        $connectionNames = array_keys($connections);
-        /**
-         * @var string[] $realEntityManagerNames
-         */
+        $connectionNames        = array_keys($connections);
         $realEntityManagerNames = array_keys($realEntityManagers);
+
         parent::__construct(
             'some_registry',
             array_combine($connectionNames, $connectionNames),
             array_combine($realEntityManagerNames, $realEntityManagerNames),
-            key($connections) ?? null,
-            key($realEntityManagers) ?? null,
-            'Doctrine\Persistence\Proxy'
+            $connectionNames[0] ?? 'default',
+            $realEntityManagerNames[0] ?? 'default',
+            Proxy::class
         );
         $this->realEntityManagers = $realEntityManagers;
         $this->connections        = $connections;


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | N/A

#### Summary

This PR enables the test suite to run with doctrine/persistence 3. Note that the CI currently won't pick up Persistence 3 because that would require a stable release of ORM 2.12.
