### PR TITLE
Add --single-block option to generate a single nowdoc sql

### DIFF
--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -43,6 +43,7 @@ class DiffGenerator
         string|null $filterExpression,
         bool $formatted = false,
         bool|null $nowdocOutput = null,
+        bool $singleBlock = false,
         int $lineLength = 120,
         bool $checkDbPlatform = true,
         bool $fromEmptySchema = false,
@@ -85,6 +86,7 @@ class DiffGenerator
             $upSql,
             $formatted,
             $nowdocOutput,
+            $singleBlock,
             $lineLength,
             $checkDbPlatform,
         );
@@ -95,6 +97,7 @@ class DiffGenerator
             $downSql,
             $formatted,
             $nowdocOutput,
+            $singleBlock,
             $lineLength,
             $checkDbPlatform,
         );

--- a/src/Generator/SqlGenerator.php
+++ b/src/Generator/SqlGenerator.php
@@ -42,6 +42,7 @@ class SqlGenerator
         array $sql,
         bool $formatted = false,
         bool|null $nowdocOutput = null,
+        bool $singleBlock = false,
         int $lineLength = 120,
         bool $checkDbPlatform = true,
     ): string {
@@ -61,7 +62,9 @@ class SqlGenerator
                 $query = $this->formatQuery($query);
             }
 
-            if ($nowdocOutput === true || ($nowdocOutput !== false && $formatted && strlen($query) > $maxLength )) {
+            if ($singleBlock === true) {
+                $code[] = $query;
+            } elseif ($nowdocOutput === true || ($nowdocOutput !== false && $formatted && strlen($query) > $maxLength )) {
                 $code[] = sprintf(
                     "\$this->addSql(<<<'SQL'\n%s\nSQL);",
                     preg_replace('/^/m', str_repeat(' ', 4), $query),
@@ -88,6 +91,13 @@ PHP
                     $currentPlatform,
                 ),
                 '',
+            );
+        }
+
+        if ($singleBlock === true) {
+            return sprintf(
+                "\$this->addSql(<<<'SQL'\n%s;\nSQL);",
+                preg_replace('/^/m', str_repeat(' ', 4), implode(";\n", $code)),
             );
         }
 

--- a/src/SchemaDumper.php
+++ b/src/SchemaDumper.php
@@ -57,6 +57,7 @@ class SchemaDumper
         array $excludedTablesRegexes = [],
         bool $formatted = false,
         bool $nowdocOutput = false,
+        bool $singleBlock = false,
         int $lineLength = 120,
     ): string {
         $schema = $this->schemaManager->introspectSchema();
@@ -75,6 +76,7 @@ class SchemaDumper
                 $upSql,
                 $formatted,
                 $nowdocOutput,
+                $singleBlock,
                 $lineLength,
             );
 
@@ -88,6 +90,7 @@ class SchemaDumper
                 $downSql,
                 $formatted,
                 $nowdocOutput,
+                $singleBlock,
                 $lineLength,
             );
 

--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -70,6 +70,12 @@ EOT)
                 'Output the generated SQL as a nowdoc string (always active for formatted queries).',
             )
             ->addOption(
+                'single-block',
+                null,
+                InputOption::VALUE_NONE,
+                'Output the generated SQL as a single block nowdoc string.',
+            )
+            ->addOption(
                 'line-length',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -109,6 +115,7 @@ EOT)
 
         $formatted       = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
         $nowdocOutput    = filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
+        $singleBlock     = filter_var($input->getOption('single-block'), FILTER_VALIDATE_BOOLEAN);
         $lineLength      = (int) $input->getOption('line-length');
         $allowEmptyDiff  = $input->getOption('allow-empty-diff');
         $checkDbPlatform = filter_var($input->getOption('check-database-platform'), FILTER_VALIDATE_BOOLEAN);
@@ -143,6 +150,7 @@ EOT)
                 $filterExpression,
                 $formatted,
                 $nowdocOutput,
+                $singleBlock,
                 $lineLength,
                 $checkDbPlatform,
                 $fromEmptySchema,

