### PR TITLE
DiffGenerator: fix removing schema from table name before applying regex filtering

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -56,6 +56,9 @@ parameters:
         -
             message: '#^Call to function method_exists\(\) with Doctrine\\DBAL\\Schema\\Table and ''getObjectName'' will always evaluate to true\.$#'
             path: src/SchemaDumper.php
+        -
+            message: '~^Parameter #1 \$array \(list<string>\) of array_values is already a list, call has no effect\.$~'
+            path: tests/Generator/DiffGeneratorTest.php
 
     symfony:
             consoleApplicationLoader: tests/doctrine-migrations-phpstan-app.php

--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -16,8 +16,6 @@ use Doctrine\Migrations\Provider\SchemaProvider;
 use function class_exists;
 use function method_exists;
 use function preg_match;
-use function strpos;
-use function substr;
 
 /**
  * The DiffGenerator class is responsible for comparing two Doctrine\DBAL\Schema\Schema instances and generating a
@@ -136,7 +134,7 @@ class DiffGenerator
             foreach ($toSchema->getTables() as $table) {
                 $tableName = $table->getName();
 
-                if ($schemaAssetsFilter($this->resolveTableName($tableName))) {
+                if ($schemaAssetsFilter($tableName)) {
                     continue;
                 }
 
@@ -145,18 +143,5 @@ class DiffGenerator
         }
 
         return $toSchema;
-    }
-
-    /**
-     * Resolve a table name from its fully qualified name. The `$name` argument
-     * comes from Doctrine\DBAL\Schema\Table#getName which can sometimes return
-     * a namespaced name with the form `{namespace}.{tableName}`. This extracts
-     * the table name from that.
-     */
-    private function resolveTableName(string $name): string
-    {
-        $pos = strpos($name, '.');
-
-        return $pos === false ? $name : substr($name, $pos + 1);
     }
 }

--- a/tests/Generator/DiffGeneratorTest.php
+++ b/tests/Generator/DiffGeneratorTest.php
@@ -18,6 +18,10 @@ use Doctrine\Migrations\Provider\SchemaProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+use function array_map;
+use function array_values;
+use function preg_match;
+
 class DiffGeneratorTest extends TestCase
 {
     private DBALConfiguration&MockObject $dbalConfiguration;
@@ -43,7 +47,7 @@ class DiffGeneratorTest extends TestCase
         $this->dbalConfiguration->expects(self::once())
             ->method('getSchemaAssetsFilter')
             ->willReturn(
-                static fn ($name): bool => $name === 'table_name1',
+                static fn ($name): bool => $name === 'schema.table_name1',
             );
 
         $table1 = $this->createMock(Table::class);
@@ -179,6 +183,49 @@ class DiffGeneratorTest extends TestCase
             ->willReturn('path2');
 
         self::assertSame('path2', $this->migrationDiffGenerator->generate('2345', null, false, false, 120, true, true));
+    }
+
+    public function testGenerateAppliesFilterOnMappedSchema(): void
+    {
+        // a standard Regex SchemaAssetsFilter already registered on the DBAL
+        $dbalSchemaAssetsFilter = static function ($assetName): bool {
+            return (bool) preg_match('~^some_schema~', $assetName);
+        };
+
+        $fromSchema = new Schema();
+
+        $toTable1 = new Table('some_schema.table1');
+        $toTable2 = new Table('some_schema.table2');
+        $toSchema = new Schema([$toTable1, $toTable2]);
+
+        $this->schemaManager->expects(self::once())
+            ->method('introspectSchema')
+            ->willReturn($fromSchema);
+
+        $this->schemaProvider->expects(self::once())
+            ->method('createSchema')
+            ->willReturn($toSchema);
+
+        $this->dbalConfiguration->expects(self::once())
+            ->method('getSchemaAssetsFilter')
+            ->willReturn($dbalSchemaAssetsFilter);
+
+        $schemaDiff = self::createStub(SchemaDiff::class);
+        $comparator = $this->mockComparator($schemaDiff);
+
+        $this->schemaManager->expects(self::once())
+            ->method('createComparator')
+            ->willReturn($comparator);
+
+        $this->migrationSqlGenerator->expects(self::exactly(2))
+            ->method('generate')
+            ->willReturnOnConsecutiveCalls('up', 'down');
+
+        $this->migrationDiffGenerator->generate('Version1234', null);
+
+        $filteredTableNames = array_map(static fn (Table $table) => $table->getName(), $toSchema->getTables());
+
+        self::assertSame(['some_schema.table1', 'some_schema.table2'], array_values($filteredTableNames));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| Fixed issues | #1487

#### Summary

Failing test and suggested fix for #1487, requested in https://github.com/doctrine/migrations/pull/1490#pullrequestreview-2645902823

There are differences in the way Migrations and DBAL apply the `SchemaAssetsFilter`, usually regex: DBAL applies it on the table name (which can be qualified or unqualified, depending on platform schema support and if the table is in the default search-path schema) while Migrations always removes the schema and only applies the filter on the unqualified table name (`my_table`). 

This fix applies the `SchemaAssetsFilter` on the table name exactly as provided by the DBAL for platforms that support schema.