### PR TITLE
Use correct default values for VersionColumnLength in doc

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -27,7 +27,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
             'table_storage' => [
                 'table_name' => 'doctrine_migration_versions',
                 'version_column_name' => 'version',
-                'version_column_length' => 1024,
+                'version_column_length' => 191,
                 'executed_at_column_name' => 'executed_at',
                 'execution_time_column_name' => 'execution_time',
             ],
@@ -50,7 +50,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
         table_storage:
            table_name: doctrine_migration_versions
            version_column_name: version
-           version_column_length: 1024
+           version_column_length: 191
            executed_at_column_name: executed_at
            execution_time_column_name: execution_time
 
@@ -81,7 +81,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
                 <table-storage
                         table-name="doctrine_migration_versions"
                         version-column-name="version"
-                        version-column-length="1024"
+                        version-column-length="191"
                         executed-at-column-name="executed_at"
                         execution-time-column-name="execution_time"
                 />
@@ -104,7 +104,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
             "table_storage": {
                "table_name": "doctrine_migration_versions",
                "version_column_name": "version",
-               "version_column_length": 1024,
+               "version_column_length": 191,
                "executed_at_column_name": "executed_at",
                "execution_time_column_name": "execution_time"
             },
@@ -164,7 +164,7 @@ Here the possible options for ``table_storage``:
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 | version_column_name        | no         | version                      | The name of the column which stores the version name.                            |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| version_column_length      | no         | 1024                         | The length of the column which stores the version name.                          |
+| version_column_length      | no         | 191                         | The length of the column which stores the version name.                          |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 | executed_at_column_name    | no         | executed_at                  | The name of the column which stores the date that a migration was executed.      |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+


### PR DESCRIPTION
See [TableMetadataStorageConfiguration](https://github.com/doctrine/migrations/blob/5713b45c933122e509d9b31c767b420c3dfed399/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorageConfiguration.php)

Relevant
https://github.com/doctrine/migrations/pull/960 (from 1024 -> 191)

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug (documentation)
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The documentation references 1024 as default version column length, but the actual default value is 191. https://github.com/doctrine/migrations/blob/5713b45c933122e509d9b31c767b420c3dfed399/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorageConfiguration.php