### PR TITLE
Removed preceding whitespace at colons in info and help messages

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -163,7 +163,7 @@ EOT
         }
 
         $this->io->success(sprintf(
-            'Successfully migrated version(s) : %s : [%s]',
+            'Successfully migrated version(s): %s: [%s]',
             implode(', ', $versions),
             strtoupper($plan->getDirection())
         ));

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -95,7 +95,7 @@ You can optionally manually specify the version you wish to migrate to:
 You can specify the version you wish to migrate to using an alias:
 
     <info>%command.full_name% prev</info>
-    <info>These alias are defined : first, latest, prev, current and next</info>
+    <info>These alias are defined: first, latest, prev, current and next</info>
 
 You can specify the version you wish to migrate to using an number against the current version:
 
@@ -216,7 +216,7 @@ EOT
         }
 
         $this->io->success(sprintf(
-            'Successfully migrated to version : %s',
+            'Successfully migrated to version: %s',
             $version
         ));
         $this->io->newLine();

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -118,7 +118,7 @@ class ExecuteCommandTest extends MigrationTestCase
 
         self::assertSame(0, $this->executeCommandTester->getStatusCode());
         self::assertStringContainsString('[notice] Executing 1 up', trim($this->executeCommandTester->getDisplay(true)));
-        self::assertStringContainsString('[OK] Successfully migrated version(s) : 1 : [UP]', trim($this->executeCommandTester->getDisplay(true)));
+        self::assertStringContainsString('[OK] Successfully migrated version(s): 1: [UP]', trim($this->executeCommandTester->getDisplay(true)));
     }
 
     public function testExecuteMultiple(): void

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -294,7 +294,7 @@ class MigrateCommandTest extends MigrationTestCase
 
         self::assertSame(0, $this->migrateCommandTester->getStatusCode());
         self::assertStringContainsString('[notice] Migrating up to A', trim($this->migrateCommandTester->getDisplay(true)));
-        self::assertStringContainsString('[OK] Successfully migrated to version : A', trim($this->migrateCommandTester->getDisplay(true)));
+        self::assertStringContainsString('[OK] Successfully migrated to version: A', trim($this->migrateCommandTester->getDisplay(true)));
     }
 
     public function testExecuteMigrateUpdatesMigrationsTableWhenNeeded(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | #1303 

#### Summary

In #1303 it was proposed to add new info messages, However, as denoted in [this comment](https://github.com/doctrine/migrations/pull/1303#issuecomment-1432084776), the info messages contain colons which are preceded by whitespaces. As this is not grammatically correct in the English language, a PR is provided to resolve it.