### PR TITLE
Bump CI workflows

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   roave_bc_check:
     name: "Roave BC Check"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: "actions/checkout@v2"
         with:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@2.0.0"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   composer_normalize:
     name: "Composer Normalize"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,7 +21,7 @@ jobs:
 
   phpunit:
     name: "PHPUnit"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
@@ -29,6 +29,7 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
         dependencies:
           - "highest"
         include:
@@ -54,6 +55,7 @@ jobs:
         uses: "ramsey/composer-install@v1"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "--ignore-platform-req=php+"
 
       - name: "Run PHPUnit"
         run: "vendor/bin/phpunit --coverage-clover=coverage.xml"
@@ -66,7 +68,7 @@ jobs:
 
   upload_coverage:
     name: "Upload coverage to Codecov"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs:
       - "phpunit"
 

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.4.1"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@2.0.0"
     secrets:
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,13 +12,13 @@ on:
 jobs:
   static-analysis-phpstan:
     name: "Static Analysis with PHPStan"
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
 
     strategy:
       matrix:
         php-version:
           - "7.4"
-          - "8.0"
+          - "8.1"
 
     steps:
       - name: "Checkout code"

--- a/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+++ b/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
+use const PHP_VERSION_ID;
+
 class SchemaDumperTest extends TestCase
 {
     /** @var AbstractPlatform|MockObject */
@@ -129,7 +131,11 @@ class SchemaDumperTest extends TestCase
     public function testRegexErrorsAreConvertedToExceptions(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Internal PCRE error, please check your Regex. Reported errors: preg_match(): Delimiter must not be alphanumeric or backslash.');
+        if (PHP_VERSION_ID < 80200) {
+            $this->expectExceptionMessage('Internal PCRE error, please check your Regex. Reported errors: preg_match(): Delimiter must not be alphanumeric or backslash.');
+        } else {
+            $this->expectExceptionMessage('Internal PCRE error, please check your Regex. Reported errors: preg_match(): Delimiter must not be alphanumeric, backslash, or NUL.');
+        }
 
         $table = $this->createMock(Table::class);
         $table->expects(self::atLeastOnce())


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

* Upgraded all workflows to Ubuntu 22.04 (from 20.04)
* Bumped all shared workflows from `doctrine/.github` to version 2.0.0
* Added a PHPUnit run on PHP 8.2 (I had to adjust one test)
* Run static analysis on PHP 8.1 instead of 8.0
