### PR TITLE
fix: Allow enum param types: ArrayParameterType and ParameterType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^8.1",
         "composer-runtime-api": "^2",
-        "doctrine/dbal": "^3.5.1 || ^4",
+        "doctrine/dbal": "^3.6 || ^4",
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "psr/log": "^1.1.3 || ^2 || ^3",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^8.1",
         "composer-runtime-api": "^2",
-        "doctrine/dbal": "^3.6 || ^4",
+        "doctrine/dbal": "^3.5.1 || ^4",
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "psr/log": "^1.1.3 || ^2 || ^3",

--- a/lib/Doctrine/Migrations/InlineParameterFormatter.php
+++ b/lib/Doctrine/Migrations/InlineParameterFormatter.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 
 use function array_map;
@@ -53,7 +55,7 @@ final class InlineParameterFormatter implements ParameterFormatter
         return sprintf('with parameters (%s)', implode(', ', $formattedParameters));
     }
 
-    private function formatParameter(mixed $value, string|int $type): string|int|bool|float|null
+    private function formatParameter(mixed $value, string|int|ArrayParameterType|ParameterType $type): string|int|bool|float|null
     {
         if (is_string($type) && Type::hasType($type)) {
             return Type::getType($type)->convertToDatabaseValue(

--- a/lib/Doctrine/Migrations/InlineParameterFormatter.php
+++ b/lib/Doctrine/Migrations/InlineParameterFormatter.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations;
 
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Types\Type;
 
 use function array_map;
@@ -55,7 +53,7 @@ final class InlineParameterFormatter implements ParameterFormatter
         return sprintf('with parameters (%s)', implode(', ', $formattedParameters));
     }
 
-    private function formatParameter(mixed $value, string|int|ArrayParameterType|ParameterType $type): string|int|bool|float|null
+    private function formatParameter(mixed $value, mixed $type): string|int|bool|float|null
     {
         if (is_string($type) && Type::hasType($type)) {
             return Type::getType($type)->convertToDatabaseValue(

--- a/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
+++ b/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
@@ -59,7 +59,7 @@ class InlineParameterFormatterTest extends TestCase
             'unknown',
             'unknown',
             ParameterType::STRING,
-            ArrayParameterType::INTEGER,
+            class_exists(ArrayParameterType::class) ? ArrayParameterType::INTEGER : Connection::PARAM_INT_ARRAY,
         ];
 
         $result = $this->parameterFormatter->formatParameters($params, $types);

--- a/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
+++ b/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
@@ -61,6 +61,7 @@ class InlineParameterFormatterTest extends TestCase
             'unknown',
             'unknown',
             ParameterType::STRING,
+            // @phpstan-ignore-next-line
             class_exists(ArrayParameterType::class) ? ArrayParameterType::INTEGER : Connection::PARAM_INT_ARRAY,
         ];
 

--- a/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
+++ b/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tests;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\InlineParameterFormatter;
@@ -35,6 +37,8 @@ class InlineParameterFormatterTest extends TestCase
             11      => true,
             12      => false,
             13      => [1, true, false, 'string value'],
+            14      => 'string value',
+            15      => [1, 2, 3],
             'named' => 'string value',
         ];
 
@@ -54,11 +58,13 @@ class InlineParameterFormatterTest extends TestCase
             'unknown',
             'unknown',
             'unknown',
+            ParameterType::STRING,
+            ArrayParameterType::INTEGER,
         ];
 
         $result = $this->parameterFormatter->formatParameters($params, $types);
 
-        $expected = 'with parameters ([string value], [1], [], [1], [1.5], [1,1,,string value], [], [], [string value], [1], [1.5], [true], [false], [1, true, false, string value], :named => [string value])';
+        $expected = 'with parameters ([string value], [1], [], [1], [1.5], [1,1,,string value], [], [], [string value], [1], [1.5], [true], [false], [1, true, false, string value], [string value], [1, 2, 3], :named => [string value])';
 
         self::assertSame($expected, $result);
     }

--- a/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
+++ b/tests/Doctrine/Migrations/Tests/InlineParameterFormatterTest.php
@@ -12,6 +12,8 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\InlineParameterFormatter;
 use PHPUnit\Framework\TestCase;
 
+use function class_exists;
+
 class InlineParameterFormatterTest extends TestCase
 {
     private Connection $connection;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1407

#### Summary

Fixes #1407

A bit lame fix, but it looks like we did not really use other int types before anyway

With this change we can use DBAL v4 new enum types: `ArrayParameterType` and `ParameterType`.

~~Bumping version of DBAL to 3.6 as before that `ArrayParameterType` did not exist.~~


Just to note - the problem itself is ONLY with DBAL 4.0+ as on 3.6 these types were classes with constants, not enums.

<!-- Provide a summary your change. -->
