### PR TITLE
Adds success message for migrations command

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -27,7 +27,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
             'table_storage' => [
                 'table_name' => 'doctrine_migration_versions',
                 'version_column_name' => 'version',
-                'version_column_length' => 1024,
+                'version_column_length' => 191,
                 'executed_at_column_name' => 'executed_at',
                 'execution_time_column_name' => 'execution_time',
             ],
@@ -50,7 +50,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
         table_storage:
            table_name: doctrine_migration_versions
            version_column_name: version
-           version_column_length: 1024
+           version_column_length: 191
            executed_at_column_name: executed_at
            execution_time_column_name: execution_time
 
@@ -81,7 +81,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
                 <table-storage
                         table-name="doctrine_migration_versions"
                         version-column-name="version"
-                        version-column-length="1024"
+                        version-column-length="191"
                         executed-at-column-name="executed_at"
                         execution-time-column-name="execution_time"
                 />
@@ -104,7 +104,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
             "table_storage": {
                "table_name": "doctrine_migration_versions",
                "version_column_name": "version",
-               "version_column_length": 1024,
+               "version_column_length": 191,
                "executed_at_column_name": "executed_at",
                "execution_time_column_name": "execution_time"
             },
@@ -164,7 +164,7 @@ Here the possible options for ``table_storage``:
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 | version_column_name        | no         | version                      | The name of the column which stores the version name.                            |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| version_column_length      | no         | 1024                         | The length of the column which stores the version name.                          |
+| version_column_length      | no         | 191                         | The length of the column which stores the version name.                          |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
 | executed_at_column_name    | no         | executed_at                  | The name of the column which stores the date that a migration was executed.      |
 +----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+

--- a/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
+++ b/lib/Doctrine/Migrations/Provider/OrmSchemaProvider.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Provider;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\Provider\Exception\NoMappingFound;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\SchemaTool;
 
-use function count;
 use function usort;
 
 /**
@@ -29,17 +27,10 @@ final class OrmSchemaProvider implements SchemaProvider
         $this->entityManager = $em;
     }
 
-    /**
-     * @throws NoMappingFound
-     */
     public function createSchema(): Schema
     {
         /** @var array<int, ClassMetadata<object>> $metadata */
         $metadata = $this->entityManager->getMetadataFactory()->getAllMetadata();
-
-        if (count($metadata) === 0) {
-            throw NoMappingFound::new();
-        }
 
         usort($metadata, static function (ClassMetadata $a, ClassMetadata $b): int {
             return $a->getTableName() <=> $b->getTableName();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-
 use function count;
 use function dirname;
 use function getcwd;
@@ -202,7 +201,7 @@ EOT
             'Migrating' . ($migratorConfiguration->isDryRun() ? ' (dry-run)' : '') . ' {direction} to {to}',
             [
                 'direction' => $plan->getDirection(),
-                'to' => (string) $version,
+                'to'        => (string) $version,
             ]
         );
 
@@ -214,6 +213,10 @@ EOT
             $writer->write($path, $plan->getDirection(), $sql);
         }
 
+        $this->io->success(sprintf(
+            'Successfully migrated to version : %s',
+            $version
+        ));
         $this->io->newLine();
 
         return 0;

--- a/tests/Doctrine/Migrations/Tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Provider/OrmSchemaProviderTest.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\ORMSetup;
-use UnexpectedValueException;
 
 /**
  * Tests the OrmSchemaProvider using a real entity manager.
@@ -37,10 +36,14 @@ class OrmSchemaProviderTest extends MigrationTestCase
         }
     }
 
-    public function testEntityManagerWithoutMetadataCausesError(): void
+    /**
+     * It should be OK to use migrations to manage tables not managed by
+     * the ORM.
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testEntityManagerWithoutMetadata(): void
     {
-        $this->expectException(UnexpectedValueException::class);
-
         $this->config->setMetadataDriverImpl(new XmlDriver([]));
 
         $this->ormProvider->createSchema();

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -294,6 +294,7 @@ class MigrateCommandTest extends MigrationTestCase
 
         self::assertSame(0, $this->migrateCommandTester->getStatusCode());
         self::assertStringContainsString('[notice] Migrating up to A', trim($this->migrateCommandTester->getDisplay(true)));
+        self::assertStringContainsString('[OK] Successfully migrated to version : A', trim($this->migrateCommandTester->getDisplay(true)));
     }
 
     public function testExecuteMigrateUpdatesMigrationsTableWhenNeeded(): void


### PR DESCRIPTION
- Added success message before new line for successful migrations
- updated unit tests

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

When executing a successful migration, the only output from the command when not using verbosity levels is a blank new line. When running from something like ansible, it's sometimes nice to see an output. This PR adds a single line output to denote a successful migration to version XXX

Examples:

Previously you would need to run the migration twice to ensure that the update was successful:

![image](https://user-images.githubusercontent.com/5278964/211762326-e34f64b2-c27e-408e-bc44-ef806937da1b.png)

This is how it will look on first run with the new change:

![image](https://user-images.githubusercontent.com/5278964/211761667-dfa25493-756b-490f-9e52-664a84fb60db.png)

