### PR TITLE
GH-1379: Improve Deprecation thrown check + logic

### DIFF
--- a/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -8,6 +8,7 @@ use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Exception\NoMigrationsToExecute;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
+use Doctrine\Migrations\Tools\Console\ConsoleInputMigratorConfigurationFactory;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
@@ -78,7 +79,7 @@ final class MigrateCommand extends DoctrineCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Wrap the entire migration in a transaction.',
-                'notprovided',
+                ConsoleInputMigratorConfigurationFactory::ABSENT_CONFIG_VALUE,
             )
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command executes a migration to a specified version or the latest available version:

--- a/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
+++ b/lib/Doctrine/Migrations/Tools/Console/ConsoleInputMigratorConfigurationFactory.php
@@ -11,6 +11,8 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationFactory
 {
+    public const ABSENT_CONFIG_VALUE = 'notprovided';
+
     public function __construct(private readonly Configuration $configuration)
     {
     }
@@ -36,7 +38,7 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
             $allOrNothingOption = $input->getOption('all-or-nothing');
         }
 
-        if ($wasOptionExplicitlyPassed && $allOrNothingOption !== null) {
+        if ($wasOptionExplicitlyPassed && ($allOrNothingOption !== null && $allOrNothingOption !== self::ABSENT_CONFIG_VALUE)) {
             Deprecation::trigger(
                 'doctrine/migrations',
                 'https://github.com/doctrine/migrations/issues/1304',
@@ -49,10 +51,10 @@ class ConsoleInputMigratorConfigurationFactory implements MigratorConfigurationF
             );
         }
 
-        if ($allOrNothingOption === 'notprovided') {
-            return null;
-        }
-
-        return (bool) ($allOrNothingOption ?? false);
+        return match ($allOrNothingOption) {
+            self::ABSENT_CONFIG_VALUE => null,
+            null => false,
+            default => (bool) $allOrNothingOption,
+        };
     }
 }

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/MigrateCommandTest.php
@@ -358,11 +358,10 @@ class MigrateCommandTest extends MigrationTestCase
                 return ['A'];
             });
 
-        if ($expectDeprecation) {
-            $this->expectDeprecationWithIdentifier(
-                'https://github.com/doctrine/migrations/issues/1304',
-            );
-        }
+        match ($expectDeprecation) {
+            true => $this->expectDeprecationWithIdentifier('https://github.com/doctrine/migrations/issues/1304'),
+            false => $this->expectNoDeprecationWithIdentifier('https://github.com/doctrine/migrations/issues/1304'),
+        };
 
         $this->migrateCommandTester->execute(
             $input,
@@ -388,8 +387,8 @@ class MigrateCommandTest extends MigrationTestCase
         yield [true, ['--all-or-nothing' => 0], false];
         yield [true, ['--all-or-nothing' => '0'], false];
 
-        yield [true, [], true];
-        yield [false, [], false];
+        yield [true, [], true, false];
+        yield [false, [], false, false];
     }
 
     public function testExecuteMigrateCancelExecutedUnavailableMigrations(): void


### PR DESCRIPTION
Unfortunately as part of the previous improvement to determine whether a deprecation is thrown, validating that the deprecation was not thrown ended up not being added explicitly.

In addition, adds the explicit expectation of not throwing the deprecation whenever the `--all-or-nothing` is not indicated, which was the root cause originating the issue.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/migrations/issues/1379

#### Summary

When the deprecation was added, the check whether the deprecation is NOT triggered was missing. This PR should solve the underlying issue.
