### PR TITLE
doc(generating-migration): change ignore table function

### DIFF
--- a/docs/en/reference/generating-migrations.rst
+++ b/docs/en/reference/generating-migrations.rst
@@ -260,7 +260,7 @@ with a schema filter.
 
 .. code-block:: php
 
-    $connection->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) {
+    $connection->getConfiguration()->setSchemaAssetsFilter(static function (string|AbstractAsset $assetName): bool {
         if ($assetName instanceof AbstractAsset) {
             $assetName = $assetName->getName();
         }

--- a/docs/en/reference/generating-migrations.rst
+++ b/docs/en/reference/generating-migrations.rst
@@ -260,7 +260,13 @@ with a schema filter.
 
 .. code-block:: php
 
-    $connection->getConfiguration()->setFilterSchemaAssetsExpression("~^(?!t_)~");
+    $connection->getConfiguration()->setSchemaAssetsFilter(static function ($assetName) {
+        if ($assetName instanceof AbstractAsset) {
+            $assetName = $assetName->getName();
+        }
+
+        return preg_match("~^(?!t_)~", $assetName);
+    });
 
 With this expression all tables prefixed with t_ will ignored by the schema tool.
 

--- a/docs/en/reference/generating-migrations.rst
+++ b/docs/en/reference/generating-migrations.rst
@@ -265,7 +265,7 @@ with a schema filter.
             $assetName = $assetName->getName();
         }
 
-        return preg_match("~^(?!t_)~", $assetName);
+        return (bool) preg_match("~^(?!t_)~", $assetName);
     });
 
 With this expression all tables prefixed with t_ will ignored by the schema tool.


### PR DESCRIPTION


<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

The setFilterSchemaAssetsExpression function no longer exists. Here is a small fix the way I found in order to be able to ignore tables without going through the parameter in the command but directly in the configuration.