--- a/src/Tools/Console/Command/DumpSchemaCommand.php
+++ b/src/Tools/Console/Command/DumpSchemaCommand.php
@@ -59,6 +59,12 @@ EOT)
                 'Output the generated SQL as a nowdoc string (always active for formatted queries).',
             )
             ->addOption(
+                'single-block',
+                null,
+                InputOption::VALUE_NONE,
+                'Output the generated SQL as a single block nowdoc string.',
+            )
+            ->addOption(
                 'namespace',
                 null,
                 InputOption::VALUE_REQUIRED,
@@ -86,6 +92,7 @@ EOT)
     ): int {
         $formatted    = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
         $nowdocOutput = filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
+        $singleBlock  = filter_var($input->getOption('single-block'), FILTER_VALIDATE_BOOLEAN);
         $lineLength   = (int) $input->getOption('line-length');
 
         $schemaDumper = $this->getDependencyFactory()->getSchemaDumper();
@@ -109,6 +116,7 @@ EOT)
             $input->getOption('filter-tables'),
             $formatted,
             $nowdocOutput,
+            $singleBlock,
             $lineLength,
         );
 

--- a/tests/Generator/DiffGeneratorTest.php
+++ b/tests/Generator/DiffGeneratorTest.php
@@ -99,10 +99,16 @@ class DiffGeneratorTest extends TestCase
 
         $this->migrationSqlGenerator->expects(self::exactly(2))
             ->method('generate')
-            ->with(self::logicalOr(
-                self::equalTo(['UPDATE table SET value = 2']),
-                self::equalTo(['UPDATE table SET value = 1']),
-            ), true, false, 80)
+            ->with(
+                fqcn: self::logicalOr(
+                    self::equalTo(['UPDATE table SET value = 2']),
+                    self::equalTo(['UPDATE table SET value = 1']),
+                ),
+                formatted: true,
+                nowdocOutput: false,
+                singleBlock: false,
+                lineLength: 80,
+            )
             ->willReturnOnConsecutiveCalls('test1', 'test2');
 
         $this->migrationGenerator->expects(self::once())
@@ -111,11 +117,12 @@ class DiffGeneratorTest extends TestCase
             ->willReturn('path');
 
         self::assertSame('path', $this->migrationDiffGenerator->generate(
-            '1234',
-            '/table_name1/',
-            true,
-            false,
-            80,
+            fqcn: '1234',
+            filterExpression: '/table_name1/',
+            formatted: true,
+            nowdocOutput: false,
+            singleBlock: false,
+            lineLength: 80,
         ));
     }
 
@@ -167,10 +174,17 @@ class DiffGeneratorTest extends TestCase
 
         $this->migrationSqlGenerator->expects(self::exactly(2))
             ->method('generate')
-            ->with(self::logicalOr(
-                self::equalTo(['CREATE TABLE table_name']),
-                self::equalTo(['DROP TABLE table_name']),
-            ), false, false, 120, true)
+            ->with(
+                fqcn: self::logicalOr(
+                    self::equalTo(['CREATE TABLE table_name']),
+                    self::equalTo(['DROP TABLE table_name']),
+                ),
+                formatted: false,
+                nowdocOutput: false,
+                singleBlock: false,
+                lineLength: 120,
+                fromEmptySchema: true,
+            )
             ->willReturnOnConsecutiveCalls('test up', 'test down');
 
         $this->migrationGenerator->expects(self::once())
@@ -178,7 +192,19 @@ class DiffGeneratorTest extends TestCase
             ->with('2345', 'test up', 'test down')
             ->willReturn('path2');
 
-        self::assertSame('path2', $this->migrationDiffGenerator->generate('2345', null, false, false, 120, true, true));
+        self::assertSame(
+            'path2',
+            $this->migrationDiffGenerator->generate(
+                fqcn: '2345',
+                filterExpression: null,
+                formatted: false,
+                nowdocOutput: false,
+                singleBlock: false,
+                lineLength: 120,
+                checkDbPlatform: true,
+                fromEmptySchema: true,
+            ),
+        );
     }
 
     protected function setUp(): void

--- a/tests/Generator/SqlGeneratorTest.php
+++ b/tests/Generator/SqlGeneratorTest.php
@@ -59,7 +59,13 @@ final class SqlGeneratorTest extends TestCase
                 CODE,
         );
 
-        $code = $migrationSqlGenerator->generate($this->sql, true, null, 80);
+        $code = $migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: true,
+            nowdocOutput: null,
+            singleBlock: false,
+            lineLength: 80,
+        );
 
         self::assertSame($expectedCode, $code);
     }
@@ -77,7 +83,14 @@ final class SqlGeneratorTest extends TestCase
             formatted: false,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, false, null, 80, false);
+        $code = $this->migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: false,
+            nowdocOutput: null,
+            singleBlock: false,
+            lineLength: 80,
+            checkDbPlatform: false,
+        );
         self::assertSame($expectedCode, $code);
     }
 
