### PR TITLE
Enlarge table to avoid to be truncated

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -116,21 +116,21 @@ Please note that if you want to use the YAML configuration option, you will need
 
 Here are details about what each configuration option does:
 
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| Name                       | Required   | Default                      | Description                                                                      |
-+============================+============+==============================+==================================================================================+
-| migrations_paths<string, string>       | yes        | null             | The PHP namespace your migration classes are located under and the path to a directory where to look for migration classes.                     |
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| table_storage              | no         |                              | Used by doctrine migrations to track the currently executed migrations           |
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| all_or_nothing             | no         | false                        | Whether or not to wrap multiple migrations in a single transaction.              |
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| migrations                 | no         | []                           | Manually specify the array of migration versions instead of finding migrations.  |
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| check_database_platform    | no         | true                         | Whether to add a database platform check at the beginning of the generated code. |
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
-| organize_migrations        | no         | ``none``                     | Whether to organize migration classes under year (``year``) or year and month (``year_and_month``) subdirectories. |
-+----------------------------+------------+------------------------------+----------------------------------------------------------------------------------+
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| Name                       | Required   | Default                      | Description                                                                                                                 |
++============================+============+==============================+=============================================================================================================================+
+| migrations_paths<string, string>       | yes        | null             | The PHP namespace your migration classes are located under and the path to a directory where to look for migration classes. |
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| table_storage              | no         |                              | Used by doctrine migrations to track the currently executed migrations                                                      |
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| all_or_nothing             | no         | false                        | Whether or not to wrap multiple migrations in a single transaction.                                                         |
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| migrations                 | no         | []                           | Manually specify the array of migration versions instead of finding migrations.                                             |
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| check_database_platform    | no         | true                         | Whether to add a database platform check at the beginning of the generated code.                                            |
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
+| organize_migrations        | no         | ``none``                     | Whether to organize migration classes under year (``year``) or year and month (``year_and_month``) subdirectories.          |
++----------------------------+------------+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
 
 
 Here the possible options for ``table_storage``:


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug (documentation)
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

On this page (https://www.doctrine-project.org/projects/doctrine-migrations/en/3.0/reference/configuration.html), from v3.0 to current version, in the table under "Here are details about what each configuration option does:", the lines "migrations_paths" and "organize_migrations" are truncated.

The PR permits to show all the text of the cell.

The patch should be merged in v3.0+ branches.
