### PR TITLE
Deprecate using `--all-or-nothing` with values

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,12 @@
+# Upgrade to 3.6
+
+## Console
+- The `--all-or-nothing` option for `migrations:migrate` does not accept a value anymore, and passing it a 
+  value will generate a deprecation. Specifying `--all-or-nothing` will wrap all the migrations to be 
+  executed into a single transaction, regardless of the specified configuration.
+
+
+
 # Upgrade to 3.1
 
 - The "version" is the FQCN of the migration class (existing entries in the migrations table will be automatically updated).

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console;
 
+use Doctrine\Deprecations\Deprecation;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\MigratorConfiguration;
 use Symfony\Component\Console\Input\InputInterface;
@@ -28,16 +29,30 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
 
     private function determineAllOrNothingValueFrom(InputInterface $input): bool|null
     {
-        if (! $input->hasOption('all-or-nothing')) {
-            return null;
+        $allOrNothingOption        = null;
+        $wasOptionExplicitlyPassed = $input->hasOption('all-or-nothing');
+
+        if ($wasOptionExplicitlyPassed) {
+            $allOrNothingOption = $input->getOption('all-or-nothing');
         }
 
-        $allOrNothingOption = $input->getOption('all-or-nothing');
+        if ($wasOptionExplicitlyPassed && $allOrNothingOption !== null) {
+            Deprecation::trigger(
+                'doctrine/migrations',
+                'https://github.com/doctrine/migrations/issues/1304',
+                <<<'DEPRECATION'
+                    Context: Passing values to option `--all-or-nothing`
+                    Problem: Passing values is deprecated
+                    Solution: From version 4.0.x, `--all-or-nothing` option won't accept any value, 
+                    and the presence of the option will be treated as `true`.
+                    DEPRECATION,
+            );
+        }
 
         if ($allOrNothingOption === 'notprovided') {
             return null;
         }
 
-        return (bool) ($allOrNothingOption ?? true);
+        return (bool) ($allOrNothingOption ?? false);
     }
 }

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -43,8 +43,8 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
                 <<<'DEPRECATION'
                     Context: Passing values to option `--all-or-nothing`
                     Problem: Passing values is deprecated
-                    Solution: From version 4.0.x, `--all-or-nothing` option won't accept any value, 
-                    and the presence of the option will be treated as `true`.
+                    Solution: If you need to disable the behavior, omit the option,
+                    otherwise, pass the option without a value
                     DEPRECATION,
             );
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | deprecation
| BC Break     | yes, in the major version 4
| Fixed issues | https://github.com/doctrine/migrations/issues/1304

#### Summary
During the iteration of the PR https://github.com/doctrine/migrations/pull/1296 an idea to deprecate passing values to this option was suggested, given how complicated was to handle using that option without any value, which led to a bug and inconsistency with the documentation.

As specified in the deprecation message, using this option from 4.0.x onwards in the CLI will be treated as `true`, and the option itself won't accept values.

