### PR TITLE
Remove overrides of deprecated static Command properties

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/CurrentCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/CurrentCommand.php
@@ -17,9 +17,6 @@ use function sprintf;
 #[AsCommand(name: 'migrations:current', description: 'Outputs the current version')]
 final class CurrentCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:current';
-
     protected function configure(): void
     {
         $this

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DiffCommand.php
@@ -33,9 +33,6 @@ use const FILTER_VALIDATE_BOOLEAN;
 #[AsCommand(name: 'migrations:diff', description: 'Generate a migration by comparing your current database to your mapping information.')]
 final class DiffCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:diff';
-
     protected function configure(): void
     {
         parent::configure();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -29,9 +29,6 @@ use function str_contains;
 #[AsCommand(name: 'migrations:dump-schema', description: 'Dump the schema for your database to a migration.')]
 final class DumpSchemaCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:dump-schema';
-
     protected function configure(): void
     {
         parent::configure();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -28,9 +28,6 @@ use function strtoupper;
 #[AsCommand(name: 'migrations:execute', description: 'Execute one or more migration versions up or down manually.')]
 final class ExecuteCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:execute';
-
     protected function configure(): void
     {
         $this

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -21,9 +21,6 @@ use function sprintf;
 #[AsCommand(name: 'migrations:generate', description: 'Generate a blank migration class.')]
 final class GenerateCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:generate';
-
     protected function configure(): void
     {
         $this

--- a/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/LatestCommand.php
@@ -17,9 +17,6 @@ use function sprintf;
 #[AsCommand(name: 'migrations:latest', description: 'Outputs the latest version')]
 final class LatestCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:latest';
-
     protected function configure(): void
     {
         $this

--- a/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/ListCommand.php
@@ -24,9 +24,6 @@ use function uasort;
 #[AsCommand(name: 'migrations:list', description: 'Display a list of all available migrations and their status.')]
 final class ListCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:list';
-
     protected function configure(): void
     {
         $this

--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -32,9 +32,6 @@ use function str_starts_with;
 #[AsCommand(name: 'migrations:migrate', description: 'Execute a migration to a specified version or the latest available version.')]
 final class MigrateCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:migrate';
-
     protected function configure(): void
     {
         $this

--- a/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/RollupCommand.php
@@ -17,9 +17,6 @@ use function sprintf;
 #[AsCommand(name: 'migrations:rollup', description: 'Rollup migrations by deleting all tracked versions and insert the one version that exists.')]
 final class RollupCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:rollup';
-
     protected function configure(): void
     {
         parent::configure();

--- a/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/StatusCommand.php
@@ -15,12 +15,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'migrations:status', description: 'View the status of a set of migrations.')]
 final class StatusCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:status';
-
     protected function configure(): void
     {
         $this
+            ->setName('migrations:status')
             ->setAliases(['status'])
             ->setDescription('View the status of a set of migrations.')
             ->setHelp(<<<'EOT'

--- a/lib/Doctrine/Migrations/Tools/Console/Command/SyncMetadataCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/SyncMetadataCommand.php
@@ -11,14 +11,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'migrations:sync-metadata-storage', description: 'Ensures that the metadata storage is at the latest version.')]
 final class SyncMetadataCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:sync-metadata-storage';
-
     protected function configure(): void
     {
         parent::configure();
 
         $this
+            ->setName('migrations:sync-metadata-storage')
             ->setAliases(['sync-metadata-storage'])
             ->setDescription('Ensures that the metadata storage is at the latest version.')
             ->setHelp(<<<'EOT'

--- a/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/UpToDateCommand.php
@@ -28,12 +28,10 @@ use function uasort;
 #[AsCommand(name: 'migrations:up-to-date', description: 'Tells you if your schema is up-to-date.')]
 final class UpToDateCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:up-to-date';
-
     protected function configure(): void
     {
         $this
+            ->setName('migrations:up-to-date')
             ->setAliases(['up-to-date'])
             ->setDescription('Tells you if your schema is up-to-date.')
             ->addOption('fail-on-unregistered', 'u', InputOption::VALUE_NONE, 'Whether to fail when there are unregistered extra migrations found')

--- a/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/VersionCommand.php
@@ -27,14 +27,12 @@ use function sprintf;
 #[AsCommand(name: 'migrations:version', description: 'Manually add and delete migration versions from the version table.')]
 final class VersionCommand extends DoctrineCommand
 {
-    /** @var string|null */
-    protected static $defaultName = 'migrations:version';
-
     private bool $markMigrated;
 
     protected function configure(): void
     {
         $this
+            ->setName('migrations:version')
             ->setAliases(['version'])
             ->setDescription('Manually add and delete migration versions from the version table.')
             ->addArgument(


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | yes
| Fixed issues | Replaces #1368

#### Summary

Since we use the `AsCommand` attribute, we don't need to override `$defaultName` anymore. Since downstream code might rely on those properties to be present, I'm removing them on the next major.