### PR TITLE
build: Fix cleanup of the backup composer lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 tests/phpunit.xml
 vendor/
 /composer.lock
+/composer.lock.back
 phpunit.xml
 /.phpunit.result.cache
 /phpcs.xml

--- a/build-phar.sh
+++ b/build-phar.sh
@@ -9,11 +9,11 @@ function restorePlatform {
     mv -f composer.lock.back composer.lock || true
 }
 
+trap restorePlatform exit
+
 # lock PHP to minimum allowed version
 composer config platform.php 7.2.0
 cp composer.lock composer.lock.back || true
 composer update
 
 php box.phar compile -vv
-
-trap restorePlatform exit


### PR DESCRIPTION
The trap function was registered as the last bash instruction and as a result was not executed if anything failed before, e.g. the composer update command or building the PHAR itself.

In the event the build PHAR script fails, the temporary backup composer.lock file may be created and not removed.

Also add the backup composer.lock file to the gitignore for good measure.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | yes
