### PR TITLE
Insert/delete sql queries for metadata table during dry-run and write-sql

### DIFF
--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -14,10 +14,12 @@ interface MetadataStorage
 
     public function getExecutedMigrations(): ExecutedMigrationsList;
 
+    public function complete(ExecutionResult $result): void;
+
+    public function reset(): void;
+
     /**
      * @return Query[]
      */
-    public function complete(ExecutionResult $result, bool $dryRun = false): array;
-
-    public function reset(): void;
+    public function getSql(ExecutionResult $result): array;
 }

--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -21,5 +21,5 @@ interface MetadataStorage
     /**
      * @return Query[]
      */
-    public function getSql(ExecutionResult $result): array;
+    public function getSql(ExecutionResult $result): iterable;
 }

--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Metadata\Storage;
 
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\ExecutionResult;
 
 interface MetadataStorage
@@ -13,7 +14,10 @@ interface MetadataStorage
 
     public function getExecutedMigrations(): ExecutedMigrationsList;
 
-    public function complete(ExecutionResult $result, bool $dry_run = false) : array;
+    /**
+     * @return Query[]
+     */
+    public function complete(ExecutionResult $result, bool $dryRun = false): array;
 
     public function reset(): void;
 }

--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -8,6 +8,9 @@ use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\ExecutionResult;
 
+/**
+ * @method iterable<Query> getSql(ExecutionResult $result);
+ */
 interface MetadataStorage
 {
     public function ensureInitialized(): void;
@@ -17,9 +20,4 @@ interface MetadataStorage
     public function complete(ExecutionResult $result): void;
 
     public function reset(): void;
-
-    /**
-     * @return Query[]
-     */
-    public function getSql(ExecutionResult $result): iterable;
 }

--- a/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/MetadataStorage.php
@@ -13,7 +13,7 @@ interface MetadataStorage
 
     public function getExecutedMigrations(): ExecutedMigrationsList;
 
-    public function complete(ExecutionResult $migration): void;
+    public function complete(ExecutionResult $result, bool $dry_run = false) : array;
 
     public function reset(): void;
 }

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -17,6 +17,7 @@ use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\MigrationsRepository;
+use Doctrine\Migrations\Query\Query;
 use Doctrine\Migrations\Version\Comparator as MigrationsComparator;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
@@ -124,25 +125,44 @@ final class TableMetadataStorage implements MetadataStorage
         );
     }
 
