### PR TITLE
Change check-database-platform option default value to true on DiffCommand

### DIFF
--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -81,7 +81,7 @@ EOT)
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Check Database Platform to the generated code.',
-                false,
+                true,
             )
             ->addOption(
                 'allow-empty-diff',


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Current behaviour, it won't generate the database-platform check code block without adding the `--check-database-platform=true` option to diff command, regardless of the value of `check_database_platform` in the configuration, and make the configuration useless. since `check-database-platform` option default value is `false`, so it won't pass this condition https://github.com/doctrine/migrations/blob/3.9.x/src/Generator/SqlGenerator.php#L74-L92

in the documentation `check_database_platform` default value  is `true` https://github.com/doctrine/migrations/blob/3.9.x/docs/en/reference/configuration.rst?plain=1#L147