### PR TITLE
Introduce addDeferredSql method in migration class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,9 @@
   to enable wrapping all migrations in a single transaction. To disable it, you can use the `--no-all-or-nothing` 
   option instead. Both options override the configuration value.
 
+## Migration classes
+- It is now possible to add SQL statements, that needs to be executed after changes made to schema object. Use
+  `addDeferredSql` method in your migrations for this purpose.
 
 
 # Upgrade to 3.6

--- a/docs/en/reference/migration-classes.rst
+++ b/docs/en/reference/migration-classes.rst
@@ -188,7 +188,7 @@ addSql
 You can use the ``addSql`` method within the ``up`` and ``down`` methods. Internally the ``addSql`` calls are passed
 to the executeQuery method in the DBAL. This means that you can use the power of prepared statements easily and that
 you don't need to copy paste the same query with different parameters. You can just pass those different parameters
-to the addSql method as parameters.
+to the addSql method as parameters. These queries are executed before changes applied to ``$schema``.
 
 .. code-block:: php
 
@@ -202,6 +202,30 @@ to the addSql method as parameters.
 
         foreach ($users as $user) {
             $this->addSql('UPDATE user SET happy = true WHERE name = :name AND id = :id', $user);
+        }
+    }
+
+addDeferredSql
+~~~~~~~~~~~~~~
+
+Works just like the ``addSql`` method, but queries are deferred to be executed after changes to ``$schema`` were
+planned.
+
+.. code-block:: php
+
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('user')->addColumn('happy', 'boolean')->setDefault(false);
+
+        $users = [
+            ['name' => 'mike', 'id' => 1],
+            ['name' => 'jwage', 'id' => 2],
+            ['name' => 'ocramius', 'id' => 3],
+        ];
+
+        foreach ($users as $user) {
+            // Use addDeferredSql since "happy" is new column, that will not yet be present in schema if called by using addSql
+            $this->addDeferredSql('UPDATE user SET happy = true WHERE name = :name AND id = :id', $user);
         }
     }
 

--- a/src/Version/DbalExecutor.php
+++ b/src/Version/DbalExecutor.php
@@ -145,6 +145,10 @@ final class DbalExecutor implements Executor
             $this->addSql(new Query($sql));
         }
 
+        foreach ($migration->getDeferredSql() as $deferredSqlQuery) {
+            $this->addSql($deferredSqlQuery);
+        }
+
         $migration->freeze();
 
         if (count($this->sql) !== 0) {

--- a/tests/AbstractMigrationTest.php
+++ b/tests/AbstractMigrationTest.php
@@ -51,6 +51,13 @@ class AbstractMigrationTest extends MigrationTestCase
         self::assertEquals([new Query('SELECT 1', [1], [2])], $this->migration->getSql());
     }
 
+    public function testAddDeferredSql(): void
+    {
+        $this->migration->exposedAddDeferredSql('SELECT 2', [1], [2]);
+
+        self::assertEquals([new Query('SELECT 2', [1], [2])], $this->migration->getDeferredSql());
+    }
+
     public function testThrowFrozenMigrationException(): void
     {
         $this->expectException(FrozenMigration::class);
@@ -58,6 +65,15 @@ class AbstractMigrationTest extends MigrationTestCase
 
         $this->migration->freeze();
         $this->migration->exposedAddSql('SELECT 1', [1], [2]);
+    }
+
+    public function testThrowFrozenMigrationExceptionOnDeferredAdd(): void
+    {
+        $this->expectException(FrozenMigration::class);
+        $this->expectExceptionMessage('The migration is frozen and cannot be edited anymore.');
+
+        $this->migration->freeze();
+        $this->migration->exposedAddDeferredSql('SELECT 2', [1], [2]);
     }
 
     public function testWarnIfOutputMessage(): void

--- a/tests/Stub/AbstractMigrationStub.php
+++ b/tests/Stub/AbstractMigrationStub.php
@@ -35,4 +35,13 @@ class AbstractMigrationStub extends AbstractMigration
     {
         $this->addSql($sql, $params, $types);
     }
+
+    /**
+     * @param int[] $params
+     * @param int[] $types
+     */
+    public function exposedAddDeferredSql(string $sql, array $params = [], array $types = []): void
+    {
+        $this->addDeferredSql($sql, $params, $types);
+    }
 }

--- a/tests/Stub/Functional/MigrateWithDeferredSql.php
+++ b/tests/Stub/Functional/MigrateWithDeferredSql.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Migrations\Tests\Stub\Functional;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class MigrateWithDeferredSql extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        // Last to be executed
+        $this->addDeferredSql('INSERT INTO test(id) VALUES(123)');
+
+        // Executed after queries from addSql()
+        $schema->createTable('test')->addColumn('id', 'integer');
+
+        // First to be executed
+        $this->addSql('SELECT 1');
+    }
+}


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no

#### Summary

This will allow to add queries that needs to be executed after changes made to schema object.

#### Reason for this change

When people need to write data in newly created table / added column, they probably resorts to calling  `$this->connection->executeStatement` in `postUp`, and this may be wrong in at least two scenarios:

1. When testing migration with `--dry-run` option, `executeStatement` is always called, since migration does not know about dry-run mode
2. Such SQLs are not visible if executed with `-vv` or `--write-sql` options, since `executeStatement` does not log queries like `addSql`.