-    public function complete(ExecutionResult $result): void
+    public function complete(ExecutionResult $result, bool $dry_run = false): array
     {
-        $this->checkInitialization();
+        $sql_queries = [];
+        if ($dry_run) {
+            $sql_queries[] = new Query('-- Version ' . (string) $result->getVersion() . ' update table metadata');
+            if ($result->getDirection() === Direction::DOWN) {
+                $delete_query = 'DELETE FROM ' . $this->configuration->getTableName() . ' WHERE ';
+                $delete_query .= $this->configuration->getVersionColumnName() . ' = ' . $this->connection->quote((string) $result->getVersion());
 
-        if ($result->getDirection() === Direction::DOWN) {
-            $this->connection->delete($this->configuration->getTableName(), [
-                $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
-            ]);
+                $sql_queries[] = new Query($delete_query);
+            } else {
+                $insert_query = 'INSERT INTO ' . $this->configuration->getTableName();
+                $insert_query .= ' (' . $this->configuration->getVersionColumnName() . ', ' . $this->configuration->getExecutedAtColumnName() . ', ' . $this->configuration->getExecutionTimeColumnName() . ')';
+                $insert_query .= ' VALUES (' . $this->connection->quote((string) $result->getVersion()) . ', NOW(), 0)';
+
+                $sql_queries[] = new Query($insert_query);
+            }
         } else {
-            $this->connection->insert($this->configuration->getTableName(), [
-                $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
-                $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
-                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : (int) round($result->getTime() * 1000),
-            ], [
-                Types::STRING,
-                Types::DATETIME_MUTABLE,
-                Types::INTEGER,
-            ]);
+            $this->checkInitialization();
+
+            if ($result->getDirection() === Direction::DOWN) {
+                $this->connection->delete($this->configuration->getTableName(), [
+                    $this->configuration->getVersionColumnName() => (string)$result->getVersion(),
+                ]);
+            } else {
+                $this->connection->insert($this->configuration->getTableName(), [
+                    $this->configuration->getVersionColumnName() => (string)$result->getVersion(),
+                    $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
+                    $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : (int)round($result->getTime() * 1000),
+                ], [
+                    Types::STRING,
+                    Types::DATETIME_MUTABLE,
+                    Types::INTEGER,
+                ]);
+            }
         }
+
+        return $sql_queries;
     }
 
     public function ensureInitialized(): void

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -149,31 +149,30 @@ final class TableMetadataStorage implements MetadataStorage
     /**
      * {@inheritDoc}
      */
-    public function getSql(ExecutionResult $result): array
+    public function getSql(ExecutionResult $result): iterable
     {
-        $sql = [new Query('-- Version ' . (string) $result->getVersion() . ' update table metadata')];
+        yield new Query('-- Version ' . (string) $result->getVersion() . ' update table metadata');
+
         if ($result->getDirection() === Direction::DOWN) {
-            $query = sprintf(
+            yield new Query(sprintf(
                 'DELETE FROM %s WHERE %s = %s',
                 $this->configuration->getTableName(),
                 $this->configuration->getVersionColumnName(),
                 $this->connection->quote((string) $result->getVersion())
-            );
-        } else {
-            $query = sprintf(
-                'INSERT INTO %s (%s, %s, %s) VALUES (%s, %s, 0)',
-                $this->configuration->getTableName(),
-                $this->configuration->getVersionColumnName(),
-                $this->configuration->getExecutedAtColumnName(),
-                $this->configuration->getExecutionTimeColumnName(),
-                $this->connection->quote((string) $result->getVersion()),
-                $this->connection->quote(($result->getExecutedAt() ?? new DateTimeImmutable())->format('Y-m-d H:i:s'))
-            );
+            ));
+
+            return;
         }
 
-        $sql[] = new Query($query);
-
-        return $sql;
+        yield new Query(sprintf(
+            'INSERT INTO %s (%s, %s, %s) VALUES (%s, %s, 0)',
+            $this->configuration->getTableName(),
+            $this->configuration->getVersionColumnName(),
+            $this->configuration->getExecutedAtColumnName(),
+            $this->configuration->getExecutionTimeColumnName(),
+            $this->connection->quote((string) $result->getVersion()),
+            $this->connection->quote(($result->getExecutedAt() ?? new DateTimeImmutable())->format('Y-m-d H:i:s'))
+        ));
     }
 
     public function ensureInitialized(): void

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -147,7 +147,7 @@ final class TableMetadataStorage implements MetadataStorage
     }
 
     /**
-     * {@inheritDoc}
+     * @return iterable<Query>
      */
     public function getSql(ExecutionResult $result): iterable
     {

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -25,6 +25,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
 use Throwable;
 
 use function count;
+use function method_exists;
 use function ucfirst;
 
 /**
@@ -203,7 +204,7 @@ final class DbalExecutor implements Executor
 
         if (! $configuration->isDryRun()) {
             $this->metadataStorage->complete($result);
-        } else {
+        } elseif (method_exists($this->metadataStorage, 'getSql')) {
             foreach ($this->metadataStorage->getSql($result) as $sqlQuery) {
                 $this->addSql($sqlQuery);
             }

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -201,8 +201,12 @@ final class DbalExecutor implements Executor
 
         $this->logger->info('Migration {version} {direction} (took {time}ms, used {memory} memory)', $params);
 
-        foreach ($this->metadataStorage->complete($result, $configuration->isDryRun()) as $sqlQuery) {
-            $this->addSql($sqlQuery);
+        if (! $configuration->isDryRun()) {
+            $this->metadataStorage->complete($result);
+        } else {
+            foreach ($this->metadataStorage->getSql($result) as $sqlQuery) {
+                $this->addSql($sqlQuery);
+            }
         }
 
         if ($migration->isTransactional()) {

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -201,8 +201,8 @@ final class DbalExecutor implements Executor
 
         $this->logger->info('Migration {version} {direction} (took {time}ms, used {memory} memory)', $params);
 
-        if (! $configuration->isDryRun()) {
-            $this->metadataStorage->complete($result);
+        foreach ($this->metadataStorage->complete($result, $configuration->isDryRun()) as $sqlQuery) {
+            $this->addSql($sqlQuery);
         }
 
         if ($migration->isTransactional()) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -44,6 +44,10 @@ parameters:
             count: 1
             path: tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-orm/cli-config.php
 
+        -
+            message: '~^Call to function method_exists\(\) with Doctrine\\Migrations\\Metadata\\Storage\\MetadataStorage and ''getSql'' will always evaluate to true\.$~'
+            path: lib/Doctrine/Migrations/Version/DbalExecutor.php
+
     symfony:
             console_application_loader: tests/Doctrine/Migrations/Tests/doctrine-migrations-phpstan-app.php
 includes:

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -355,4 +355,42 @@ class TableMetadataStorageTest extends TestCase
         );
         self::assertCount(0, $this->connection->fetchAllAssociative($sql));
     }
+
+    public function testGetSql(): void
+    {
+        $this->storage->ensureInitialized();
+
+        $result = new ExecutionResult(new Version('2230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
+
+        $queries = $this->storage->getSql($result);
+
+        self::assertCount(2, $queries);
+        self::assertSame('-- Version 2230 update table metadata', $queries[0]->getStatement());
+        self::assertSame('INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUES (\'2230\', \'2010-01-05 10:30:21\', 0)', $queries[1]->getStatement());
+
+        foreach ($queries as $query) {
+            $this->connection->executeStatement($query);
+        }
+
+        $sql = sprintf(
+            'SELECT * FROM %s WHERE version = 2230',
+            $this->connection->getDatabasePlatform()->quoteIdentifier($this->config->getTableName())
+        );
+
+        self::assertCount(1, $this->connection->fetchAllAssociative($sql));
+
+        $result = new ExecutionResult(new Version('2230'), Direction::DOWN, new DateTimeImmutable('2010-01-05 10:30:21'));
+
+        $queries = $this->storage->getSql($result);
+
+        self::assertCount(2, $queries);
+        self::assertSame('-- Version 2230 update table metadata', $queries[0]->getStatement());
+        self::assertSame('DELETE FROM doctrine_migration_versions WHERE version = \'2230\'', $queries[1]->getStatement());
+
+        foreach ($queries as $query) {
+            $this->connection->executeStatement($query);
+        }
+
+        self::assertCount(0, $this->connection->fetchAllAssociative($sql));
+    }
 }

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -27,6 +27,7 @@ use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 
+use function iterator_to_array;
 use function sprintf;
 
 class TableMetadataStorageTest extends TestCase
@@ -362,11 +363,15 @@ class TableMetadataStorageTest extends TestCase
 
         $result = new ExecutionResult(new Version('2230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
 
-        $queries = $this->storage->getSql($result);
+        $queries = iterator_to_array($this->storage->getSql($result));
 
         self::assertCount(2, $queries);
         self::assertSame('-- Version 2230 update table metadata', $queries[0]->getStatement());
-        self::assertSame('INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUES (\'2230\', \'2010-01-05 10:30:21\', 0)', $queries[1]->getStatement());
+        self::assertSame(sprintf(
+            "INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUES ('%s', '%s', 0)",
+            '2230',
+            '2010-01-05 10:30:21'
+        ), $queries[1]->getStatement());
 
         foreach ($queries as $query) {
             $this->connection->executeStatement($query);
@@ -381,11 +386,14 @@ class TableMetadataStorageTest extends TestCase
 
         $result = new ExecutionResult(new Version('2230'), Direction::DOWN, new DateTimeImmutable('2010-01-05 10:30:21'));
 
-        $queries = $this->storage->getSql($result);
+        $queries = iterator_to_array($this->storage->getSql($result));
 
         self::assertCount(2, $queries);
         self::assertSame('-- Version 2230 update table metadata', $queries[0]->getStatement());
-        self::assertSame('DELETE FROM doctrine_migration_versions WHERE version = \'2230\'', $queries[1]->getStatement());
+        self::assertSame(sprintf(
+            "DELETE FROM doctrine_migration_versions WHERE version = '%s'",
+            '2230'
+        ), $queries[1]->getStatement());
 
         foreach ($queries as $query) {
             $this->connection->executeStatement($query);

--- a/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Doctrine/Migrations/Tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -27,7 +27,6 @@ use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 
-use function iterator_to_array;
 use function sprintf;
 
 class TableMetadataStorageTest extends TestCase
@@ -363,7 +362,7 @@ class TableMetadataStorageTest extends TestCase
 
         $result = new ExecutionResult(new Version('2230'), Direction::UP, new DateTimeImmutable('2010-01-05 10:30:21'));
 
-        $queries = iterator_to_array($this->storage->getSql($result));
+        $queries = [...$this->storage->getSql($result)];
 
         self::assertCount(2, $queries);
         self::assertSame('-- Version 2230 update table metadata', $queries[0]->getStatement());
@@ -374,7 +373,7 @@ class TableMetadataStorageTest extends TestCase
         ), $queries[1]->getStatement());
 
         foreach ($queries as $query) {
-            $this->connection->executeStatement($query);
+            $this->connection->executeStatement($query->getStatement());
         }
 
         $sql = sprintf(
@@ -386,7 +385,7 @@ class TableMetadataStorageTest extends TestCase
 
         $result = new ExecutionResult(new Version('2230'), Direction::DOWN, new DateTimeImmutable('2010-01-05 10:30:21'));
 
-        $queries = iterator_to_array($this->storage->getSql($result));
+        $queries = [...$this->storage->getSql($result)];
 
         self::assertCount(2, $queries);
         self::assertSame('-- Version 2230 update table metadata', $queries[0]->getStatement());
@@ -396,7 +395,7 @@ class TableMetadataStorageTest extends TestCase
         ), $queries[1]->getStatement());
 
         foreach ($queries as $query) {
-            $this->connection->executeStatement($query);
+            $this->connection->executeStatement($query->getStatement());
         }
 
         self::assertCount(0, $this->connection->fetchAllAssociative($sql));

--- a/tests/Doctrine/Migrations/Tests/RollupTest.php
+++ b/tests/Doctrine/Migrations/Tests/RollupTest.php
@@ -56,8 +56,9 @@ class RollupTest extends TestCase
         $this->storage
            ->expects(self::exactly(1))
            ->method('complete')
-           ->willReturnCallback(static function (ExecutionResult $result): void {
+           ->willReturnCallback(static function (ExecutionResult $result): array {
               self::assertEquals(new Version('A'), $result->getVersion());
+              return [];
            })->with();
 
         $this->rollup->rollup();

--- a/tests/Doctrine/Migrations/Tests/RollupTest.php
+++ b/tests/Doctrine/Migrations/Tests/RollupTest.php
@@ -58,6 +58,7 @@ class RollupTest extends TestCase
            ->method('complete')
            ->willReturnCallback(static function (ExecutionResult $result): array {
               self::assertEquals(new Version('A'), $result->getVersion());
+
               return [];
            })->with();
 

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -102,6 +102,7 @@ class ExecutorTest extends TestCase
                 self::assertSame(Direction::UP, $result->getDirection());
                 self::assertNotNull($result->getTime());
                 self::assertNotNull($result->getExecutedAt());
+
                 return [];
             });
 
@@ -166,6 +167,7 @@ class ExecutorTest extends TestCase
                 self::assertSame(Direction::DOWN, $result->getDirection());
                 self::assertNotNull($result->getTime());
                 self::assertNotNull($result->getExecutedAt());
+
                 return [];
             });
 
@@ -210,14 +212,12 @@ class ExecutorTest extends TestCase
     {
         $this->metadataStorage
             ->expects(self::exactly(1))
-            ->method('complete')->willReturnCallback(static function (ExecutionResult $result, bool $dry_run): array {
-                self::assertTrue($dry_run);
+            ->method('complete')->willReturnCallback(static function (ExecutionResult $result, bool $dryRun): array {
+                self::assertTrue($dryRun);
                 self::assertSame(Direction::UP, $result->getDirection());
-                return [
-                    new Query('INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUE (' . $result->getVersion() . ', NOW(), 0)')
-                ];
-            })
-        ;
+
+                return [new Query('INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUE (' . $result->getVersion() . ', NOW(), 0)')];
+            });
 
         $this->connection
             ->expects(self::never())

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -98,12 +98,10 @@ class ExecutorTest extends TestCase
     {
         $this->metadataStorage
             ->expects(self::once())
-            ->method('complete')->willReturnCallback(static function (ExecutionResult $result): array {
+            ->method('complete')->willReturnCallback(static function (ExecutionResult $result): void {
                 self::assertSame(Direction::UP, $result->getDirection());
                 self::assertNotNull($result->getTime());
                 self::assertNotNull($result->getExecutedAt());
-
-                return [];
             });
 
         $migratorConfiguration = (new MigratorConfiguration())
@@ -163,12 +161,10 @@ class ExecutorTest extends TestCase
     {
         $this->metadataStorage
             ->expects(self::once())
-            ->method('complete')->willReturnCallback(static function (ExecutionResult $result): array {
+            ->method('complete')->willReturnCallback(static function (ExecutionResult $result): void {
                 self::assertSame(Direction::DOWN, $result->getDirection());
                 self::assertNotNull($result->getTime());
                 self::assertNotNull($result->getExecutedAt());
-
-                return [];
             });
 
         $migratorConfiguration = (new MigratorConfiguration())
@@ -211,9 +207,12 @@ class ExecutorTest extends TestCase
     public function testExecuteDryRun(): void
     {
         $this->metadataStorage
-            ->expects(self::exactly(1))
-            ->method('complete')->willReturnCallback(static function (ExecutionResult $result, bool $dryRun): array {
-                self::assertTrue($dryRun);
+            ->expects(self::never())
+            ->method('complete');
+
+        $this->metadataStorage
+            ->expects(self::once())
+            ->method('getSql')->willReturnCallback(static function (ExecutionResult $result): array {
                 self::assertSame(Direction::UP, $result->getDirection());
 
                 return [new Query('INSERT INTO doctrine_migration_versions (version, executed_at, execution_time) VALUE (' . $result->getVersion() . ', NOW(), 0)')];


### PR DESCRIPTION
Db user in my app doesn't have CREATE, ALTER query permissions so i cant run my migrations from php. Instead of this i write all necessary sql queries to file and run it from another user. After upgrading doctrine migrations to newer version i faced with issue, that resulted sql file doesnt contain insert/delete queries for meta table (doctrine_migration_versions). Very frustrating to insert this information myself so i ended up with this solution.

Such issue already been described in https://github.com/doctrine/migrations/issues/1082

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 1082

#### Summary

I am not sure about TableMetadataStorage::complete method. I see you using Connection::insert, Connection::delete methods. It seems like we need to replace it with Connection::execute and use already generated queries
