### PR TITLE
DiffGenerator: fix applying regex pattern filter to mappings schema

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,10 +35,6 @@ parameters:
             path: src/DependencyFactory.php
 
         -
-            message: '~^Strict comparison using !== between callable\(\)\: mixed and null will always evaluate to true\.$~'
-            path: src/Generator/DiffGenerator.php
-
-        -
             message: '~Doctrine\\ORM\\Tools\\Console\\Helper\\EntityManagerHelper~'
             path: src/Tools/Console/ConsoleRunner.php
 

--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -14,8 +14,6 @@ use Doctrine\Migrations\Provider\SchemaProvider;
 
 use function method_exists;
 use function preg_match;
-use function strpos;
-use function substr;
 
 /**
  * The DiffGenerator class is responsible for comparing two Doctrine\DBAL\Schema\Schema instances and generating a
@@ -46,14 +44,22 @@ class DiffGenerator
         bool $checkDbPlatform = true,
         bool $fromEmptySchema = false,
     ): string {
+        $toSchema = $this->createToSchema();
+
         if ($filterExpression !== null) {
+            // whitelist assets we already know about in $toSchema, use the existing $filterExpression otherwise
+            // @see https://github.com/doctrine/orm/pull/7875
             $this->dbalConfiguration->setSchemaAssetsFilter(
-                static function ($assetName) use ($filterExpression) {
+                static function ($assetName) use ($filterExpression, $toSchema): bool {
                     if ($assetName instanceof AbstractAsset) {
                         $assetName = $assetName->getName();
                     }
 
-                    return preg_match($filterExpression, $assetName);
+                    if ($toSchema->hasTable($assetName) || $toSchema->hasSequence($assetName)) {
+                        return true;
+                    }
+
+                    return (bool) preg_match($filterExpression, $assetName);
                 },
             );
         }
@@ -61,8 +67,6 @@ class DiffGenerator
         $fromSchema = $fromEmptySchema
             ? $this->createEmptySchema()
             : $this->createFromSchema();
-
-        $toSchema = $this->createToSchema();
 
         // prior to DBAL 4.0, the schema name was set to the first element in the search path,
         // which is not necessarily the default schema name
@@ -119,35 +123,6 @@ class DiffGenerator
 
     private function createToSchema(): Schema
     {
-        $toSchema = $this->schemaProvider->createSchema();
-
-        $schemaAssetsFilter = $this->dbalConfiguration->getSchemaAssetsFilter();
-
-        if ($schemaAssetsFilter !== null) {
-            foreach ($toSchema->getTables() as $table) {
-                $tableName = $table->getName();
-
-                if ($schemaAssetsFilter($this->resolveTableName($tableName))) {
-                    continue;
-                }
-
-                $toSchema->dropTable($tableName);
-            }
-        }
-
-        return $toSchema;
-    }
-
-    /**
-     * Resolve a table name from its fully qualified name. The `$name` argument
-     * comes from Doctrine\DBAL\Schema\Table#getName which can sometimes return
-     * a namespaced name with the form `{namespace}.{tableName}`. This extracts
-     * the table name from that.
-     */
-    private function resolveTableName(string $name): string
-    {
-        $pos = strpos($name, '.');
-
-        return $pos === false ? $name : substr($name, $pos + 1);
+        return $this->schemaProvider->createSchema();
     }
 }

--- a/tests/Generator/DiffGeneratorTest.php
+++ b/tests/Generator/DiffGeneratorTest.php
@@ -38,32 +38,11 @@ class DiffGeneratorTest extends TestCase
         $toSchema   = $this->createMock(Schema::class);
 
         $this->dbalConfiguration->expects(self::once())
-            ->method('setSchemaAssetsFilter');
-
-        $this->dbalConfiguration->expects(self::once())
-            ->method('getSchemaAssetsFilter')
-            ->willReturn(
-                static fn ($name): bool => $name === 'table_name1',
-            );
-
-        $table1 = $this->createMock(Table::class);
-        $table1->expects(self::once())
-            ->method('getName')
-            ->willReturn('schema.table_name1');
-
-        $table2 = $this->createMock(Table::class);
-        $table2->expects(self::once())
-            ->method('getName')
-            ->willReturn('schema.table_name2');
-
-        $table3 = $this->createMock(Table::class);
-        $table3->expects(self::once())
-            ->method('getName')
-            ->willReturn('schema.table_name3');
-
-        $toSchema->expects(self::once())
-            ->method('getTables')
-            ->willReturn([$table1, $table2, $table3]);
+            ->method('setSchemaAssetsFilter')
+            ->willReturnCallback(static function (callable $schemaAssetsFilter): void {
+                // also test the closure provided to setSchemaAssetsFilter
+                self::assertTrue($schemaAssetsFilter('table_name1'));
+            });
 
         $this->emptySchemaProvider->expects(self::never())
             ->method('createSchema');
@@ -75,10 +54,6 @@ class DiffGeneratorTest extends TestCase
         $this->schemaProvider->expects(self::once())
             ->method('createSchema')
             ->willReturn($toSchema);
-
-        $toSchema->expects(self::exactly(2))
-            ->method('dropTable')
-            ->willReturnSelf();
 
         $schemaDiff = self::createStub(SchemaDiff::class);
 
@@ -125,10 +100,6 @@ class DiffGeneratorTest extends TestCase
 
         $this->dbalConfiguration->expects(self::never())
             ->method('setSchemaAssetsFilter');
-
-        $this->dbalConfiguration->expects(self::once())
-            ->method('getSchemaAssetsFilter')
-            ->willReturn(static fn () => true);
 
         $toSchema->method('getTables')
             ->willReturn([new Table('table_name')]);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no/minor
| Fixed issues | #1487

#### Summary

DiffGenerator [applies regex pattern filtering to the metadata-based schema](https://github.com/doctrine/migrations/blob/3.8.x/src/Generator/DiffGenerator.php#L124) (`$toSchema`) using DBAL's `schemaAssetsFilter` (and DoctrineBundle's `doctrine.dbal.schema_filter`, if applicable), which was meant for filtering the introspected schema (`$fromSchema` ) to prevent dropping existing tables from the database  (DBAL and DoctrineBundle already cover this). This is also [explained in the docs](https://www.doctrine-project.org/projects/doctrine-migrations/en/3.8/reference/generating-migrations.html#ignoring-custom-tables) : "custom tables which are not managed by Doctrine" = not in the Doctrine mappings, so if an asset is in the metadata ("managed by Doctrine"), it should be included in both `$toSchema` and `$fromSchema` (if it exists), regardless of `doctrine.dbal.schema_filter` config.

This extra filtering also generates differences in the diff created by Migrations vs the ones created by [ORM's SchemaTool](https://github.com/doctrine/orm/blob/3.3.x/src/Tools/SchemaTool.php#L887), as explained in #1487 . 

The logic not to exclude tables in the introspected schema that exist in the mappings was ported from https://github.com/doctrine/orm/pull/7875 and prevents adding unwanted "CREATE TABLE" queries.