### PR TITLE
GH-1443: Fix default option when `--all-or-nothing` option is used as intended

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -243,18 +243,23 @@ Setting ``transactional`` to ``false`` will disable that.
 From the Command Line
 ~~~~~~~~~~~~~~~~~~~~~
 
-You can also set this option from the command line with the ``migrate`` command and the ``--all-or-nothing`` option:
+To override the configuration and explicitly enable All or Nothing Transaction from the command line,
+use the ``--all-or-nothing`` option:
 
 .. code-block:: sh
 
     $ ./vendor/bin/doctrine-migrations migrate --all-or-nothing
 
-If you have it enabled at the configuration level and want to change it for an individual migration you can
-pass a value of ``0`` or ``1`` to ``--all-or-nothing``.
+.. note::
+
+    Passing options to --all-or-nothing is deprecated from 3.7.x, and will not be allowed in 4.x
+
+To override the configuration and explicitly disable All or Nothing Transaction from the command line,
+use the ``--no-all-or-nothing`` option:
 
 .. code-block:: sh
 
-    $ ./vendor/bin/doctrine-migrations migrate --all-or-nothing=0
+    $ ./vendor/bin/doctrine-migrations migrate --no-all-or-nothing
 
 Connection Configuration
 ------------------------

--- a/src/Tools/Console/Command/MigrateCommand.php
+++ b/src/Tools/Console/Command/MigrateCommand.php
@@ -81,6 +81,12 @@ final class MigrateCommand extends DoctrineCommand
                 'Wrap the entire migration in a transaction.',
                 ConsoleInputMigratorConfigurationFactory::ABSENT_CONFIG_VALUE,
             )
+            ->addOption(
+                'no-all-or-nothing',
+                null,
+                InputOption::VALUE_NONE,
+                'Disable wrapping the entire migration in a transaction.',
+            )
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command executes a migration to a specified version or the latest available version:
 

--- a/src/Tools/Console/InvalidAllOrNothingConfiguration.php
+++ b/src/Tools/Console/InvalidAllOrNothingConfiguration.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tools\Console;
+
+use Doctrine\Migrations\Configuration\Exception\ConfigurationException;
+use LogicException;
+
+final class InvalidAllOrNothingConfiguration extends LogicException implements ConfigurationException
+{
+    public static function new(): self
+    {
+        return new self('Providing --all-or-nothing and --no-all-or-nothing simultaneously is forbidden.');
+    }
+}

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -93,4 +93,18 @@ class ConfigurationTest extends TestCase
         self::assertFalse($config->areMigrationsOrganizedByYearAndMonth());
         self::assertFalse($config->areMigrationsOrganizedByYear());
     }
+
+    public function testTransactionalConfigDefaultOption(): void
+    {
+        $config = new Configuration();
+
+        self::assertTrue($config->isTransactional());
+    }
+
+    public function testAllOrNothingConfigDefaultOption(): void
+    {
+        $config = new Configuration();
+
+        self::assertFalse($config->isAllOrNothing());
+    }
 }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/migrations/issues/1443
#### Summary

After a review of the issue reported (linked above), it seems the default behavior of specifying the option is opposite of what was intended, and also what is currently documented. This PR applies the correct default when the user specifies the `--all-or-nothing` option in the command line.

### Background:

Previous PR's and their linked issues contain more context regarding each iteration so far. They are presented below in the chronological order in which they were merged:
- https://github.com/doctrine/migrations/pull/1296
- https://github.com/doctrine/migrations/pull/1308
- https://github.com/doctrine/migrations/pull/1305
- https://github.com/doctrine/migrations/pull/1381
