### PR TITLE
Added success message for Command Output

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -215,6 +215,10 @@ EOT
             $writer->write($path, $plan->getDirection(), $sql);
         }
 
+        $this->io->success(sprintf(
+            'Successfully migrated to version : %s',
+            $version
+        ));
         $this->io->newLine();
 
         return 0;

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -294,6 +294,7 @@ class MigrateCommandTest extends MigrationTestCase
 
         self::assertSame(0, $this->migrateCommandTester->getStatusCode());
         self::assertStringContainsString('[notice] Migrating up to A', trim($this->migrateCommandTester->getDisplay(true)));
+        self::assertStringContainsString('[OK] Successfully migrated to version : A', trim($this->migrateCommandTester->getDisplay(true)));
     }
 
     public function testExecuteMigrateUpdatesMigrationsTableWhenNeeded(): void


### PR DESCRIPTION
- Added success message before new line for successful migrations
- updated unit tests

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | none

#### Summary

When executing a successful migration, the only output from the command when not using verbosity levels is a blank new line. When running from something like ansible, it's sometimes nice to see an output. This PR adds a single line output to denote a successful migration to version XXX

Examples:

Previously you would need to run the migration twice to ensure that the update was successful:

![image](https://user-images.githubusercontent.com/5278964/211822012-66521845-6413-466f-995d-ddd213553c8c.png)

This is how it will look on first run with the new change:

![image](https://user-images.githubusercontent.com/5278964/211822065-65f58cc3-1d31-4b2a-807f-e5c5a0063a54.png)

