### PR TITLE
Handle absence of value for `--all-or-nothing` properly

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -75,7 +75,8 @@ final class MigrateCommand extends DoctrineCommand
                 'all-or-nothing',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Wrap the entire migration in a transaction.'
+                'Wrap the entire migration in a transaction.',
+                'notprovided'
             )
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command executes a migration to a specified version or the latest available version:

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -21,12 +21,26 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
     {
         $timeAllQueries = $input->hasOption('query-time') ? (bool) $input->getOption('query-time') : false;
         $dryRun         = $input->hasOption('dry-run') ? (bool) $input->getOption('dry-run') : false;
-        $allOrNothing   = $input->hasOption('all-or-nothing') ? $input->getOption('all-or-nothing') : null;
-        $allOrNothing   = (bool) ($allOrNothing ?? $this->configuration->isAllOrNothing());
+        $allOrNothing   = $this->determineAllOrNothingValueFrom($input) ?? $this->configuration->isAllOrNothing();
 
         return (new MigratorConfiguration())
             ->setDryRun($dryRun)
             ->setTimeAllQueries($timeAllQueries)
             ->setAllOrNothing($allOrNothing);
+    }
+
+    private function determineAllOrNothingValueFrom(InputInterface $input): ?bool
+    {
+        $allOrNothingOption = null;
+
+        if ($input->hasOption('all-or-nothing')) {
+            $allOrNothingOption = $input->getOption('all-or-nothing');
+        }
+
+        if ($allOrNothingOption === 'notprovided') {
+            return null;
+        }
+
+        return (bool) ($allOrNothingOption ?? true);
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -362,7 +362,7 @@ class MigrateCommandTest extends MigrationTestCase
     }
 
     /**
-     * @psalm-param array<string, bool> $input
+     * @psalm-param array<string, bool|int|string|null> $input
      *
      * @dataProvider allOrNothing
      */
@@ -390,13 +390,22 @@ class MigrateCommandTest extends MigrationTestCase
     }
 
     /**
-     * @psalm-return Generator<array{bool, array<string, bool>, bool}>
+     * @psalm-return Generator<array{bool, array<string, bool|int|string|null>, bool}>
      */
     public function allOrNothing(): Generator
     {
         yield [false, ['--all-or-nothing' => false], false];
+        yield [false, ['--all-or-nothing' => 0], false];
+        yield [false, ['--all-or-nothing' => '0'], false];
+
         yield [false, ['--all-or-nothing' => true], true];
+        yield [false, ['--all-or-nothing' => 1], true];
+        yield [false, ['--all-or-nothing' => '1'], true];
+        yield [false, ['--all-or-nothing' => null], true];
+
         yield [true, ['--all-or-nothing' => false], false];
+        yield [true, ['--all-or-nothing' => 0], false];
+        yield [true, ['--all-or-nothing' => '0'], false];
 
         yield [true, [], true];
         yield [false, [], false];


### PR DESCRIPTION
### Expected behavior:
Upon specification of the option `--all-or-nothing` wraps multiple migrations into a transaction

### Observed behavior
Specifying `--all-or-nothing` by itself does not cause the desired effect, as the result of the statement `$input->getOption('all-or-nothing')` is `null`, and therefore, in the absence of config, this value is ultimately evaluated to `false`, therefore not wrapping multiple migrations into a single transaction.


<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/migrations/issues/1279 

#### Summary

<!-- Provide a summary your change. -->
