### PR TITLE
Remove migration table from generated comparison schema

### DIFF
--- a/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Event\Listeners;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+class RemoveMigrationTableFromSchemaListener
+{
+    private TableMetadataStorageConfiguration|null $configuration = null;
+
+    public function __construct(
+        private readonly DependencyFactory $dependencyFactory,
+    ) {
+        $configuration = $this->dependencyFactory->getConfiguration()->getMetadataStorageConfiguration();
+
+        if ($configuration instanceof TableMetadataStorageConfiguration) {
+            $this->configuration = $configuration;
+        }
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $args): void
+    {
+        $this->removeMigrationsTableFromSchema($args->getSchema());
+    }
+
+    public function postGenerateComparisonSchema(GenerateSchemaEventArgs $args): void
+    {
+        $this->removeMigrationsTableFromSchema($args->getSchema());
+    }
+
+    private function removeMigrationsTableFromSchema(Schema $schema)
+    {
+        if (!($this->configuration instanceof TableMetadataStorageConfiguration)) {
+            return;
+        }
+
+        $tableName = $this->configuration->getTableName();
+
+        if ($schema->hasTable($tableName)) {
+            $schema->dropTable($tableName);
+        }
+    }
+}

--- a/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Event\Listeners;
 
+use Doctrine\Common\EventSubscriber;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
 
