### PR TITLE
Add nowdoc option, by default activated for formatted output

### DIFF
--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -42,6 +42,7 @@ class DiffGenerator
         string $fqcn,
         string|null $filterExpression,
         bool $formatted = false,
+        bool|null $nowdocOutput = null,
         int $lineLength = 120,
         bool $checkDbPlatform = true,
         bool $fromEmptySchema = false,
@@ -83,6 +84,7 @@ class DiffGenerator
         $up = $this->migrationSqlGenerator->generate(
             $upSql,
             $formatted,
+            $nowdocOutput,
             $lineLength,
             $checkDbPlatform,
         );
@@ -92,6 +94,7 @@ class DiffGenerator
         $down = $this->migrationSqlGenerator->generate(
             $downSql,
             $formatted,
+            $nowdocOutput,
             $lineLength,
             $checkDbPlatform,
         );

--- a/src/SchemaDumper.php
+++ b/src/SchemaDumper.php
@@ -56,6 +56,7 @@ class SchemaDumper
         string $fqcn,
         array $excludedTablesRegexes = [],
         bool $formatted = false,
+        bool $nowdocOutput = false,
         int $lineLength = 120,
     ): string {
         $schema = $this->schemaManager->introspectSchema();
@@ -73,6 +74,7 @@ class SchemaDumper
             $upCode = $this->migrationSqlGenerator->generate(
                 $upSql,
                 $formatted,
+                $nowdocOutput,
                 $lineLength,
             );
 
@@ -85,6 +87,7 @@ class SchemaDumper
             $downCode = $this->migrationSqlGenerator->generate(
                 $downSql,
                 $formatted,
+                $nowdocOutput,
                 $lineLength,
             );
 

--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -64,6 +64,12 @@ EOT)
                 'Format the generated SQL.',
             )
             ->addOption(
+                'nowdoc',
+                null,
+                InputOption::VALUE_NEGATABLE,
+                'Output the generated SQL as a nowdoc string (always active for formatted queries).',
+            )
+            ->addOption(
                 'line-length',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -102,6 +108,7 @@ EOT)
         }
 
         $formatted       = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
+        $nowdocOutput    = filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
         $lineLength      = (int) $input->getOption('line-length');
         $allowEmptyDiff  = $input->getOption('allow-empty-diff');
         $checkDbPlatform = filter_var($input->getOption('check-database-platform'), FILTER_VALIDATE_BOOLEAN);
@@ -135,6 +142,7 @@ EOT)
                 $fqcn,
                 $filterExpression,
                 $formatted,
+                $nowdocOutput,
                 $lineLength,
                 $checkDbPlatform,
                 $fromEmptySchema,

--- a/src/Tools/Console/Command/DumpSchemaCommand.php
+++ b/src/Tools/Console/Command/DumpSchemaCommand.php
@@ -14,8 +14,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function addslashes;
 use function class_exists;
+use function filter_var;
 use function sprintf;
 use function str_contains;
