### PR TITLE
Fix handling of `--nowdoc` options

### DIFF
--- a/src/SchemaDumper.php
+++ b/src/SchemaDumper.php
@@ -57,7 +57,7 @@ class SchemaDumper
         string $fqcn,
         array $excludedTablesRegexes = [],
         bool $formatted = false,
-        bool $nowdocOutput = false,
+        bool|null $nowdocOutput = null,
         int $lineLength = 120,
     ): string {
         $schema = $this->schemaManager->introspectSchema();

--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -67,7 +67,7 @@ EOT)
                 'nowdoc',
                 null,
                 InputOption::VALUE_NEGATABLE,
-                'Output the generated SQL as a nowdoc string (always active for formatted queries).',
+                'Output the generated SQL as a nowdoc string (enabled by default for formatted queries).',
             )
             ->addOption(
                 'line-length',
@@ -108,7 +108,8 @@ EOT)
         }
 
         $formatted       = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
-        $nowdocOutput    = filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
+        $nowdocOutput    = $input->getOption('nowdoc');
+        $nowdocOutput    = $nowdocOutput === null ? null : filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
         $lineLength      = (int) $input->getOption('line-length');
         $allowEmptyDiff  = $input->getOption('allow-empty-diff');
         $checkDbPlatform = filter_var($input->getOption('check-database-platform'), FILTER_VALIDATE_BOOLEAN);

--- a/src/Tools/Console/Command/DumpSchemaCommand.php
+++ b/src/Tools/Console/Command/DumpSchemaCommand.php
@@ -55,8 +55,8 @@ EOT)
             ->addOption(
                 'nowdoc',
                 null,
-                InputOption::VALUE_NONE,
-                'Output the generated SQL as a nowdoc string (always active for formatted queries).',
+                InputOption::VALUE_NEGATABLE,
+                'Output the generated SQL as a nowdoc string (enabled by default for formatted queries).',
             )
             ->addOption(
                 'namespace',
@@ -85,7 +85,8 @@ EOT)
         OutputInterface $output,
     ): int {
         $formatted    = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
-        $nowdocOutput = filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
+        $nowdocOutput = $input->getOption('nowdoc');
+        $nowdocOutput = $nowdocOutput === null ? null : filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
         $lineLength   = (int) $input->getOption('line-length');
 
         $schemaDumper = $this->getDependencyFactory()->getSchemaDumper();


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
With these changes we get the behavior described here: https://github.com/doctrine/migrations/pull/1504#discussion_r2163725374

It fixes the behavior for `--formatted` without `--nowdoc` option.

And the pr adds the `--no-nowdoc` option to `DumpSchemaCommand` by also using `InputOption::VALUE_NEGATABLE` there.