### PR TITLE
Make it possible to `addSql()` that is executed as a statement

### DIFF
--- a/lib/Doctrine/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/Migrations/AbstractMigration.php
@@ -126,9 +126,10 @@ abstract class AbstractMigration
     protected function addSql(
         string $sql,
         array $params = [],
-        array $types = []
+        array $types = [],
+        bool $executeAsStatement = false
     ): void {
-        $this->plannedSql[] = new Query($sql, $params, $types);
+        $this->plannedSql[] = new Query($sql, $params, $types, $executeAsStatement);
     }
 
     /** @return Query[] */

--- a/lib/Doctrine/Migrations/Query/Query.php
+++ b/lib/Doctrine/Migrations/Query/Query.php
@@ -21,19 +21,22 @@ final class Query
     /** @var mixed[] */
     private array $types;
 
+    private bool $executeAsStatement;
+
     /**
      * @param mixed[] $parameters
      * @param mixed[] $types
      */
-    public function __construct(string $statement, array $parameters = [], array $types = [])
+    public function __construct(string $statement, array $parameters = [], array $types = [], bool $executeAsStatement = false)
     {
         if (count($types) > count($parameters)) {
             throw InvalidArguments::wrongTypesArgumentCount($statement, count($parameters), count($types));
         }
 
-        $this->statement  = $statement;
-        $this->parameters = $parameters;
-        $this->types      = $types;
+        $this->statement          = $statement;
+        $this->parameters         = $parameters;
+        $this->types              = $types;
+        $this->executeAsStatement = $executeAsStatement;
     }
 
     public function __toString(): string
@@ -56,5 +59,10 @@ final class Query
     public function getTypes(): array
     {
         return $this->types;
+    }
+
+    public function getExecuteAsStatement(): bool
+    {
+        return $this->executeAsStatement;
     }
 }

--- a/lib/Doctrine/Migrations/Version/DbalExecutor.php
+++ b/lib/Doctrine/Migrations/Version/DbalExecutor.php
@@ -290,8 +290,13 @@ final class DbalExecutor implements Executor
             $this->outputSqlQuery($query, $configuration);
 
             $stopwatchEvent = $this->stopwatch->start('query');
-            // executeQuery() must be used here because $query might return a result set, for instance REPAIR does
-            $this->connection->executeQuery($query->getStatement(), $query->getParameters(), $query->getTypes());
+
+            if ($query->getExecuteAsStatement()) {
+                $this->connection->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
+            } else {
+                $this->connection->executeQuery($query->getStatement(), $query->getParameters(), $query->getTypes());
+            }
+
             $stopwatchEvent->stop();
 
             if (! $configuration->getTimeAllQueries()) {

--- a/tests/Doctrine/Migrations/Tests/Version/Fixture/TestMigrationWithStatement.php
+++ b/tests/Doctrine/Migrations/Tests/Version/Fixture/TestMigrationWithStatement.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Version\Fixture;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class TestMigrationWithStatement extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TRIGGER', executeAsStatement: true);
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | fixes #1325

#### Summary

When the DBAL connection uses `mysqli` as the driver, prepared statements are sent to the MySQL server through a dedicated protocol mechanism. For example, `CREATE TRIGGER` statements are not possible in this case.

To use SQL statements like `CREATE TRIGGER`, the `DbalExecutor` may not (at least in the case of the `mysqli` driver) use `Connection::executeQuery()`, but has to call `Connection::executeStatement()`. See #1325 for more details.

This PR adds a new `executeAsStatement` parameter to `\Doctrine\Migrations\AbstractMigration::addSql()`, which defaults to `false` (current behaviour). 

By setting it to `true`, a migration can pass the information to the `DbalExecutor` that the statement must be executed with `executeStatement()` instead of `executeQuery()`.
