### PR TITLE
Fix test failing on Windows

### DIFF
--- a/tests/Finder/RecursiveRegexFinderTest.php
+++ b/tests/Finder/RecursiveRegexFinderTest.php
@@ -9,9 +9,8 @@ use InvalidArgumentException;
 
 use function count;
 use function in_array;
+use function is_link;
 use function sort;
-
-use const PHP_OS_FAMILY;
 
 class RecursiveRegexFinderTest extends FinderTestCase
 {
@@ -43,11 +42,12 @@ class RecursiveRegexFinderTest extends FinderTestCase
             'TestMigrations\\DifferentNamingSchema',
         ];
 
-        if (PHP_OS_FAMILY !== 'Windows') {
+        // Some Windows installations may not support symlinks
+        if (is_link(__DIR__ . '/_files/_symlinked_files')) {
             $tests[] = 'TestMigrations\\Version1SymlinkedFile';
         }
 
-        self::assertCount(count($tests), $migrations); // Windows does not support symlinks
+        self::assertCount(count($tests), $migrations);
         foreach ($tests as $fqcn) {
             self::assertTrue(in_array($fqcn, $migrations, true));
         }


### PR DESCRIPTION
Removed checking PHP_OS_FAMILY in favor of using is_link on symlinked directory. 

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Symilnks works fine under Windows, so we should not assert that symlinked files will not work in this OS family.

