### PR TITLE
Add doctrine/event-manager:v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "composer-runtime-api": "^2",
         "doctrine/dbal": "^3.5.1",
         "doctrine/deprecations": "^0.5.3 || ^1",
-        "doctrine/event-manager": "^1.0",
+        "doctrine/event-manager": "^1.2 || ^2.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "psr/log": "^1.1.3 || ^2 || ^3",
         "symfony/console": "^4.4.16 || ^5.4 || ^6.0",


### PR DESCRIPTION
https://github.com/doctrine/migrations/pull/1295 seems stalled.

Now that https://github.com/doctrine/migrations/pull/1297 has been merged, CI should pass