### PR TITLE
Drop support for Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "psr/log": "^1.1.3 || ^2 || ^3",
-        "symfony/console": "^4.4.16 || ^5.4 || ^6.0",
-        "symfony/stopwatch": "^4.4 || ^5.4 || ^6.0",
+        "symfony/console": "^5.4 || ^6.0",
+        "symfony/stopwatch": "^5.4 || ^6.0",
         "symfony/var-exporter": "^6.2"
     },
     "require-dev": {
@@ -46,9 +46,9 @@
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^10.3",
-        "symfony/cache": "^4.4 || ^5.4 || ^6.0",
-        "symfony/process": "^4.4 || ^5.4 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
+        "symfony/cache": "^5.4 || ^6.0",
+        "symfony/process": "^5.4 || ^6.0",
+        "symfony/yaml": "^5.4 || ^6.0"
     },
     "conflict": {
         "doctrine/orm": "<2.12"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

Symfony 4 is EOL. Let's make our lives easier by removing it from our test matrix.
