### PR TITLE
Ask for a namespace of when more one path

### DIFF
--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -9,19 +9,15 @@ use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use Doctrine\SqlFormatter\SqlFormatter;
-use OutOfBoundsException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function addslashes;
-use function assert;
 use function class_exists;
 use function count;
 use function filter_var;
-use function is_string;
-use function key;
 use function sprintf;
 
 use const FILTER_VALIDATE_BOOLEAN;
@@ -110,10 +106,6 @@ EOT)
         $allowEmptyDiff  = $input->getOption('allow-empty-diff');
         $checkDbPlatform = filter_var($input->getOption('check-database-platform'), FILTER_VALIDATE_BOOLEAN);
         $fromEmptySchema = $input->getOption('from-empty-schema');
-        $namespace       = $input->getOption('namespace');
-        if ($namespace === '') {
-            $namespace = null;
-        }
 
         if ($formatted) {
             if (! class_exists(SqlFormatter::class)) {
@@ -123,16 +115,7 @@ EOT)
             }
         }
 
-        $configuration = $this->getDependencyFactory()->getConfiguration();
-
-        $dirs = $configuration->getMigrationDirectories();
-        if ($namespace === null) {
-            $namespace = key($dirs);
-        } elseif (! isset($dirs[$namespace])) {
-            throw new OutOfBoundsException(sprintf('Path not defined for the namespace %s', $namespace));
-        }
-
-        assert(is_string($namespace));
+        $namespace = $this->getNamespace($input, $output);
 
         $statusCalculator              = $this->getDependencyFactory()->getMigrationStatusCalculator();
         $executedUnavailableMigrations = $statusCalculator->getExecutedUnavailableMigrations();

--- a/src/Tools/Console/Command/DumpSchemaCommand.php
+++ b/src/Tools/Console/Command/DumpSchemaCommand.php
@@ -13,10 +13,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function addslashes;
-use function assert;
 use function class_exists;
-use function is_string;
-use function key;
 use function sprintf;
 use function str_contains;
 
@@ -91,15 +88,7 @@ EOT)
             }
         }
 
-        $configuration = $this->getDependencyFactory()->getConfiguration();
-
-        $namespace = $input->getOption('namespace');
-        if ($namespace === null) {
-            $dirs      = $configuration->getMigrationDirectories();
-            $namespace = key($dirs);
-        }
-
-        assert(is_string($namespace));
+        $namespace = $this->getNamespace($input, $output);
 
         $this->checkNoPreviousDumpExistsForNamespace($namespace);
 

--- a/src/Tools/Console/Command/GenerateCommand.php
+++ b/src/Tools/Console/Command/GenerateCommand.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
-use Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-use function assert;
-use function is_string;
-use function key;
 use function sprintf;
 
 /**
@@ -47,23 +43,9 @@ EOT);
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $configuration = $this->getDependencyFactory()->getConfiguration();
-
         $migrationGenerator = $this->getDependencyFactory()->getMigrationGenerator();
 
-        $namespace = $input->getOption('namespace');
-        if ($namespace === '') {
-            $namespace = null;
-        }
-
-        $dirs = $configuration->getMigrationDirectories();
-        if ($namespace === null) {
-            $namespace = key($dirs);
-        } elseif (! isset($dirs[$namespace])) {
-            throw new Exception(sprintf('Path not defined for the namespace %s', $namespace));
-        }
-
-        assert(is_string($namespace));
+        $namespace = $this->getNamespace($input, $output);
 
         $fqcn = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName($namespace);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | no

# Summary

When using multiple namespaces with Doctrine Migrations, the first one is selected by default. However, I suggest using an interactive namespace selection mode. This can be very convenient in situations where you have several databases within a modular monolithic application, where the migrations are located in each module.

The improvement affects three a commands:
- `migrations:generate`
- `migrations:diff`
- `migrations:dump-schema`


# Example

### Global config
```yaml
# config/packages/doctrine_migrations.yaml

doctrine_migrations:
    migrations_paths:
        'App\Migration': '%kernel.project_dir%/migrations'
    enable_profiler: '%kernel.debug%'
    organize_migrations: BY_YEAR

```

### Modules

```php
// src/Auth/config.php
<?php

declare(strict_types=1);

namespace App\Auth;

return static function (ContainerConfigurator $configurator): void {
    $configurator->extension('doctrine_migrations', [
        'migrations_paths' => [
            'App\\Auth\\Migration' => __DIR__ . '/Migration',
        ],
    ]);
};
```

### Console

#### Run command without `--no-interaction`: 
```
php bin/console doctrine:migrations:generate
```

![Снимок экрана 2024-03-09 в 19 20 57](https://github.com/doctrine/migrations/assets/31630905/d4681262-76ce-41b3-bc6c-6aee4f25fc52)

Generated new migration class to path `app/src/Auth/Migration` with namespace `App\Auth\Migration`

#### Run command with `--no-interaction`:  
```
php bin/console doctrine:migrations:generate --no-interaction
```
![Снимок экрана 2024-03-09 в 19 22 46](https://github.com/doctrine/migrations/assets/31630905/00f9f6e8-80de-450e-ab40-4e9752510679)

Generated new migration class to path `app/migrations` with namespace `App\Migration`