-class RemoveMigrationTableFromSchemaListener
+class RemoveMigrationTableFromSchemaListener implements EventSubscriber
 {
     private Configuration $configuration;
 
@@ -18,6 +20,15 @@ class RemoveMigrationTableFromSchemaListener
         DependencyFactory $dependencyFactory,
     ) {
         $this->configuration = $dependencyFactory->getConfiguration();
+    }
+
+    /** {@inheritDoc} */
+    public function getSubscribedEvents()
+    {
+        return [
+            ToolEvents::postGenerateSchema,
+            ToolEvents::postGenerateComparisonSchema,
+        ];
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void

--- a/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
@@ -5,24 +5,19 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Event\Listeners;
 
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 
 class RemoveMigrationTableFromSchemaListener
 {
-    private TableMetadataStorageConfiguration|null $configuration = null;
+    private Configuration $configuration;
 
     public function __construct(
-        private readonly DependencyFactory $dependencyFactory,
+        DependencyFactory $dependencyFactory,
     ) {
-        $configuration = $this->dependencyFactory->getConfiguration()->getMetadataStorageConfiguration();
-
-        if (! ($configuration instanceof TableMetadataStorageConfiguration)) {
-            return;
-        }
-
-        $this->configuration = $configuration;
+        $this->configuration = $dependencyFactory->getConfiguration();
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void
@@ -37,11 +32,13 @@ class RemoveMigrationTableFromSchemaListener
 
     private function removeMigrationsTableFromSchema(Schema $schema): void
     {
-        if (! ($this->configuration instanceof TableMetadataStorageConfiguration)) {
+        $metadataConfiguration = $this->configuration->getMetadataStorageConfiguration();
+
+        if (! ($metadataConfiguration instanceof TableMetadataStorageConfiguration)) {
             return;
         }
 
-        $tableName = $this->configuration->getTableName();
+        $tableName = $metadataConfiguration->getTableName();
 
         if (! $schema->hasTable($tableName)) {
             return;

--- a/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
+++ b/lib/Doctrine/Migrations/Event/Listeners/RemoveMigrationTableFromSchemaListener.php
@@ -18,9 +18,11 @@ class RemoveMigrationTableFromSchemaListener
     ) {
         $configuration = $this->dependencyFactory->getConfiguration()->getMetadataStorageConfiguration();
 
-        if ($configuration instanceof TableMetadataStorageConfiguration) {
-            $this->configuration = $configuration;
+        if (! ($configuration instanceof TableMetadataStorageConfiguration)) {
+            return;
         }
+
+        $this->configuration = $configuration;
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $args): void
@@ -33,16 +35,18 @@ class RemoveMigrationTableFromSchemaListener
         $this->removeMigrationsTableFromSchema($args->getSchema());
     }
 
-    private function removeMigrationsTableFromSchema(Schema $schema)
+    private function removeMigrationsTableFromSchema(Schema $schema): void
     {
-        if (!($this->configuration instanceof TableMetadataStorageConfiguration)) {
+        if (! ($this->configuration instanceof TableMetadataStorageConfiguration)) {
             return;
         }
 
         $tableName = $this->configuration->getTableName();
 
-        if ($schema->hasTable($tableName)) {
-            $schema->dropTable($tableName);
+        if (! $schema->hasTable($tableName)) {
+            return;
         }
+
+        $schema->dropTable($tableName);
     }
 }

--- a/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
+++ b/lib/Doctrine/Migrations/Version/SortedMigrationPlanCalculator.php
@@ -45,7 +45,7 @@ final class SortedMigrationPlanCalculator implements MigrationPlanCalculator
         $availableMigrations = array_filter(
             $migrationsToCheck,
             // in_array third parameter is intentionally false to force object to string casting
-            static fn (AvailableMigration $availableMigration): bool => in_array($availableMigration->getVersion(), $versions, false)
+            static fn (AvailableMigration $availableMigration): bool => in_array($availableMigration->getVersion(), $versions, false),
         );
 
         $planItems = array_map(static fn (AvailableMigration $availableMigration): MigrationPlan => new MigrationPlan($availableMigration->getVersion(), $availableMigration->getMigration(), $direction), $availableMigrations);

--- a/tests/Doctrine/Migrations/Tests/Event/Listeners/RemoveMigrationTableFromSchemaListenerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/Listeners/RemoveMigrationTableFromSchemaListenerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Event\Listeners;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
+use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Event\Listeners\RemoveMigrationTableFromSchemaListener;
+use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Migrations\Tests\MigrationTestCase;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+
+class RemoveMigrationTableFromSchemaListenerTest extends MigrationTestCase
+{
+    private RemoveMigrationTableFromSchemaListener $listener;
+    private Configuration $configuration;
+    private EntityManagerInterface $entityManager;
+
+    public function testListenerRemovesMigrationSchema(): void
+    {
+        $metadataConfiguration = new TableMetadataStorageConfiguration();
+        $tableName             = $metadataConfiguration->getTableName();
+        $this->configuration->setMetadataStorageConfiguration($metadataConfiguration);
+
+        $schema = new Schema();
+        $schema->createTable($tableName);
+
+        static::assertTrue($schema->hasTable($tableName));
+
+        $this->listener->postGenerateSchema(new GenerateSchemaEventArgs($this->entityManager, $schema));
+
+        static::assertFalse($schema->hasTable($tableName));
+    }
+
+    public function testListenerIgnoresMissingTable(): void
+    {
+        $metadataConfiguration = new TableMetadataStorageConfiguration();
+        $tableName             = $metadataConfiguration->getTableName();
+        $this->configuration->setMetadataStorageConfiguration($metadataConfiguration);
+
+        $schema = new Schema();
+
+        static::assertFalse($schema->hasTable($tableName));
+
+        $this->listener->postGenerateSchema(new GenerateSchemaEventArgs($this->entityManager, $schema));
+
+        static::assertFalse($schema->hasTable($tableName));
+    }
+
+    public function testListenerIgnoresMissingConfiguration(): void
+    {
+        $this->listener->postGenerateSchema(new GenerateSchemaEventArgs($this->entityManager, new Schema()));
+
+        static::assertTrue(true);
+    }
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManager::class);
+
+        $this->configuration = new Configuration();
+
+        $dependencyFactory = DependencyFactory::fromEntityManager(
+            new ExistingConfiguration($this->configuration),
+            new ExistingEntityManager($this->entityManager),
+        );
+
+        $this->listener = new RemoveMigrationTableFromSchemaListener($dependencyFactory);
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Event/Listeners/RemoveMigrationTableFromSchemaListenerTest.php
+++ b/tests/Doctrine/Migrations/Tests/Event/Listeners/RemoveMigrationTableFromSchemaListenerTest.php
@@ -55,9 +55,9 @@ class RemoveMigrationTableFromSchemaListenerTest extends MigrationTestCase
 
     public function testListenerIgnoresMissingConfiguration(): void
     {
-        $this->listener->postGenerateSchema(new GenerateSchemaEventArgs($this->entityManager, new Schema()));
+        static::expectNotToPerformAssertions();
 
-        static::assertTrue(true);
+        $this->listener->postGenerateSchema(new GenerateSchemaEventArgs($this->entityManager, new Schema()));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1406

#### Summary

> doctrine/orm#11374
> 
> Schemas generated from metadata cause the event `ToolEvents::postGenerateSchema` to be triggered in the method `SchemaTool::getSchemaFromMetadata`. It would be helpful to do the same for schemas generated for comparison in `SchemaTool::createSchemaForComparison`. This PR introduces the new event ToolEvents::postGenerateComparisonSchema.

This new event, given that the PR in `doctrine/orm` proceeds, can be utilized in a listener to remove the metadata table from the comparison schema.

PR relates to an attempt to fix doctrine/migrations#1406. It requires doctrine/orm#11374 and is a requirement of doctrine/DoctrineMigrationsBundle#529.