+
+use const FILTER_VALIDATE_BOOLEAN;
 
 /**
  * The DumpSchemaCommand class is responsible for dumping your current database schema to a migration class. This is
@@ -50,6 +53,12 @@ EOT)
                 'Format the generated SQL.',
             )
             ->addOption(
+                'nowdoc',
+                null,
+                InputOption::VALUE_NONE,
+                'Output the generated SQL as a nowdoc string (always active for formatted queries).',
+            )
+            ->addOption(
                 'namespace',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -75,8 +84,9 @@ EOT)
         InputInterface $input,
         OutputInterface $output,
     ): int {
-        $formatted  = $input->getOption('formatted');
-        $lineLength = (int) $input->getOption('line-length');
+        $formatted    = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
+        $nowdocOutput = filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
+        $lineLength   = (int) $input->getOption('line-length');
 
         $schemaDumper = $this->getDependencyFactory()->getSchemaDumper();
 
@@ -98,6 +108,7 @@ EOT)
             $fqcn,
             $input->getOption('filter-tables'),
             $formatted,
+            $nowdocOutput,
             $lineLength,
         );
 

--- a/tests/Generator/DiffGeneratorTest.php
+++ b/tests/Generator/DiffGeneratorTest.php
@@ -102,7 +102,7 @@ class DiffGeneratorTest extends TestCase
             ->with(self::logicalOr(
                 self::equalTo(['UPDATE table SET value = 2']),
                 self::equalTo(['UPDATE table SET value = 1']),
-            ), true, 80)
+            ), true, false, 80)
             ->willReturnOnConsecutiveCalls('test1', 'test2');
 
         $this->migrationGenerator->expects(self::once())
@@ -114,6 +114,7 @@ class DiffGeneratorTest extends TestCase
             '1234',
             '/table_name1/',
             true,
+            false,
             80,
         ));
     }
@@ -169,7 +170,7 @@ class DiffGeneratorTest extends TestCase
             ->with(self::logicalOr(
                 self::equalTo(['CREATE TABLE table_name']),
                 self::equalTo(['DROP TABLE table_name']),
-            ), false, 120, true)
+            ), false, false, 120, true)
             ->willReturnOnConsecutiveCalls('test up', 'test down');
 
         $this->migrationGenerator->expects(self::once())
@@ -177,7 +178,7 @@ class DiffGeneratorTest extends TestCase
             ->with('2345', 'test up', 'test down')
             ->willReturn('path2');
 
-        self::assertSame('path2', $this->migrationDiffGenerator->generate('2345', null, false, 120, true, true));
+        self::assertSame('path2', $this->migrationDiffGenerator->generate('2345', null, false, false, 120, true, true));
     }
 
     protected function setUp(): void

--- a/tests/Generator/SqlGeneratorTest.php
+++ b/tests/Generator/SqlGeneratorTest.php
@@ -51,24 +51,37 @@ final class SqlGeneratorTest extends TestCase
                     "Migration can only be executed safely on '\\$expectedPlatform'."
                 );
 
-                \$this->addSql(<<<'SQL'
-                    SELECT 1
-                SQL);
-                \$this->addSql(<<<'SQL'
-                    SELECT 2
-                SQL);
+                \$this->addSql('SELECT 1');
+                \$this->addSql('SELECT 2');
                 \$this->addSql(<<<'SQL'
                     %s
                 SQL);
                 CODE,
         );
 
-        $code = $migrationSqlGenerator->generate($this->sql, true, 80);
+        $code = $migrationSqlGenerator->generate($this->sql, true, null, 80);
 
         self::assertSame($expectedCode, $code);
     }
 
-    public function testGenerationWithoutCheckingDatabasePlatform(): void
+    public function testGenerationWithoutFormatting(): void
+    {
+        $this->configuration->setCheckDatabasePlatform(true);
+
+        $expectedCode = $this->prepareGeneratedCode(
+            <<<'CODE'
+                $this->addSql('SELECT 1');
+                $this->addSql('SELECT 2');
+                $this->addSql('%s');
+                CODE,
+            formatted: false,
+        );
+
+        $code = $this->migrationSqlGenerator->generate($this->sql, false, null, 80, false);
+        self::assertSame($expectedCode, $code);
+    }
+
+    public function testGenerationWithNowDocOutput(): void
     {
         $this->configuration->setCheckDatabasePlatform(true);
 
@@ -84,9 +97,47 @@ final class SqlGeneratorTest extends TestCase
                     %s
                 SQL);
                 CODE,
+            formatted: false,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, true, 80, false);
+        $code = $this->migrationSqlGenerator->generate($this->sql, false, true, 80, false);
+        self::assertSame($expectedCode, $code);
+    }
+
+    public function testGenerationWithNoNowDocFormatting(): void
+    {
+        $this->configuration->setCheckDatabasePlatform(true);
+
+        $expectedCode = $this->prepareGeneratedCode(
+            <<<'CODE'
+                $this->addSql('SELECT 1');
+                $this->addSql('SELECT 2');
+                $this->addSql('%s');
+                CODE,
+            formatted: true,
+            nowdoc: false,
+        );
+
+        $code = $this->migrationSqlGenerator->generate($this->sql, true, false, 80, false);
+
+        self::assertSame($expectedCode, $code);
+    }
+
+    public function testGenerationWithoutCheckingDatabasePlatform(): void
+    {
+        $this->configuration->setCheckDatabasePlatform(true);
+
+        $expectedCode = $this->prepareGeneratedCode(
+            <<<'CODE'
+                $this->addSql('SELECT 1');
+                $this->addSql('SELECT 2');
+                $this->addSql(<<<'SQL'
+                    %s
+                SQL);
+                CODE,
+        );
+
+        $code = $this->migrationSqlGenerator->generate($this->sql, true, null, 80, false);
 
         self::assertSame($expectedCode, $code);
     }
@@ -97,19 +148,15 @@ final class SqlGeneratorTest extends TestCase
 
         $expectedCode = $this->prepareGeneratedCode(
             <<<'CODE'
-                $this->addSql(<<<'SQL'
-                    SELECT 1
-                SQL);
-                $this->addSql(<<<'SQL'
-                    SELECT 2
-                SQL);
+                $this->addSql('SELECT 1');
+                $this->addSql('SELECT 2');
                 $this->addSql(<<<'SQL'
                     %s
                 SQL);
                 CODE,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, true, 80);
+        $code = $this->migrationSqlGenerator->generate($this->sql, true, null, 80);
 
         self::assertSame($expectedCode, $code);
     }
@@ -127,7 +174,7 @@ final class SqlGeneratorTest extends TestCase
         );
     }
 
-    private function prepareGeneratedCode(string $expectedCode): string
+    private function prepareGeneratedCode(string $expectedCode, bool $formatted = true, bool $nowdoc = true): string
     {
         $this->sql = [
             'SELECT 1',
@@ -138,15 +185,21 @@ final class SqlGeneratorTest extends TestCase
 
         $this->metadataConfig->setTableName('migrations_table_name');
 
+        if ($formatted) {
+            $formattedSql = (new SqlFormatter(new NullHighlighter()))->format($this->sql[2]);
+            if ($nowdoc) {
+                $formattedSql = implode(
+                    "\n" . str_repeat(' ', 4),
+                    explode("\n", $formattedSql),
+                );
+            }
+
+            return sprintf($expectedCode, $formattedSql);
+        }
+
         return sprintf(
             $expectedCode,
-            implode(
-                "\n" . str_repeat(' ', 4),
-                explode(
-                    "\n",
-                    (new SqlFormatter(new NullHighlighter()))->format($this->sql[2]),
-                ),
-            ),
+            $this->sql[2],
         );
     }
 }

--- a/tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Tools/Console/Command/DiffCommandTest.php
@@ -65,12 +65,13 @@ final class DiffCommandTest extends TestCase
 
         $this->migrationDiffGenerator->expects(self::once())
             ->method('generate')
-            ->with('FooNs\\Version1234', 'filter expression', true, 80)
+            ->with('FooNs\\Version1234', 'filter expression', true, false, 80)
             ->willReturn('/path/to/migration.php');
 
         $this->diffCommandTester->execute([
             '--filter-expression' => 'filter expression',
             '--formatted' => true,
+            '--nowdoc' => false,
             '--line-length' => 80,
             '--allow-empty-diff' => true,
             '--check-database-platform' => true,

--- a/tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -77,12 +77,13 @@ final class DumpSchemaCommandTest extends TestCase
 
         $this->schemaDumper->expects(self::once())
             ->method('dump')
-            ->with('FooNs\\Version1234', ['/foo/'], true, 80);
+            ->with('FooNs\\Version1234', ['/foo/'], true, false, 80);
 
         $this->dumpSchemaCommandTester->execute([
             '--filter-tables' => ['/foo/'],
             '--line-length' => 80,
             '--formatted' => true,
+            '--nowdoc' => false,
         ]);
 
         $output = $this->dumpSchemaCommandTester->getDisplay(true);


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     |no

#### Summary

Improvement following [PR-1473](https://github.com/doctrine/migrations/pull/1473) adding nowdoc by default for formated output only, add an option --nowdoc for full nowdoc output