### PR TITLE
Allow psr/log 1 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "doctrine/dbal": "^3.6 || ^4",
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2.0",
-        "psr/log": "^2 || ^3",
+        "psr/log": "^1.1.3 || ^2 || ^3",
         "symfony/console": "^5.4 || ^6.0 || ^7.0",
         "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0",
         "symfony/var-exporter": "^6.2 || ^7.0"


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | N/A

#### Summary

With #1449 and #1450, we've removed all custom implementations of the psr/log contracts. Because of that, we can revert the version bump made in #1446.

We still need to require the psr/log package because we use Symfony's `ConsoleLogger` class and Symfony does not declare the dependency itself.