### PR TITLE
Remove unused paramaters from DiffCommand and VersionCommand

### DIFF
--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -138,7 +138,7 @@ EOT)
         $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();
         $newMigrations                 = $statusCalculator->getNewMigrations();
 
-        if (! $this->checkNewMigrationsOrExecutedUnavailable($newMigrations, $executedUnavailableMigrations, $input, $output)) {
+        if (! $this->checkNewMigrationsOrExecutedUnavailable($newMigrations, $executedUnavailableMigrations, $input)) {
             $this->io->error('Migration cancelled!');
 
             return 3;
@@ -189,7 +189,6 @@ EOT)
         AvailableMigrationsList $newMigrations,
         ExecutedMigrationsList $executedUnavailableMigrations,
         InputInterface $input,
-        OutputInterface $output,
     ): bool {
         if (count($newMigrations) === 0 && count($executedUnavailableMigrations) === 0) {
             return true;

--- a/src/Tools/Console/Command/VersionCommand.php
+++ b/src/Tools/Console/Command/VersionCommand.php
@@ -115,19 +115,19 @@ EOT);
             $confirmation = $this->io->confirm($question);
 
             if ($confirmation) {
-                $this->markVersions($input, $output);
+                $this->markVersions($input);
             } else {
                 $this->io->error('Migration cancelled!');
             }
         } else {
-            $this->markVersions($input, $output);
+            $this->markVersions($input);
         }
 
         return 0;
     }
 
     /** @throws InvalidOptionUsage */
-    private function markVersions(InputInterface $input, OutputInterface $output): void
+    private function markVersions(InputInterface $input): void
     {
         $affectedVersion = $input->getArgument('version');
         $allOption       = $input->getOption('all');
@@ -151,15 +151,15 @@ EOT);
         if ($allOption === true) {
             if ($input->getOption('delete') === true) {
                 foreach ($executedMigrations->getItems() as $availableMigration) {
-                    $this->mark($input, $output, $availableMigration->getVersion(), false, $executedMigrations);
+                    $this->mark($input, $availableMigration->getVersion(), false, $executedMigrations);
                 }
             }
 
             foreach ($availableVersions->getItems() as $availableMigration) {
-                $this->mark($input, $output, $availableMigration->getVersion(), true, $executedMigrations);
+                $this->mark($input, $availableMigration->getVersion(), true, $executedMigrations);
             }
         } elseif ($affectedVersion !== null) {
-            $this->mark($input, $output, new Version($affectedVersion), false, $executedMigrations);
+            $this->mark($input, new Version($affectedVersion), false, $executedMigrations);
         } elseif ($rangeFromOption !== null && $rangeToOption !== null) {
             $migrate = false;
             foreach ($availableVersions->getItems() as $availableMigration) {
@@ -168,7 +168,7 @@ EOT);
                 }
 
                 if ($migrate) {
-                    $this->mark($input, $output, $availableMigration->getVersion(), true, $executedMigrations);
+                    $this->mark($input, $availableMigration->getVersion(), true, $executedMigrations);
                 }
 
                 if ((string) $availableMigration->getVersion() === $rangeToOption) {
@@ -185,7 +185,7 @@ EOT);
      * @throws VersionDoesNotExist
      * @throws UnknownMigrationVersion
      */
-    private function mark(InputInterface $input, OutputInterface $output, Version $version, bool $all, ExecutedMigrationsList $executedMigrations): void
+    private function mark(InputInterface $input, Version $version, bool $all, ExecutedMigrationsList $executedMigrations): void
     {
         try {
             $availableMigration = $this->getDependencyFactory()->getMigrationRepository()->getMigration($version);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | -

#### Summary

Remove unused parameter `OutputInterface $output` from `DiffCommand` & `VersionCommand`
