### PR TITLE
Update generated diff to match ORM schema diff

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,7 +35,7 @@ parameters:
             path: src/DependencyFactory.php
 
         -
-            message: '~^Strict comparison using !== between callable\(\)\: mixed and null will always evaluate to true\.$~'
+            message: '~^Strict comparison using === between callable\(\)\: mixed and null will always evaluate to false\.$~'
             path: src/Generator/DiffGenerator.php
 
         -

--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -14,8 +14,6 @@ use Doctrine\Migrations\Provider\SchemaProvider;
 
 use function method_exists;
 use function preg_match;
-use function strpos;
-use function substr;
 
 /**
  * The DiffGenerator class is responsible for comparing two Doctrine\DBAL\Schema\Schema instances and generating a
@@ -58,11 +56,11 @@ class DiffGenerator
             );
         }
 
+        $toSchema = $this->createToSchema();
+
         $fromSchema = $fromEmptySchema
             ? $this->createEmptySchema()
-            : $this->createFromSchema();
-
-        $toSchema = $this->createToSchema();
+            : $this->createFromSchema($toSchema);
 
         // prior to DBAL 4.0, the schema name was set to the first element in the search path,
         // which is not necessarily the default schema name
@@ -112,42 +110,37 @@ class DiffGenerator
         return $this->emptySchemaProvider->createSchema();
     }
 
-    private function createFromSchema(): Schema
+    /**
+     * Creates the schema from the database, ensuring tables from the target schema are whitelisted for comparison.
+     *
+     * @see https://github.com/doctrine/orm/pull/7875
+     */
+    private function createFromSchema(Schema $toSchema): Schema
     {
-        return $this->schemaManager->introspectSchema();
+        // backup schema assets filter
+        $previousFilter = $this->dbalConfiguration->getSchemaAssetsFilter();
+
+        if ($previousFilter === null) {
+            return $this->schemaManager->introspectSchema();
+        }
+
+        // whitelist assets we already know about in $toSchema, use the existing filter otherwise
+        $this->dbalConfiguration->setSchemaAssetsFilter(static function ($asset) use ($previousFilter, $toSchema): bool {
+            $assetName = $asset instanceof AbstractAsset ? $asset->getName() : $asset;
+
+            return $toSchema->hasTable($assetName) || $toSchema->hasSequence($assetName) || $previousFilter($asset);
+        });
+
+        try {
+            return $this->schemaManager->introspectSchema();
+        } finally {
+            // restore schema assets filter
+            $this->dbalConfiguration->setSchemaAssetsFilter($previousFilter);
+        }
     }
 
     private function createToSchema(): Schema
     {
-        $toSchema = $this->schemaProvider->createSchema();
-
-        $schemaAssetsFilter = $this->dbalConfiguration->getSchemaAssetsFilter();
-
-        if ($schemaAssetsFilter !== null) {
-            foreach ($toSchema->getTables() as $table) {
-                $tableName = $table->getName();
-
-                if ($schemaAssetsFilter($this->resolveTableName($tableName))) {
-                    continue;
-                }
-
-                $toSchema->dropTable($tableName);
-            }
-        }
-
-        return $toSchema;
-    }
-
-    /**
-     * Resolve a table name from its fully qualified name. The `$name` argument
-     * comes from Doctrine\DBAL\Schema\Table#getName which can sometimes return
-     * a namespaced name with the form `{namespace}.{tableName}`. This extracts
-     * the table name from that.
-     */
-    private function resolveTableName(string $name): string
-    {
-        $pos = strpos($name, '.');
-
-        return $pos === false ? $name : substr($name, $pos + 1);
+        return $this->schemaProvider->createSchema();
     }
 }

--- a/tests/Generator/DiffGeneratorTest.php
+++ b/tests/Generator/DiffGeneratorTest.php
@@ -37,7 +37,8 @@ class DiffGeneratorTest extends TestCase
         $fromSchema = $this->createMock(Schema::class);
         $toSchema   = $this->createMock(Schema::class);
 
-        $this->dbalConfiguration->expects(self::once())
+        // once to set provided $filterExpression then 2 times during decoration to whitelist tables in from schema
+        $this->dbalConfiguration->expects(self::exactly(3))
             ->method('setSchemaAssetsFilter');
 
         $this->dbalConfiguration->expects(self::once())
@@ -45,25 +46,6 @@ class DiffGeneratorTest extends TestCase
             ->willReturn(
                 static fn ($name): bool => $name === 'table_name1',
             );
-
-        $table1 = $this->createMock(Table::class);
-        $table1->expects(self::once())
-            ->method('getName')
-            ->willReturn('schema.table_name1');
-
-        $table2 = $this->createMock(Table::class);
-        $table2->expects(self::once())
-            ->method('getName')
-            ->willReturn('schema.table_name2');
-
-        $table3 = $this->createMock(Table::class);
-        $table3->expects(self::once())
-            ->method('getName')
-            ->willReturn('schema.table_name3');
-
-        $toSchema->expects(self::once())
-            ->method('getTables')
-            ->willReturn([$table1, $table2, $table3]);
 
         $this->emptySchemaProvider->expects(self::never())
             ->method('createSchema');
@@ -75,10 +57,6 @@ class DiffGeneratorTest extends TestCase
         $this->schemaProvider->expects(self::once())
             ->method('createSchema')
             ->willReturn($toSchema);
-
-        $toSchema->expects(self::exactly(2))
-            ->method('dropTable')
-            ->willReturnSelf();
 
         $schemaDiff = self::createStub(SchemaDiff::class);
 
@@ -125,10 +103,6 @@ class DiffGeneratorTest extends TestCase
 
         $this->dbalConfiguration->expects(self::never())
             ->method('setSchemaAssetsFilter');
-
-        $this->dbalConfiguration->expects(self::once())
-            ->method('getSchemaAssetsFilter')
-            ->willReturn(static fn () => true);
 
         $toSchema->method('getTables')
             ->willReturn([new Table('table_name')]);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no/minor
| Fixed issues | #1487

#### Summary

Ports https://github.com/doctrine/orm/pull/7875 into Migrations to improve consistency between queries generated by Migrations diff and the ones generated by the ORM schema update/validate commands. In most cases, the queries where already identical, but in some rare cases (like #1487), the migrations generated from diff did not contain the same queries as the ORM schema update and validate commands.

It also removes filtering the schema generated from metadata (`$toSchema`) using DBAL's `schemaAssetsFilter` and the `doctrine.dbal.schema_filter` config, which should only be used to exclude tables in the schema generated from the existing database (`$fromSchema` - DBAL and DoctrineBundle already cover this). This might be considered a minor BC-break, but if the metadata contains unwanted tables, they shouldn't be included in the mappings in the first place.

The decoration of the existing `schemaAssetsFilter` from the DBAL configuration is done in https://github.com/doctrine/orm/pull/7875 to whitelist assets present in the `$toSchema` so that they don't get removed from the `$fromSchema` by the default `schemaAssetsFilter` (usually based on the `doctrine.dbal.schema_filter` config) - a difference which would lead to always generating `CREATE TABLE` queries.

I think this last part is best tested in a functional/integration test, but I would need some guidance on how to set it up.

If it's a wanted change, I can also add a note to `UPGRADE.md`, depending on the branch it would be included in and if it's considered a minor BC break.

