### PR TITLE
PHPStan: Remove ignored XML variable property access error that is no longer matched

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,9 +12,6 @@ parameters:
             message: '~^Call to function in_array\(\) requires parameter #3 to be true\.$~'
             path: src/Version/SortedMigrationPlanCalculator.php
         -
-            message: '~^Variable property access on SimpleXMLElement\.$~'
-            path: src/Configuration/Migration/XmlFile.php
-        -
             message: '~^Call to function is_bool\(\) with bool will always evaluate to true\.$~'
             path: src/InlineParameterFormatter.php
         -


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

PHPStan fails with the following message:
> Error: Ignored error pattern `~^Variable property access on SimpleXMLElement\.$~` in path /home/runner/work/migrations/migrations/src/Configuration/Migration/XmlFile.php was not matched in reported errors.

Could be that a newer version of PHPStan or a dependency no longer triggers this error.