### PR TITLE
Fix command options mode (`InputOption::VALUE_REQUIRED`)

### DIFF
--- a/src/Tools/Console/Command/DumpSchemaCommand.php
+++ b/src/Tools/Console/Command/DumpSchemaCommand.php
@@ -73,7 +73,7 @@ EOT)
             ->addOption(
                 'line-length',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Max line length of unformatted lines.',
                 '120',
             );

--- a/src/Tools/Console/Command/VersionCommand.php
+++ b/src/Tools/Console/Command/VersionCommand.php
@@ -64,13 +64,13 @@ final class VersionCommand extends DoctrineCommand
             ->addOption(
                 'range-from',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Apply from specified version.',
             )
             ->addOption(
                 'range-to',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Apply to specified version.',
             )
             ->setHelp(<<<'EOT'


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

These options (when used) always require a value.
