### PR TITLE
Remove stable specifiction for v3.3.x

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -27,8 +27,7 @@
             "name": "3.3",
             "branchName": "3.3.x",
             "slug": "3.3",
-            "aliases": ["stable"],
-            "current": true
+            "maintained": false
         },
         {
             "name": "3.2",


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

On Slack, I was told by Grégoire Paris that the 3.3.x branch was mistakenly marked as stable.
