### PR TITLE
Be consistent with how we deal with preg_match's return type

### DIFF
--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -9,7 +9,6 @@ use Doctrine\Migrations\Generator\Exception\InvalidTemplateSpecified;
 use Doctrine\Migrations\Tools\Console\Helper\MigrationDirectoryHelper;
 use InvalidArgumentException;
 
-use function assert;
 use function explode;
 use function file_get_contents;
 use function file_put_contents;
@@ -75,13 +74,10 @@ TEMPLATE;
         string|null $up = null,
         string|null $down = null,
     ): string {
-        $mch         = [];
-        $matchResult = preg_match('~(.*)\\\\([^\\\\]+)~', $fqcn, $mch);
-        if ($matchResult === 0) {
+        $mch = [];
+        if (preg_match('~(.*)\\\\([^\\\\]+)~', $fqcn, $mch) !== 1) {
             throw new InvalidArgumentException(sprintf('Invalid FQCN'));
         }
-
-        assert($matchResult !== false);
 
         [$fqcn, $namespace, $className] = $mch;
 


### PR DESCRIPTION
I'm a bit undecided on what's the best way of doing this. Let's at least use the same strategy everywhere we can.