### PR TITLE
Allow doctrine/deprecations 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^7.2 || ^8.0",
         "composer-runtime-api": "^2",
         "doctrine/dbal": "^2.11 || ^3.0",
-        "doctrine/deprecations": "^0.5.3",
+        "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.0",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "psr/log": "^1.1.3 || ^2 || ^3",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

3.4.x is the last branch that still supports DBAL 2. Unfortunately, it does not allow the installation of Deprecations 1.0 although there haven't been breaking changes between 0.5 and 1.0. This in turn blocks upgrading to recent versions of the ORM.

It would make the upgrade path for projects that are still on DBAL 2 a lot easier if we pushed a new 3.4.x tag that allows `doctrine/deprecations` 1.x.
