### PR TITLE
Add property types to tests

### DIFF
--- a/tests/Doctrine/Migrations/Tests/Configuration/Connection/ConnectionRegistryLoaderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/Connection/ConnectionRegistryLoaderTest.php
@@ -14,11 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 final class ConnectionRegistryLoaderTest extends TestCase
 {
-    /** @var Connection|MockObject */
-    private $connection1;
+    /** @var Connection&MockObject */
+    private Connection $connection1;
 
-    /** @var Connection|MockObject */
-    private $connection2;
+    /** @var Connection&MockObject */
+    private Connection $connection2;
 
     private AbstractManagerRegistry $registry;
 

--- a/tests/Doctrine/Migrations/Tests/Configuration/EntityManager/EntityManagerRegistryLoaderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/EntityManager/EntityManagerRegistryLoaderTest.php
@@ -14,11 +14,11 @@ use PHPUnit\Framework\TestCase;
 
 final class EntityManagerRegistryLoaderTest extends TestCase
 {
-    /** @var EntityManager|MockObject */
-    private $em1;
+    /** @var EntityManager&MockObject */
+    private EntityManager $em1;
 
-    /** @var EntityManager|MockObject */
-    private $em2;
+    /** @var EntityManager&MockObject */
+    private EntityManager $em2;
 
     private AbstractManagerRegistry $registry;
 

--- a/tests/Doctrine/Migrations/Tests/DependencyFactoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/DependencyFactoryTest.php
@@ -28,13 +28,13 @@ use stdClass;
 
 final class DependencyFactoryTest extends MigrationTestCase
 {
-    /** @var MockObject|Connection */
-    private $connection;
+    /** @var Connection&MockObject */
+    private Connection $connection;
 
     private Configuration $configuration;
 
-    /** @var EntityManager|MockObject */
-    private $entityManager;
+    /** @var EntityManager&MockObject */
+    private EntityManager $entityManager;
 
     public function setUp(): void
     {

--- a/tests/Doctrine/Migrations/Tests/DependencyFactoryWithConnectionRegistryTest.php
+++ b/tests/Doctrine/Migrations/Tests/DependencyFactoryWithConnectionRegistryTest.php
@@ -15,11 +15,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 final class DependencyFactoryWithConnectionRegistryTest extends MigrationTestCase
 {
-    /** @var MockObject|Connection */
-    private $connection1;
+    /** @var Connection&MockObject */
+    private Connection $connection1;
 
-    /** @var MockObject|Connection */
-    private $connection2;
+    /** @var Connection&MockObject */
+    private Connection $connection2;
 
     private Configuration $configuration;
 

--- a/tests/Doctrine/Migrations/Tests/DependencyFactoryWithEntityManagerRegistryTest.php
+++ b/tests/Doctrine/Migrations/Tests/DependencyFactoryWithEntityManagerRegistryTest.php
@@ -16,17 +16,17 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 final class DependencyFactoryWithEntityManagerRegistryTest extends MigrationTestCase
 {
-    /** @var MockObject|Connection */
-    private $connection1;
+    /** @var Connection&MockObject */
+    private Connection $connection1;
 
-    /** @var MockObject|Connection */
-    private $connection2;
+    /** @var Connection&MockObject */
+    private Connection $connection2;
 
-    /** @var MockObject|EntityManager */
-    private $em1;
+    /** @var EntityManager&MockObject */
+    private EntityManager $em1;
 
-    /** @var MockObject|EntityManager */
-    private $em2;
+    /** @var EntityManager&MockObject */
+    private EntityManager $em2;
 
     private Configuration $configuration;
 

--- a/tests/Doctrine/Migrations/Tests/Event/EventArgsTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/EventArgsTest.php
@@ -18,11 +18,11 @@ use PHPUnit\Framework\TestCase;
 
 class EventArgsTest extends TestCase
 {
-    /** @var MockObject|Connection */
-    private $connection;
+    /** @var Connection&MockObject */
+    private Connection $connection;
 
-    /** @var MockObject|MigratorConfiguration */
-    private $config;
+    /** @var MigratorConfiguration&MockObject */
+    private MigratorConfiguration $config;
 
     private MigrationPlan $plan;
 

--- a/tests/Doctrine/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/Listeners/AutoCommitListenerTest.php
@@ -16,8 +16,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class AutoCommitListenerTest extends MigrationTestCase
 {
-    /** @var Connection|MockObject */
-    private $conn;
+    /** @var Connection&MockObject */
+    private Connection $conn;
 
     private AutoCommitListener $listener;
 

--- a/tests/Doctrine/Migrations/Tests/Generator/ConcatenationFileBuilderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/ConcatenationFileBuilderTest.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 class ConcatenationFileBuilderTest extends TestCase
 {
-    /** @var AbstractPlatform|MockObject */
-    private $platform;
+    /** @var AbstractPlatform&MockObject */
+    private AbstractPlatform $platform;
 
     private FileBuilder $migrationFileBuilder;
 

--- a/tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/DiffGeneratorTest.php
@@ -20,28 +20,28 @@ use PHPUnit\Framework\TestCase;
 
 class DiffGeneratorTest extends TestCase
 {
-    /** @var DBALConfiguration|MockObject */
-    private $dbalConfiguration;
+    /** @var DBALConfiguration&MockObject */
+    private DBALConfiguration $dbalConfiguration;
 
-    /** @var AbstractSchemaManager<AbstractPlatform>|MockObject */
-    private $schemaManager;
+    /** @var AbstractSchemaManager<AbstractPlatform>&MockObject */
+    private AbstractSchemaManager $schemaManager;
 
-    /** @var SchemaProvider|MockObject */
-    private $schemaProvider;
+    /** @var SchemaProvider&MockObject */
+    private SchemaProvider $schemaProvider;
 
-    /** @var AbstractPlatform|MockObject */
-    private $platform;
+    /** @var AbstractPlatform&MockObject */
+    private AbstractPlatform $platform;
 
-    /** @var Generator|MockObject */
-    private $migrationGenerator;
+    /** @var Generator&MockObject */
+    private Generator $migrationGenerator;
 
-    /** @var SqlGenerator|MockObject */
-    private $migrationSqlGenerator;
+    /** @var SqlGenerator&MockObject */
+    private SqlGenerator $migrationSqlGenerator;
 
     private DiffGenerator $migrationDiffGenerator;
 
-    /** @var SchemaProvider|MockObject */
-    private $emptySchemaProvider;
+    /** @var SchemaProvider&MockObject */
+    private SchemaProvider $emptySchemaProvider;
 
     public function testGenerate(): void
     {

--- a/tests/Doctrine/Migrations/Tests/Generator/SqlGeneratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Generator/SqlGeneratorTest.php
@@ -20,8 +20,8 @@ final class SqlGeneratorTest extends TestCase
 {
     private Configuration $configuration;
 
-    /** @var AbstractPlatform|MockObject */
-    private $platform;
+    /** @var AbstractPlatform&MockObject */
+    private AbstractPlatform $platform;
 
     private SqlGenerator $migrationSqlGenerator;
 

--- a/tests/Doctrine/Migrations/Tests/MigrationRepository/FilesystemMigrationsRepositoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigrationRepository/FilesystemMigrationsRepositoryTest.php
@@ -22,8 +22,8 @@ use PHPUnit\Framework\TestCase;
 
 class FilesystemMigrationsRepositoryTest extends TestCase
 {
-    /** @var MigrationFactory|MockObject */
-    private $versionFactory;
+    /** @var MigrationFactory&MockObject */
+    private MigrationFactory $versionFactory;
 
     private MigrationsRepository $migrationRepository;
 

--- a/tests/Doctrine/Migrations/Tests/MigratorTest.php
+++ b/tests/Doctrine/Migrations/Tests/MigratorTest.php
@@ -35,8 +35,8 @@ use const DIRECTORY_SEPARATOR;
 
 class MigratorTest extends MigrationTestCase
 {
-    /** @var Connection|MockObject */
-    private $conn;
+    /** @var Connection&MockObject */
+    private Connection $conn;
 
     private Configuration $config;
 

--- a/tests/Doctrine/Migrations/Tests/Provider/EmptySchemaProviderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/EmptySchemaProviderTest.php
@@ -16,8 +16,8 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class EmptySchemaProviderTest extends MigrationTestCase
 {
-    /** @var AbstractSchemaManager<AbstractPlatform>|MockObject */
-    private $schemaManager;
+    /** @var AbstractSchemaManager<AbstractPlatform>&MockObject */
+    private AbstractSchemaManager $schemaManager;
 
     private EmptySchemaProvider $emptyProvider;
 

--- a/tests/Doctrine/Migrations/Tests/RollupTest.php
+++ b/tests/Doctrine/Migrations/Tests/RollupTest.php
@@ -19,14 +19,14 @@ use PHPUnit\Framework\TestCase;
 
 class RollupTest extends TestCase
 {
-    /** @var MockObject|AbstractMigration */
-    private $abstractMigration;
+    /** @var AbstractMigration&MockObject */
+    private AbstractMigration $abstractMigration;
 
-    /** @var MigrationsRepository|MockObject */
-    private $repository;
+    /** @var MigrationsRepository&MockObject */
+    private MigrationsRepository $repository;
 
-    /** @var MetadataStorage|MockObject */
-    private $storage;
+    /** @var MetadataStorage&MockObject */
+    private MetadataStorage $storage;
 
     private Rollup $rollup;
 

--- a/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+++ b/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
@@ -20,17 +20,17 @@ use const PHP_VERSION_ID;
 
 class SchemaDumperTest extends TestCase
 {
-    /** @var AbstractPlatform|MockObject */
-    private $platform;
+    /** @var AbstractPlatform&MockObject */
+    private AbstractPlatform $platform;
 
-    /** @var AbstractSchemaManager<AbstractPlatform>|MockObject */
-    private $schemaManager;
+    /** @var AbstractSchemaManager<AbstractPlatform>&MockObject */
+    private AbstractSchemaManager $schemaManager;
 
-    /** @var Generator|MockObject */
-    private $migrationGenerator;
+    /** @var Generator&MockObject */
+    private Generator $migrationGenerator;
 
-    /** @var SqlGenerator|MockObject */
-    private $migrationSqlGenerator;
+    /** @var SqlGenerator&MockObject */
+    private SqlGenerator $migrationSqlGenerator;
 
     private SchemaDumper $schemaDumper;
 

--- a/tests/Doctrine/Migrations/Tests/Stub/CustomClassNameMigrationFactory.php
+++ b/tests/Doctrine/Migrations/Tests/Stub/CustomClassNameMigrationFactory.php
@@ -11,8 +11,8 @@ class CustomClassNameMigrationFactory implements MigrationFactory
 {
     private MigrationFactory $parentMigrationFactory;
 
-    /** @psalm-var class-string<AbstractMigration> */
-    private $migrationClassName;
+    /** @var class-string<AbstractMigration> */
+    private string $migrationClassName;
 
     /**
      * @param class-string<AbstractMigration> $migrationClassName

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DiffCommandTest.php
@@ -27,23 +27,23 @@ use function trim;
 
 final class DiffCommandTest extends TestCase
 {
-    /** @var DiffGenerator|MockObject */
-    private $migrationDiffGenerator;
+    /** @var DiffGenerator&MockObject */
+    private DiffGenerator $migrationDiffGenerator;
 
-    /** @var MigrationStatusCalculator|MockObject */
-    private $migrationStatusCalculator;
+    /** @var MigrationStatusCalculator&MockObject */
+    private MigrationStatusCalculator $migrationStatusCalculator;
 
     private Configuration $configuration;
 
     private DiffCommand $diffCommand;
 
-    /** @var MockObject|DependencyFactory */
-    private $dependencyFactory;
+    /** @var DependencyFactory&MockObject */
+    private DependencyFactory $dependencyFactory;
 
     private CommandTester $diffCommandTester;
 
-    /** @var ClassNameGenerator|MockObject */
-    private $classNameGenerator;
+    /** @var ClassNameGenerator&MockObject */
+    private ClassNameGenerator $classNameGenerator;
 
     public function testExecute(): void
     {

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -29,14 +29,14 @@ final class DumpSchemaCommandTest extends TestCase
 {
     private Configuration $configuration;
 
-    /** @var DependencyFactory|MockObject */
-    private $dependencyFactory;
+    /** @var DependencyFactory&MockObject */
+    private DependencyFactory $dependencyFactory;
 
-    /** @var MigrationsRepository|MockObject */
-    private $migrationRepository;
+    /** @var MigrationsRepository&MockObject */
+    private MigrationsRepository $migrationRepository;
 
-    /** @var SchemaDumper|MockObject */
-    private $schemaDumper;
+    /** @var SchemaDumper&MockObject */
+    private SchemaDumper $schemaDumper;
 
     private DumpSchemaCommand $dumpSchemaCommand;
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -39,8 +39,8 @@ class ExecuteCommandTest extends MigrationTestCase
 
     private MockObject $queryWriter;
 
-    /** @var MigrationPlanCalculator|MockObject */
-    private $planCalculator;
+    /** @var MigrationPlanCalculator&MockObject */
+    private MigrationPlanCalculator $planCalculator;
 
     /**
      * @param bool|string|null $arg

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -22,11 +22,11 @@ final class GenerateCommandTest extends TestCase
 {
     private Configuration $configuration;
 
-    /** @var DependencyFactory|MockObject */
-    private $dependencyFactory;
+    /** @var DependencyFactory&MockObject */
+    private DependencyFactory $dependencyFactory;
 
-    /** @var Generator|MockObject */
-    private $migrationGenerator;
+    /** @var Generator&MockObject */
+    private Generator $migrationGenerator;
 
     private GenerateCommand $generateCommand;
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -56,8 +56,8 @@ class MigrateCommandTest extends MigrationTestCase
 
     private MockObject $queryWriter;
 
-    /** @var MockObject|QuestionHelper */
-    private $questions;
+    /** @var QuestionHelper&MockObject */
+    private QuestionHelper $questions;
 
     private MigrationsRepository $migrationRepository;
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/RollupCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/RollupCommandTest.php
@@ -16,11 +16,11 @@ use function trim;
 
 final class RollupCommandTest extends TestCase
 {
-    /** @var DependencyFactory|MockObject */
-    private $dependencyFactory;
+    /** @var DependencyFactory&MockObject */
+    private DependencyFactory $dependencyFactory;
 
-    /** @var Rollup|MockObject */
-    private $rollup;
+    /** @var Rollup&MockObject */
+    private Rollup $rollup;
 
     private RollupCommand $rollupCommand;
 

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/SyncMetadataCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/SyncMetadataCommandTest.php
@@ -13,11 +13,11 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 final class SyncMetadataCommandTest extends TestCase
 {
-    /** @var DependencyFactory|MockObject */
-    private $dependencyFactory;
+    /** @var DependencyFactory&MockObject */
+    private DependencyFactory $dependencyFactory;
 
-    /** @var MetadataStorage|MockObject */
-    private $storage;
+    /** @var MetadataStorage&MockObject */
+    private MetadataStorage $storage;
 
     private SyncMetadataCommand $storageCommand;
 

--- a/tests/Doctrine/Migrations/Tests/Version/DbalFactoryTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/DbalFactoryTest.php
@@ -15,10 +15,10 @@ use ReflectionProperty;
 
 final class DbalFactoryTest extends TestCase
 {
-    /** @var MockObject|Connection */
-    private $connection;
-    /** @var MockObject|LoggerInterface */
-    private $logger;
+    /** @var Connection&MockObject */
+    private Connection $connection;
+    /** @var LoggerInterface&MockObject */
+    private LoggerInterface $logger;
 
     private DbalMigrationFactory $versionFactory;
 

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -33,17 +33,17 @@ use Throwable;
 
 class ExecutorTest extends TestCase
 {
-    /** @var Connection|MockObject */
-    private $connection;
+    /** @var Connection&MockObject */
+    private Connection $connection;
 
-    /** @var SchemaDiffProvider|MockObject */
-    private $schemaDiffProvider;
+    /** @var SchemaDiffProvider&MockObject */
+    private SchemaDiffProvider $schemaDiffProvider;
 
-    /** @var ParameterFormatter|MockObject */
-    private $parameterFormatter;
+    /** @var ParameterFormatter&MockObject */
+    private ParameterFormatter $parameterFormatter;
 
-    /** @var Stopwatch|MockObject */
-    private $stopwatch;
+    /** @var Stopwatch&MockObject */
+    private Stopwatch $stopwatch;
 
     private DbalExecutor $versionExecutor;
 

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationPlanCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationPlanCalculatorTest.php
@@ -28,14 +28,14 @@ final class MigrationPlanCalculatorTest extends TestCase
 {
     private MigrationPlanCalculator $migrationPlanCalculator;
 
-    /** @var MockObject|MigrationsRepository */
-    private $migrationRepository;
+    /** @var MigrationsRepository&MockObject */
+    private MigrationsRepository $migrationRepository;
 
-    /** @var MockObject|MetadataStorage */
-    private $metadataStorage;
+    /** @var MetadataStorage&MockObject */
+    private MetadataStorage $metadataStorage;
 
-    /** @var MockObject|AbstractMigration */
-    private $abstractMigration;
+    /** @var AbstractMigration&MockObject */
+    private AbstractMigration $abstractMigration;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/MigrationStatusCalculatorTest.php
@@ -21,14 +21,14 @@ final class MigrationStatusCalculatorTest extends TestCase
 {
     private MigrationStatusCalculator $migrationStatusCalculator;
 
-    /** @var MockObject|MigrationPlanCalculator */
-    private $migrationPlanCalculator;
+    /** @var MigrationPlanCalculator&MockObject */
+    private MigrationPlanCalculator $migrationPlanCalculator;
 
-    /** @var MockObject|MetadataStorage */
-    private $metadataStorage;
+    /** @var MetadataStorage&MockObject */
+    private MetadataStorage $metadataStorage;
 
-    /** @var MockObject|AbstractMigration */
-    private $abstractMigration;
+    /** @var AbstractMigration&MockObject */
+    private AbstractMigration $abstractMigration;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

This PR adds PHP 7.4 compatible native property types to all tests that were still missing them. I'm targeting 3.5 because these changes don't affect any production code.
