### PR TITLE
Remove default value for all-or-nothing option to avoid triggering deprecation notice

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -78,7 +78,6 @@ final class MigrateCommand extends DoctrineCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Wrap the entire migration in a transaction.',
-                'notprovided',
             )
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command executes a migration to a specified version or the latest available version:

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -388,8 +388,8 @@ class MigrateCommandTest extends MigrationTestCase
         yield [true, ['--all-or-nothing' => 0], false];
         yield [true, ['--all-or-nothing' => '0'], false];
 
-        yield [true, [], true];
-        yield [false, [], false];
+        yield [true, [], true, false];
+        yield [false, [], false, false];
     }
 
     public function testExecuteMigrateCancelExecutedUnavailableMigrations(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1379
#### Summary

Since 3.7 all-or-nothing option triggers a deprecation notice but `\Doctrine\Migrations\Tools\Console\Command\MigrateCommand::configure` defines a default value to `notprovided` which triggers the notice.
