### PR TITLE
Unable to create migration: The namespace with name "public" already exists.

### DIFF
--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -70,7 +70,7 @@ class DiffGenerator
             ! method_exists($this->schemaManager, 'getSchemaSearchPaths')
             && $this->platform->supportsSchemas()
         ) {
-            $defaultNamespace = $toSchema->getNamespaceName();
+            $defaultNamespace = $toSchema->getNamespaceName() ?? '';
             if ($defaultNamespace !== '') {
                 $toSchema->createNamespace($defaultNamespace);
             }

--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -70,7 +70,7 @@ class DiffGenerator
             ! method_exists($this->schemaManager, 'getSchemaSearchPaths')
             && $this->platform->supportsSchemas()
         ) {
-            $defaultNamespace = $toSchema->getName();
+            $defaultNamespace = $toSchema->getNamespaceName();
             if ($defaultNamespace !== '') {
                 $toSchema->createNamespace($defaultNamespace);
             }


### PR DESCRIPTION
fix: unable to make migration on Postgres

Error message "The namespace with name "public" already exists." on d:m:diff or migration:make fixed.