### PR TITLE
Formatted queries: use 4 spaces as indentation

### DIFF
--- a/src/Generator/SqlGenerator.php
+++ b/src/Generator/SqlGenerator.php
@@ -98,6 +98,6 @@ PHP
     {
         $this->formatter ??= new SqlFormatter(new NullHighlighter());
 
-        return $this->formatter->format($query);
+        return $this->formatter->format($query, '    ');
     }
 }

--- a/tests/Generator/SqlGeneratorTest.php
+++ b/tests/Generator/SqlGeneratorTest.php
@@ -186,7 +186,7 @@ final class SqlGeneratorTest extends TestCase
         $this->metadataConfig->setTableName('migrations_table_name');
 
         if ($formatted) {
-            $formattedSql = (new SqlFormatter(new NullHighlighter()))->format($this->sql[2]);
+            $formattedSql = (new SqlFormatter(new NullHighlighter()))->format($this->sql[2], '    ');
             if ($nowdoc) {
                 $formattedSql = implode(
                     "\n" . str_repeat(' ', 4),


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

The migration php files use 4 spaces as indentation. So in my opinion the formatted sql queries should also use 4 spaces.
