### PR TITLE
get all table to check if asset table exists

### DIFF
--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -212,7 +212,7 @@ final class TableMetadataStorage implements MetadataStorage
             $this->connection->ensureConnectedToPrimary();
         }
 
-        return $this->schemaManager->tablesExist([$this->configuration->getTableName()]);
+        return $this->schemaManager->tablesExist([$this->configuration->getTableName()], false);
     }
 
     private function checkInitialization(): void


### PR DESCRIPTION
use new dbal module option to get all tables with assets to check if table exists


|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | https://github.com/doctrine/DoctrineMigrationsBundle/issues/584

#### Summary
need https://github.com/doctrine/dbal/pull/6729 to set an option to allow get all tables (with assets) for check if doctrine migration table exists
