### PR TITLE
Apply assets filter on sequences

### DIFF
--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -120,6 +120,16 @@ class DiffGenerator
 
                 $toSchema->dropTable($tableName);
             }
+
+            foreach ($toSchema->getSequences() as $sequence) {
+                $sequenceName = $sequence->getName();
+
+                if ($schemaAssetsFilter($sequenceName)) {
+                    continue;
+                }
+
+                $toSchema->dropSequence($sequenceName);
+            }
         }
 
         return $toSchema;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Asset filter is used for tables and sequences on `fromSchema`, but only for tables on `toSchema`. It generates `CREATE SEQUENCE` migration query. This PR applies the filter for sequences on `toSchema`.

<!-- Provide a summary your change. -->
