### PR TITLE
fix testing on php 7.4 with the lowest composer dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
         dependencies:
           - "highest"
         include:
-          - deps: "lowest"
+          - dependencies: "lowest"
             php-version: "7.4"
 
     steps:


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | 
#### Summary

Looks to have been broken since https://github.com/doctrine/migrations/pull/1133
