### PR TITLE
Remove ignore rule for @method-provided method

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -43,10 +43,6 @@ parameters:
             count: 1
             path: tests/Doctrine/Migrations/Tests/Tools/Console/legacy-config-orm/cli-config.php
 
-        -
-            message: '~^Call to function method_exists\(\) with Doctrine\\Migrations\\Metadata\\Storage\\MetadataStorage and ''getSql'' will always evaluate to true\.$~'
-            path: lib/Doctrine/Migrations/Version/DbalExecutor.php
-
         # TODO: deprecate using the connection event manager and expose
         # our own event manager instead.
         -


### PR DESCRIPTION
It looks like PHPStan no longer treats `@method` as a guarantee that the method will exist.