### PR TITLE
Fixed rendering of the Migration Events list

### DIFF
--- a/docs/en/reference/events.rst
+++ b/docs/en/reference/events.rst
@@ -4,7 +4,7 @@ Migrations Events
 The Doctrine Migrations library emits a series of events during the migration process.
 
 - ``onMigrationsMigrating``: dispatched immediately before starting to execute versions. This does not fire if
-there are no versions to be executed.
+  there are no versions to be executed.
 - ``onMigrationsVersionExecuting``: dispatched before a single version executes.
 - ``onMigrationsVersionExecuted``: dispatched after a single version executes.
 - ``onMigrationsVersionSkipped``: dispatched when a single version is skipped.


### PR DESCRIPTION
Fixed rendering of Migration Events list on https://www.doctrine-project.org/projects/doctrine-migrations/en/3.9/reference/events.html#migrations-events

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1532

