### PR TITLE
Compare versions of migrations without namespace

### DIFF
--- a/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php
+++ b/lib/Doctrine/Migrations/Version/AlphabeticalComparator.php
@@ -10,6 +10,12 @@ final class AlphabeticalComparator implements Comparator
 {
     public function compare(Version $a, Version $b): int
     {
-        return strcmp((string) $a, (string) $b);
+        return strcmp($this->stripNamespace($a), $this->stripNamespace($b));
+    }
+
+    private function stripNamespace(Version $version): string
+    {
+        $path = explode('\\', (string) $version);
+        return end($path);
     }
 }


### PR DESCRIPTION
Strip namespace, so namespace do not affect version comparsion.

<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

### Summary
Previous behaviour
Migrations\Version2022 will always migrate AFTER Brand\Migrations\Version2024, but based on pure versions - Version2022 SHOULD be migrated BEFORE Version2024. 

ZBrand\Migrations\Version2024 - will migrate AFTER Migrations\Version2022. So comparsion was not actually performed on version, but on namespace first. Which is kind of wrong, non intuitive, and break namespace functional.

New behaviour ignore namespace, and compare versions only by version. Default behaviour should not depend on namespace. If someone need to override it - he should did it explicitly for project.