### PR TITLE
Throw an exception if addSql is used in post methods

### DIFF
--- a/src/Exception/FrozenMigration.php
+++ b/src/Exception/FrozenMigration.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Exception;
+
+use LogicException;
+
+final class FrozenMigration extends LogicException implements MigrationException
+{
+    public static function new(): self
+    {
+        return new self('The migration is frozen and cannot be edited anymore.');
+    }
+}

--- a/src/Version/DbalExecutor.php
+++ b/src/Version/DbalExecutor.php
@@ -145,6 +145,8 @@ final class DbalExecutor implements Executor
             $this->addSql(new Query($sql));
         }
 
+        $migration->freeze();
+
         if (count($this->sql) !== 0) {
             if (! $configuration->isDryRun()) {
                 $this->executeResult($configuration);

--- a/tests/AbstractMigrationTest.php
+++ b/tests/AbstractMigrationTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tests;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\AbortMigration;
+use Doctrine\Migrations\Exception\FrozenMigration;
 use Doctrine\Migrations\Exception\IrreversibleMigration;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Doctrine\Migrations\Query\Query;
@@ -45,6 +46,15 @@ class AbstractMigrationTest extends MigrationTestCase
         $this->migration->exposedAddSql('SELECT 1', [1], [2]);
 
         self::assertEquals([new Query('SELECT 1', [1], [2])], $this->migration->getSql());
+    }
+
+    public function testThrowFrozenMigrationException(): void
+    {
+        $this->expectException(FrozenMigration::class);
+        $this->expectExceptionMessage('The migration is frozen and cannot be edited anymore.');
+
+        $this->migration->freeze();
+        $this->migration->exposedAddSql('SELECT 1', [1], [2]);
     }
 
     public function testWarnIfOutputMessage(): void


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | ?
| Fixed issues | #1431

#### Summary

Using `addSql` in post methods should be reported since the sql will be ignored during the migration.
