### PR TITLE
Make test insensitive to PHP version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,6 +33,7 @@ jobs:
           - "8.1"
           - "8.2"
           - "8.3"
+          - "8.4"
         dependencies:
           - "highest"
         stability:
@@ -43,7 +44,7 @@ jobs:
             php-version: "8.1"
           - dependencies: "highest"
             stability: "dev"
-            php-version: "8.3"
+            php-version: "8.4"
 
     steps:
       - name: "Checkout"

--- a/tests/SchemaDumperTest.php
+++ b/tests/SchemaDumperTest.php
@@ -16,8 +16,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-use const PHP_VERSION_ID;
-
 class SchemaDumperTest extends TestCase
 {
     /** @var AbstractPlatform&MockObject */
@@ -131,11 +129,7 @@ class SchemaDumperTest extends TestCase
     public function testRegexErrorsAreConvertedToExceptions(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        if (PHP_VERSION_ID < 80200) {
-            $this->expectExceptionMessage('Internal PCRE error, please check your Regex. Reported errors: preg_match(): Delimiter must not be alphanumeric or backslash.');
-        } else {
-            $this->expectExceptionMessage('Internal PCRE error, please check your Regex. Reported errors: preg_match(): Delimiter must not be alphanumeric, backslash, or NUL.');
-        }
+        $this->expectExceptionMessageMatches('/Internal PCRE error/');
 
         $table = $this->createMock(Table::class);
         $table->expects(self::atLeastOnce())


### PR DESCRIPTION
We already have two possible error messages depending on the version of PHP, and recently, a third made its appearance. Let us use a regex to match this message from PCRE (very meta, I know).

See https://github.com/php/php-src/pull/13068

This didn't get caught earlier, probably because we were not running tests with PHP 8.4. This is now addressed as well.