### PR TITLE
build: Use the new compactors

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,8 +1,8 @@
 {
     "alias": "doctrine-migrations.phar",
     "compactors": [
-        "Herrera\\Box\\Compactor\\Php",
-        "Herrera\\Box\\Compactor\\Json"
+        "KevinGH\\Box\\Compactor\\Php",
+        "KevinGH\\Box\\Compactor\\Json"
     ],
     "compression": "GZ",
     "main": "bin/doctrine-migrations.php",


### PR DESCRIPTION
Those compactors are stricly identical to the old ones, only the FQCN changed (and they are removed in Box 4.x).

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
