### PR TITLE
Add phpdoc for LogInterface::log() $message argument

### DIFF
--- a/src/Tools/Console/ConsoleLogger.php
+++ b/src/Tools/Console/ConsoleLogger.php
@@ -71,7 +71,8 @@ final class ConsoleLogger extends AbstractLogger
     /**
      * {@inheritDoc}
      *
-     * @param mixed[] $context
+     * @param string|Stringable $message
+     * @param mixed[]           $context
      */
     public function log($level, $message, array $context = []): void
     {

--- a/tests/Metadata/Storage/DebugLogger.php
+++ b/tests/Metadata/Storage/DebugLogger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tests\Metadata\Storage;
 
 use Psr\Log\AbstractLogger;
+use Stringable;
 
 final class DebugLogger extends AbstractLogger
 {
@@ -13,7 +14,8 @@ final class DebugLogger extends AbstractLogger
     /**
      * {@inheritDoc}
      *
-     * @param mixed[] $context
+     * @param string|Stringable $message
+     * @param mixed[]           $context
      */
     public function log($level, $message, array $context = []): void
     {

--- a/tests/TestLogger.php
+++ b/tests/TestLogger.php
@@ -23,7 +23,8 @@ class TestLogger extends AbstractLogger
     /**
      * {@inheritDoc}
      *
-     * @param mixed[] $context
+     * @param string|Stringable $message
+     * @param mixed[]           $context
      */
     public function log($level, $message, array $context = []): void
     {


### PR DESCRIPTION
PHPStan complains that it is not specified. Looking at the method signature of Psr\Log\LoggerTrait, it appears that $level uses a phpdoc, and both $message and $context use native type declarations, so [the corresponding phpdoc was removed in 3.0.1](https://github.com/php-fig/log/pull/80)