### PR TITLE
PHPStan: Remove obsolete rule

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,9 +20,6 @@ parameters:
         -
             message: '~^Call to an undefined method Symfony\\Component\\Console\\Output\\OutputInterface\:\:getErrorOutput\(\)\.$~'
             path: lib/Doctrine/Migrations/Tools/Console/ConsoleLogger.php
-        -
-            message: '~^Method Doctrine\\Migrations\\Tests\\Stub\\DoctrineRegistry::getService\(\) should return Doctrine\\Persistence\\ObjectManager but returns Doctrine\\DBAL\\Connection\|Doctrine\\ORM\\EntityManager~'
-            path: tests/Doctrine/Migrations/Tests/Stub/DoctrineRegistry.php
 
         # https://github.com/phpstan/phpstan/issues/5982
         -


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | chore
| BC Break     | no
| Fixed issues | none

#### Summary

This rule is obsolete after the Persistence 3.3.3 release. Removing it fixes our CI.
