### PR TITLE
Don't throw NoMappingFound from OrmSchemaProvider

### DIFF
--- a/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Provider;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\Provider\Exception\NoMappingFound;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
 
-use function count;
 use function usort;
 
 /**
@@ -29,17 +27,10 @@ final class OrmSchemaProvider implements SchemaProvider
         $this->entityManager = $em;
     }
 
-    /**
-     * @throws NoMappingFound
-     */
     public function createSchema(): Schema
     {
         /** @var array<int, ClassMetadata<object>> $metadata */
         $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
-
-        if (count($metadata) === 0) {
-            throw NoMappingFound::new();
-        }
 
         usort($metadata, static function (ClassMetadata $a, ClassMetadata $b): int {
             return $a->getTableName() <=> $b->getTableName();

--- a/tests/Doctrine/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\ORMSetup;
-use UnexpectedValueException;
 
 /**
  * Tests the OrmSchemaProvider using a real entity manager.
@@ -37,10 +36,14 @@ class OrmSchemaProviderTest extends MigrationTestCase
         }
     }
 
-    public function testEntityManagerWithoutMetadataCausesError(): void
+    /**
+     * It should be OK to use migrations to manage tables not managed by
+     * the ORM.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testEntityManagerWithoutMetadata(): void
     {
-        $this->expectException(UnexpectedValueException::class);
-
         $this->config->setMetadataDriverImpl(new XmlDriver([]));
 
         $this->ormProvider->createSchema();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | -

This is something we figured out in Symfony: when there is no mapping info available, it doesn't mean there is no migration to generate. This happens when there are schema listeners that integrate with migrations, as is the case for those:
https://github.com/symfony/symfony/tree/6.2/src/Symfony/Bridge/Doctrine/SchemaListener

Right now, one has to have entities before they can generate migrations, but those schema are entity-less.

Removing this check does the job.