### PR TITLE
TableMetadataStorage - fix isAlreadyV3Format for the same version values

### DIFF
--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -276,8 +276,8 @@ final class TableMetadataStorage implements MetadataStorage
 
     private function isAlreadyV3Format(AvailableMigration $availableMigration, ExecutedMigration $executedMigration): bool
     {
-        return $availableMigration->getVersion() !== $executedMigration->getVersion()
-            && strpos(
+        return (string) $availableMigration->getVersion() === (string) $executedMigration->getVersion()
+            || strpos(
                 (string) $availableMigration->getVersion(),
                 (string) $executedMigration->getVersion(),
             ) !== strlen((string) $availableMigration->getVersion()) -

--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -276,10 +276,11 @@ final class TableMetadataStorage implements MetadataStorage
 
     private function isAlreadyV3Format(AvailableMigration $availableMigration, ExecutedMigration $executedMigration): bool
     {
-        return strpos(
-            (string) $availableMigration->getVersion(),
-            (string) $executedMigration->getVersion(),
-        ) !== strlen((string) $availableMigration->getVersion()) -
-                strlen((string) $executedMigration->getVersion());
+        return $availableMigration->getVersion() !== $executedMigration->getVersion()
+            && strpos(
+                (string) $availableMigration->getVersion(),
+                (string) $executedMigration->getVersion(),
+            ) !== strlen((string) $availableMigration->getVersion()) -
+            strlen((string) $executedMigration->getVersion());
     }
 }

--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -281,6 +281,6 @@ final class TableMetadataStorage implements MetadataStorage
                 (string) $availableMigration->getVersion(),
                 (string) $executedMigration->getVersion(),
             ) !== strlen((string) $availableMigration->getVersion()) -
-            strlen((string) $executedMigration->getVersion());
+                    strlen((string) $executedMigration->getVersion());
     }
 }

--- a/tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -18,7 +18,10 @@ use Doctrine\DBAL\Types\DateTimeType;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Exception\MetadataStorageError;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\ExecutedMigration;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\Version\AlphabeticalComparator;
@@ -399,5 +402,22 @@ class TableMetadataStorageTest extends TestCase
         }
 
         self::assertCount(0, $this->connection->fetchAllAssociative($sql));
+    }
+
+    public function testIsAlreadyV3FormatDoesntMissTheSameVersions()
+    {
+        $availableMigration = new AvailableMigration(
+            new Version('Foo\\Version1234'),
+            $this->createMock(AbstractMigration::class)
+        );
+        $executedMigrationV3 = new ExecutedMigration(new Version('Foo\\Version1234'));
+        $executedMigrationOlder = new ExecutedMigration(new Version('Version1234'));
+
+        $reflection = new \ReflectionClass(TableMetadataStorage::class);
+        $method = $reflection->getMethod('isAlreadyV3Format');
+        $method->setAccessible(true);
+
+        self::assertTrue($method->invokeArgs($this->storage, [$availableMigration, $executedMigrationV3]));
+        self::assertFalse($method->invokeArgs($this->storage, [$availableMigration, $executedMigrationOlder]));
     }
 }

--- a/tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -30,6 +30,7 @@ use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\Test\TestLogger;
+use ReflectionClass;
 
 use function sprintf;
 
@@ -404,17 +405,17 @@ class TableMetadataStorageTest extends TestCase
         self::assertCount(0, $this->connection->fetchAllAssociative($sql));
     }
 
-    public function testIsAlreadyV3FormatDoesntMissTheSameVersions()
+    public function testIsAlreadyV3FormatDoesntMissTheSameVersions(): void
     {
-        $availableMigration = new AvailableMigration(
+        $availableMigration     = new AvailableMigration(
             new Version('Foo\\Version1234'),
-            $this->createMock(AbstractMigration::class)
+            $this->createMock(AbstractMigration::class),
         );
-        $executedMigrationV3 = new ExecutedMigration(new Version('Foo\\Version1234'));
+        $executedMigrationV3    = new ExecutedMigration(new Version('Foo\\Version1234'));
         $executedMigrationOlder = new ExecutedMigration(new Version('Version1234'));
 
-        $reflection = new \ReflectionClass(TableMetadataStorage::class);
-        $method = $reflection->getMethod('isAlreadyV3Format');
+        $reflection = new ReflectionClass(TableMetadataStorage::class);
+        $method     = $reflection->getMethod('isAlreadyV3Format');
         $method->setAccessible(true);
 
         self::assertTrue($method->invokeArgs($this->storage, [$availableMigration, $executedMigrationV3]));


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | no link, the explanation below

#### Summary

`Doctrine\Migrations\Metadata\Storage\TableMetadataStorage::isAlreadyV3Format()` method was returning `false` even if both versions in the arguments have exactly the same value. E.g.:

```
       strpos(
            'Namespace\Version1234',
            'Namespace\Version1234'
        ) !== (
                strlen('Namespace\Version1234') -
                strlen('Namespace\Version1234')
            );
```
Compares `0 !== 0` what gives false, but `isAlreadyV3Format()` should return `true` when the versions are the same.