@@ -100,7 +113,14 @@ final class SqlGeneratorTest extends TestCase
             formatted: false,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, false, true, 80, false);
+        $code = $this->migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: false,
+            nowdocOutput: true,
+            singleBlock: false,
+            lineLength: 80,
+            checkDbPlatform: false,
+        );
         self::assertSame($expectedCode, $code);
     }
 
@@ -118,7 +138,41 @@ final class SqlGeneratorTest extends TestCase
             nowdoc: false,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, true, false, 80, false);
+        $code = $this->migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: true,
+            nowdocOutput: false,
+            singleBlock: false,
+            lineLength: 80,
+            checkDbPlatform: false,
+        );
+        self::assertSame($expectedCode, $code);
+    }
+
+    public function testGenerationWithSingleBlockOutput(): void
+    {
+        $this->configuration->setCheckDatabasePlatform(true);
+
+        $expectedCode = $this->prepareGeneratedCode(
+            <<<'CODE'
+                $this->addSql(<<<'SQL'
+                    SELECT 1;
+                    SELECT 2;
+                    %s;
+                SQL);
+                CODE,
+            formatted: true,
+            nowdoc: true,
+        );
+
+        $code = $this->migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: true,
+            nowdocOutput: false,
+            singleBlock: true,
+            lineLength: 80,
+            checkDbPlatform: false,
+        );
 
         self::assertSame($expectedCode, $code);
     }
@@ -137,7 +191,14 @@ final class SqlGeneratorTest extends TestCase
                 CODE,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, true, null, 80, false);
+        $code = $this->migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: true,
+            nowdocOutput: null,
+            singleBlock: false,
+            lineLength: 80,
+            checkDbPlatform: false,
+        );
 
         self::assertSame($expectedCode, $code);
     }
@@ -156,7 +217,13 @@ final class SqlGeneratorTest extends TestCase
                 CODE,
         );
 
-        $code = $this->migrationSqlGenerator->generate($this->sql, true, null, 80);
+        $code = $this->migrationSqlGenerator->generate(
+            sql: $this->sql,
+            formatted: true,
+            nowdocOutput: null,
+            singleBlock: false,
+            lineLength: 80,
+        );
 
         self::assertSame($expectedCode, $code);
     }

--- a/tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Tools/Console/Command/DiffCommandTest.php
@@ -66,13 +66,21 @@ final class DiffCommandTest extends TestCase
 
         $this->migrationDiffGenerator->expects(self::once())
             ->method('generate')
-            ->with('FooNs\\Version1234', 'filter expression', true, false, 80)
+            ->with(
+                fqcn: 'FooNs\\Version1234',
+                filterExpression: 'filter expression',
+                formatted: true,
+                nowdocOutput: false,
+                singleBlock: false,
+                lineLength: 80,
+            )
             ->willReturn('/path/to/migration.php');
 
         $this->diffCommandTester->execute([
             '--filter-expression' => 'filter expression',
             '--formatted' => true,
             '--nowdoc' => false,
+            '--single-block' => false,
             '--line-length' => 80,
             '--allow-empty-diff' => true,
             '--check-database-platform' => true,

--- a/tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -78,13 +78,14 @@ final class DumpSchemaCommandTest extends TestCase
 
         $this->schemaDumper->expects(self::once())
             ->method('dump')
-            ->with('FooNs\\Version1234', ['/foo/'], true, false, 80);
+            ->with('FooNs\\Version1234', ['/foo/'], true, false, false, 80);
 
         $this->dumpSchemaCommandTester->execute([
             '--filter-tables' => ['/foo/'],
             '--line-length' => 80,
             '--formatted' => true,
             '--nowdoc' => false,
+            '--single-block' => false,
         ]);
 
         $output = $this->dumpSchemaCommandTester->getDisplay(true);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

Add --singl-block option to generate single nowdoc sql 
`#doctrine:migrations:diff --single-block`

```php
public function up(Schema $schema): void
{
    $this->addSql(<<<'SQL'
        CREATE TABLE "user" (
          id SERIAL PRIMARY KEY,
          firstname VARCHAR(100) NOT NULL,
          lastname VARCHAR(100) NOT NULL
        );
        ALTER TABLE emails ADD test_number INT NOT NULL;
        ALTER TABLE platform ADD test_number INT NOT NULL;
    SQL);
}
```