### PR TITLE
Drop support for silencing errors about DDL in transactions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,8 @@
+# Upgrade to 4.0
+
+It is no longer possible to relying on silencing to enable transactional
+migrations when the platform does not allow DDL inside transactions.
+
 # Upgrade to 3.1
 
 - The "version" is the FQCN of the migration class (existing entries in the migrations table will be automatically updated).

--- a/lib/Doctrine/Migrations/DbalMigrator.php
+++ b/lib/Doctrine/Migrations/DbalMigrator.php
@@ -73,14 +73,14 @@ class DbalMigrator implements Migrator
             $this->dispatcher->dispatchMigrationEvent(Events::onMigrationsMigrated, $migrationsPlan, $migratorConfiguration);
         } catch (Throwable $e) {
             if ($allOrNothing) {
-                TransactionHelper::rollbackIfInTransaction($this->connection);
+                TransactionHelper::rollback($this->connection);
             }
 
             throw $e;
         }
 
         if ($allOrNothing) {
-            TransactionHelper::commitIfInTransaction($this->connection);
+            TransactionHelper::commit($this->connection);
         }
 
         return $sql;

--- a/lib/Doctrine/Migrations/Event/Listeners/AutoCommitListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/AutoCommitListener.php
@@ -26,7 +26,7 @@ final class AutoCommitListener implements EventSubscriber
             return;
         }
 
-        TransactionHelper::commitIfInTransaction($conn);
+        TransactionHelper::commit($conn);
     }
 
     /** {@inheritdoc} */

--- a/lib/Doctrine/Migrations/Tools/TransactionHelper.php
+++ b/lib/Doctrine/Migrations/Tools/TransactionHelper.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tools;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\Deprecations\Deprecation;
 use LogicException;
 use PDO;
 
@@ -16,43 +15,35 @@ use function method_exists;
  */
 final class TransactionHelper
 {
-    public static function commitIfInTransaction(Connection $connection): void
+    public static function commit(Connection $connection): void
     {
         if (! self::inTransaction($connection)) {
-            Deprecation::trigger(
-                'doctrine/migrations',
-                'https://github.com/doctrine/migrations/issues/1169',
-                <<<'DEPRECATION'
+            throw new LogicException(
+                <<<'EXCEPTION'
 Context: trying to commit a transaction
-Problem: the transaction is already committed, relying on silencing is deprecated.
+Problem: the transaction is already committed.
 Solution: override `AbstractMigration::isTransactional()` so that it returns false.
 Automate that by setting `transactional` to false in the configuration.
 More details at https://www.doctrine-project.org/projects/doctrine-migrations/en/3.2/explanation/implicit-commits.html
-DEPRECATION
+EXCEPTION
             );
-
-            return;
         }
 
         $connection->commit();
     }
 
-    public static function rollbackIfInTransaction(Connection $connection): void
+    public static function rollback(Connection $connection): void
     {
         if (! self::inTransaction($connection)) {
-            Deprecation::trigger(
-                'doctrine/migrations',
-                'https://github.com/doctrine/migrations/issues/1169',
-                <<<'DEPRECATION'
+            throw new LogicException(
+                <<<'EXCEPTION'
 Context: trying to rollback a transaction
-Problem: the transaction is already rolled back, relying on silencing is deprecated.
+Problem: the transaction is already rolled back.
 Solution: override `AbstractMigration::isTransactional()` so that it returns false.
 Automate that by setting `transactional` to false in the configuration.
 More details at https://www.doctrine-project.org/projects/doctrine-migrations/en/3.2/explanation/implicit-commits.html
-DEPRECATION
+EXCEPTION
             );
-
-            return;
         }
 
         $connection->rollBack();

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -211,7 +211,7 @@ final class DbalExecutor implements Executor
         }
 
         if ($migration->isTransactional()) {
-            TransactionHelper::commitIfInTransaction($this->connection);
+            TransactionHelper::commit($this->connection);
         }
 
         $plan->markAsExecuted($result);
@@ -252,7 +252,7 @@ final class DbalExecutor implements Executor
         $migration = $plan->getMigration();
         if ($migration->isTransactional()) {
             //only rollback transaction if in transactional mode
-            TransactionHelper::rollbackIfInTransaction($this->connection);
+            TransactionHelper::rollback($this->connection);
         }
 
         $plan->markAsExecuted($result);


### PR DESCRIPTION
I hesitated between this and removing the transaction helper entirely, but I think this solution will result in less support for us. Let me know if you think I should remove the transaction helper.