### PR TITLE
Fixed `all-or-nothing` console input value determination.

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -31,11 +31,11 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
 
     private function determineAllOrNothingValueFrom(InputInterface $input): ?bool
     {
-        $allOrNothingOption = null;
-
-        if ($input->hasOption('all-or-nothing')) {
-            $allOrNothingOption = $input->getOption('all-or-nothing');
+        if (! $input->hasOption('all-or-nothing')) {
+            return null;
         }
+
+        $allOrNothingOption = $input->getOption('all-or-nothing');
 
         if ($allOrNothingOption === 'notprovided') {
             return null;

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -177,6 +177,28 @@ class ExecuteCommandTest extends MigrationTestCase
         self::assertSame(1, $this->executeCommandTester->getStatusCode());
     }
 
+    public function testExecuteAllOrNothingDefaultsToFalse(): void
+    {
+        $this->executeCommandTester->setInputs(['yes']);
+
+        $this->migrator
+            ->expects(self::once())
+            ->method('migrate')
+            ->willReturnCallback(static function (MigrationPlanList $planList, MigratorConfiguration $configuration): array {
+                self::assertFalse($configuration->isAllOrNothing());
+
+                return ['A'];
+            });
+
+        $this->executeCommandTester->execute([
+            'versions' => ['1'],
+            '--down' => true,
+        ]);
+
+        self::assertSame(0, $this->executeCommandTester->getStatusCode());
+        self::assertStringContainsString('[notice] Executing 1 up', trim($this->executeCommandTester->getDisplay(true)));
+    }
+
     protected function setUp(): void
     {
         $connection = $this->getSqliteConnection();


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes

#### Summary

This fixes a bug that was introduced in #1296 where the configuration value of `MigratorConfiguration::allOrNothing` got set to `true` if the command didn't have an `all-or-nothing` option. Now the value is set from input options only if the command that is being executed has an `all-or-nothing` option.
