### PR TITLE
feat(Console): Add --check option to diff command

### DIFF
--- a/src/Generator/DiffGenerator.php
+++ b/src/Generator/DiffGenerator.php
@@ -37,6 +37,38 @@ class DiffGenerator
     ) {
     }
 
+    public function hasChanges(string|null $filterExpression, bool $fromEmptySchema = false): bool
+    {
+        if ($filterExpression !== null) {
+            $this->dbalConfiguration->setSchemaAssetsFilter(
+                static function ($assetName) use ($filterExpression) {
+                    if ($assetName instanceof AbstractAsset) {
+                        $assetName = $assetName->getName();
+                    }
+
+                    return preg_match($filterExpression, $assetName);
+                },
+            );
+        }
+
+        $fromSchema = $fromEmptySchema
+            ? $this->createEmptySchema()
+            : $this->createFromSchema();
+
+        $toSchema = $this->createToSchema();
+
+        if (class_exists(ComparatorConfig::class)) {
+            $comparator = $this->schemaManager->createComparator((new ComparatorConfig())->withReportModifiedIndexes(false));
+        } else {
+            $comparator = $this->schemaManager->createComparator();
+        }
+
+        $upSql   = $this->platform->getAlterSchemaSQL($comparator->compareSchemas($fromSchema, $toSchema));
+        $downSql = $this->platform->getAlterSchemaSQL($comparator->compareSchemas($toSchema, $fromSchema));
+
+        return $upSql !== [] || $downSql !== [];
+    }
+
     /** @throws NoChangesDetected */
     public function generate(
         string $fqcn,

--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -42,9 +42,9 @@ final class DiffCommand extends DoctrineCommand
             ->setHelp(<<<'EOT'
 The <info>%command.name%</info> command generates a migration by comparing your current database to your mapping information:
 
-    <info>%command.full_name%</info>
+	<info>%command.full_name%</info>
 
-EOT)
+EOT,)
             ->addOption(
                 'namespace',
                 null,
@@ -94,6 +94,12 @@ EOT)
                 null,
                 InputOption::VALUE_NONE,
                 'Generate a full migration as if the current database was empty.',
+            )
+            ->addOption(
+                'check',
+                null,
+                InputOption::VALUE_NONE,
+                'Check if a migration is needed and exit with a non-zero status code if it is.',
             );
     }
 
@@ -107,13 +113,34 @@ EOT)
             $filterExpression = null;
         }
 
+        $fromEmptySchema = $input->getOption('from-empty-schema');
+        $check           = $input->getOption('check');
+
+        $diffGenerator = $this->getDependencyFactory()->getDiffGenerator();
+
+        if ($check) {
+            if ($diffGenerator->hasChanges($filterExpression, $fromEmptySchema)) {
+                $this->io->error([
+                    'The database schema is not in sync with the mapping.',
+                    'Run the following command to generate a migration:',
+                    '',
+                    'bin/console doctrine:migrations:diff',
+                ]);
+
+                return 1;
+            }
+
+            $this->io->success('The database schema is in sync with the mapping. No migration required.');
+
+            return 0;
+        }
+
         $formatted       = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
         $nowdocOutput    = $input->getOption('nowdoc');
         $nowdocOutput    = $nowdocOutput === null ? null : filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
         $lineLength      = (int) $input->getOption('line-length');
         $allowEmptyDiff  = $input->getOption('allow-empty-diff');
         $checkDbPlatform = filter_var($input->getOption('check-database-platform'), FILTER_VALIDATE_BOOLEAN);
-        $fromEmptySchema = $input->getOption('from-empty-schema');
 
         if ($formatted) {
             if (! class_exists(SqlFormatter::class)) {
@@ -135,8 +162,7 @@ EOT)
             return 3;
         }
 
-        $fqcn          = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName($namespace);
-        $diffGenerator = $this->getDependencyFactory()->getDiffGenerator();
+        $fqcn = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName($namespace);
 
         try {
             $path = $diffGenerator->generate(

--- a/tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Tools/Console/Command/DiffCommandTest.php
@@ -182,6 +182,54 @@ final class DiffCommandTest extends TestCase
         self::assertStringContainsString(sprintf('You have selected the "%s" namespace', $namespace), $output);
     }
 
+    public function testCheckReturnsZeroWhenNoChanges(): void
+    {
+        $this->migrationDiffGenerator
+            ->expects(self::once())
+            ->method('hasChanges')
+            ->with(null, false)
+            ->willReturn(false);
+
+        $this->migrationDiffGenerator
+            ->expects(self::never())
+            ->method('generate');
+
+        $this->diffCommandTester->execute(['--check' => true]);
+
+        $output     = $this->diffCommandTester->getDisplay(true);
+        $statusCode = $this->diffCommandTester->getStatusCode();
+
+        self::assertStringContainsString('[OK] The database schema is in sync with the mapping. No migration required.', $output);
+        self::assertSame(0, $statusCode);
+    }
+
+    public function testCheckReturnsOneWhenChanges(): void
+    {
+        $this->migrationDiffGenerator
+            ->expects(self::once())
+            ->method('hasChanges')
+            ->with('filter', true)
+            ->willReturn(true);
+
+        $this->migrationDiffGenerator
+            ->expects(self::never())
+            ->method('generate');
+
+        $this->diffCommandTester->execute([
+            '--check' => true,
+            '--filter-expression' => 'filter',
+            '--from-empty-schema' => true,
+        ]);
+
+        $output     = $this->diffCommandTester->getDisplay(true);
+        $statusCode = $this->diffCommandTester->getStatusCode();
+
+        self::assertStringContainsString('[ERROR] The database schema is not in sync with the mapping.', $output);
+        self::assertStringContainsString('Run the following command to generate a migration:', $output);
+        self::assertStringContainsString('bin/console doctrine:migrations:diff', $output);
+        self::assertSame(1, $statusCode);
+    }
+
     protected function setUp(): void
     {
         $this->migrationDiffGenerator    = $this->createMock(DiffGenerator::class);


### PR DESCRIPTION
  |      Q       |   A
  |------------- | -----------
  | Type         | feature
  | BC Break     | no
  | Fixed issues | N/A

**Summary**

  This pull request introduces a new `--check` option to the `doctrine:migrations:diff` command to improve its usability in CI/CD environments.

  Currently, verifying that no pending migrations exist requires using fragile and complex shell scripts that check for the creation of new migration files. This approach is not ideal as it's not explicit and can be brittle. This PR proposes a cleaner, integrated solution.

  The new `--check` flag allows you to verify the database schema status without generating a migration file.

   * If the database schema is in sync with the mapping, the command will output a success message and exit with a 0 status code.
   * If the database schema is not in sync, the command will output a clear, actionable error message (suggesting the diff command to run) and exit with a 1 status code.

  This makes CI configuration much simpler, more readable, and improves the overall developer experience by providing a robust, self-documenting way to ensure schema consistency in automated workflows.

