### PR TITLE
Leverage LazyProxyTrait in LazySchemaDiffProvider

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,15 +26,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
-          - "8.0"
           - "8.1"
           - "8.2"
         dependencies:
           - "highest"
         include:
           - dependencies: "lowest"
-            php-version: "7.4"
+            php-version: "8.1"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
           - "8.1"
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,15 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2",
         "doctrine/dbal": "^3.4.3",
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.0",
-        "friendsofphp/proxy-manager-lts": "^1.0",
         "psr/log": "^1.1.3 || ^2 || ^3",
         "symfony/console": "^4.4.16 || ^5.4 || ^6.0",
-        "symfony/stopwatch": "^4.4 || ^5.4 || ^6.0"
+        "symfony/stopwatch": "^4.4 || ^5.4 || ^6.0",
+        "symfony/var-exporter": "^6.2"
     },
     "conflict": {
         "doctrine/orm": "<2.12"
@@ -49,7 +49,7 @@
         "phpstan/phpstan-phpunit": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-symfony": "^1.1",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.24",
         "symfony/cache": "^4.4 || ^5.4 || ^6.0",
         "symfony/process": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.4 || ^6.0"

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -279,7 +279,7 @@ class DependencyFactory
     public function getSchemaDiffProvider(): SchemaDiffProvider
     {
         return $this->getDependency(SchemaDiffProvider::class, function (): LazySchemaDiffProvider {
-            return LazySchemaDiffProvider::fromDefaultProxyFactoryConfiguration(
+            return new LazySchemaDiffProvider(
                 new DBALSchemaDiffProvider(
                     $this->getConnection()->createSchemaManager(),
                     $this->getConnection()->getDatabasePlatform()

--- a/lib/Doctrine/Migrations/Provider/LazySchema.php
+++ b/lib/Doctrine/Migrations/Provider/LazySchema.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Provider;
+
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\VarExporter\LazyProxyTrait;
+
+/**
+ * @internal
+ */
+class LazySchema extends Schema
+{
+    use LazyProxyTrait;
+}

--- a/lib/Doctrine/Migrations/Provider/LazySchemaDiffProvider.php
+++ b/lib/Doctrine/Migrations/Provider/LazySchemaDiffProvider.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Provider;
 
 use Doctrine\DBAL\Schema\Schema;
-use ProxyManager\Configuration;
-use ProxyManager\Factory\LazyLoadingValueHolderFactory;
-use ProxyManager\GeneratorStrategy\EvaluatingGeneratorStrategy;
-use ProxyManager\Proxy\LazyLoadingInterface;
 
 /**
  * The LazySchemaDiffProvider is responsible for lazily generating the from schema when diffing two schemas
@@ -18,59 +14,27 @@ use ProxyManager\Proxy\LazyLoadingInterface;
  */
 class LazySchemaDiffProvider implements SchemaDiffProvider
 {
-    private LazyLoadingValueHolderFactory $proxyFactory;
-
     private SchemaDiffProvider $originalSchemaManipulator;
 
     public function __construct(
-        LazyLoadingValueHolderFactory $proxyFactory,
         SchemaDiffProvider $originalSchemaManipulator
     ) {
-        $this->proxyFactory              = $proxyFactory;
         $this->originalSchemaManipulator = $originalSchemaManipulator;
-    }
-
-    public static function fromDefaultProxyFactoryConfiguration(
-        SchemaDiffProvider $originalSchemaManipulator
-    ): LazySchemaDiffProvider {
-        $proxyConfig = new Configuration();
-        $proxyConfig->setGeneratorStrategy(new EvaluatingGeneratorStrategy());
-        $proxyFactory = new LazyLoadingValueHolderFactory($proxyConfig);
-
-        return new LazySchemaDiffProvider($proxyFactory, $originalSchemaManipulator);
     }
 
     public function createFromSchema(): Schema
     {
         $originalSchemaManipulator = $this->originalSchemaManipulator;
 
-        return $this->proxyFactory->createProxy(
-            Schema::class,
-            static function (&$wrappedObject, $proxy, $method, array $parameters, &$initializer) use ($originalSchemaManipulator): bool {
-                $initializer = null;
-
-                $wrappedObject = $originalSchemaManipulator->createFromSchema();
-
-                return true;
-            }
-        );
+        return LazySchema::createLazyProxy(static fn () => $originalSchemaManipulator->createFromSchema());
     }
 
     public function createToSchema(Schema $fromSchema): Schema
     {
         $originalSchemaManipulator = $this->originalSchemaManipulator;
 
-        if ($fromSchema instanceof LazyLoadingInterface && ! $fromSchema->isProxyInitialized()) {
-            return $this->proxyFactory->createProxy(
-                Schema::class,
-                static function (&$wrappedObject, $proxy, $method, array $parameters, &$initializer) use ($originalSchemaManipulator, $fromSchema): bool {
-                    $initializer = null;
-
-                    $wrappedObject = $originalSchemaManipulator->createToSchema($fromSchema);
-
-                    return true;
-                }
-            );
+        if ($fromSchema instanceof LazySchema && ! $fromSchema->isLazyObjectInitialized()) {
+            return LazySchema::createLazyProxy(static fn () => $originalSchemaManipulator->createToSchema($fromSchema));
         }
 
         return $this->originalSchemaManipulator->createToSchema($fromSchema);
@@ -80,8 +44,8 @@ class LazySchemaDiffProvider implements SchemaDiffProvider
     public function getSqlDiffToMigrate(Schema $fromSchema, Schema $toSchema): array
     {
         if (
-            $toSchema instanceof LazyLoadingInterface
-            && ! $toSchema->isProxyInitialized()
+            $toSchema instanceof LazySchema
+            && ! $toSchema->isLazyObjectInitialized()
         ) {
             return [];
         }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,7 +13,6 @@ parameters:
         -
             message: '~^Variable property access on SimpleXMLElement\.$~'
             path: lib/Doctrine/Migrations/Configuration/Migration/XmlFile.php
-
         -
             message: '~^Call to function is_bool\(\) with bool will always evaluate to true\.$~'
             path: lib/Doctrine/Migrations/InlineParameterFormatter.php
@@ -23,11 +22,6 @@ parameters:
         -
             message: '~^Method Doctrine\\Migrations\\Tests\\Stub\\DoctrineRegistry::getService\(\) should return Doctrine\\Persistence\\ObjectManager but returns Doctrine\\DBAL\\Connection\|Doctrine\\ORM\\EntityManager~'
             path: tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
-
-        # We cannot document the closure as precise as PHPStan wants us to.
-        -
-            message: '~^Parameter #2 \$initializer of method ProxyManager\\Factory\\LazyLoadingValueHolderFactory\:\:createProxy\(\) expects Closure\(.*\)\: bool, Closure\(.*\)\: true given\.$~'
-            path: lib/Doctrine/Migrations/Provider/LazySchemaDiffProvider.php
 
         # https://github.com/phpstan/phpstan/issues/5982
         -


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no (LazySchemaDiffProvider is internal)
| Fixed issues | -

This PR proposes to leverage the new `LazyProxyTrait` that's going to be shipped with Symfony 6.2 to implement lazy schemas as required by LazySchemaDiffProvider. (See https://symfony.com/blog/revisiting-lazy-loading-proxies-in-php for an introduction to this trait.)

This would require bumping the minimum PHP version to 8.1 in the next minor version.
The main benefit is simplicity. As you can read in the patch, using this trait requires no proxy generation infrastructure, and no calls to `eval()` either. The other benefit is simplifying dependency management.