### PR TITLE
ensure that CLI input in tests is passed as strings

### DIFF
--- a/tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Tools/Console/Command/DiffCommandTest.php
@@ -144,18 +144,18 @@ final class DiffCommandTest extends TestCase
         self::assertSame(3, $statusCode);
     }
 
-    /** @return array<string, array{int|null, string}> */
+    /** @return array<string, array{string, string}> */
     public static function getSelectedNamespace(): array
     {
         return [
-            'no' => [null, 'FooNs'],
-            'first' => [0, 'FooNs'],
-            'two' => [1, 'FooNs2'],
+            'no' => ['', 'FooNs'],
+            'first' => ['0', 'FooNs'],
+            'two' => ['1', 'FooNs2'],
         ];
     }
 
     #[DataProvider('getSelectedNamespace')]
-    public function testExecuteWithMultipleDirectories(int|null $input, string $namespace): void
+    public function testExecuteWithMultipleDirectories(string $input, string $namespace): void
     {
         $this->migrationStatusCalculator
             ->method('getNewMigrations')

--- a/tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -103,18 +103,18 @@ final class DumpSchemaCommandTest extends TestCase
         );
     }
 
-    /** @return array<string, array<int, int|string|null>> */
+    /** @return array<string, array{string, string}> */
     public static function getNamespaceSelected(): array
     {
         return [
-            'no' => [null, 'FooNs'],
-            'first' => [0, 'FooNs'],
-            'two' => [1, 'FooNs2'],
+            'no' => ['', 'FooNs'],
+            'first' => ['0', 'FooNs'],
+            'two' => ['1', 'FooNs2'],
         ];
     }
 
     #[DataProvider('getNamespaceSelected')]
-    public function testExecuteWithMultipleDirectories(int|null $input, string $namespace): void
+    public function testExecuteWithMultipleDirectories(string $input, string $namespace): void
     {
         $this->migrationRepository->expects(self::once())
             ->method('getMigrations')

--- a/tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Tools/Console/Command/GenerateCommandTest.php
@@ -65,18 +65,18 @@ final class GenerateCommandTest extends TestCase
         ], array_map(trim(...), explode("\n", trim($output))));
     }
 
-    /** @return array<string, array<int, int|string|null>> */
+    /** @return array<string, array{string, string}> */
     public static function getNamespaceSelected(): array
     {
         return [
-            'no' => [null, 'FooNs'],
-            'first' => [0, 'FooNs'],
-            'two' => [1, 'FooNs2'],
+            'no' => ['', 'FooNs'],
+            'first' => ['0', 'FooNs'],
+            'two' => ['1', 'FooNs2'],
         ];
     }
 
     #[DataProvider('getNamespaceSelected')]
-    public function testExecuteWithMultipleDirectories(int|null $input, string $namespace): void
+    public function testExecuteWithMultipleDirectories(string $input, string $namespace): void
     {
         $this->configuration->addMigrationsDirectory('FooNs2', sys_get_temp_dir());
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

see the PHP deprecations triggered when running tests:

```
3 tests triggered 2 PHP deprecations:

1) /home/runner/work/migrations/migrations/vendor/symfony/console/Tester/TesterTrait.php:171
fwrite(): Passing null to parameter #2 ($data) of type string is deprecated

Triggered by:

* Doctrine\Migrations\Tests\Tools\Console\Command\DiffCommandTest::testExecuteWithMultipleDirectories#no
  /home/runner/work/migrations/migrations/tests/Tools/Console/Command/DiffCommandTest.php:158

* Doctrine\Migrations\Tests\Tools\Console\Command\DumpSchemaCommandTest::testExecuteWithMultipleDirectories#no
  /home/runner/work/migrations/migrations/tests/Tools/Console/Command/DumpSchemaCommandTest.php:117

* Doctrine\Migrations\Tests\Tools\Console\Command\GenerateCommandTest::testExecuteWithMultipleDirectories#no
  /home/runner/work/migrations/migrations/tests/Tools/Console/Command/GenerateCommandTest.php:79

2) /home/runner/work/migrations/migrations/vendor/symfony/console/Tester/TesterTrait.php:173
str_ends_with(): Passing null to parameter #1 ($haystack) of type string is deprecated

Triggered by:

* Doctrine\Migrations\Tests\Tools\Console\Command\DiffCommandTest::testExecuteWithMultipleDirectories#no
  /home/runner/work/migrations/migrations/tests/Tools/Console/Command/DiffCommandTest.php:158

* Doctrine\Migrations\Tests\Tools\Console\Command\DumpSchemaCommandTest::testExecuteWithMultipleDirectories#no
  /home/runner/work/migrations/migrations/tests/Tools/Console/Command/DumpSchemaCommandTest.php:117

* Doctrine\Migrations\Tests\Tools\Console\Command\GenerateCommandTest::testExecuteWithMultipleDirectories#no
  /home/runner/work/migrations/migrations/tests/Tools/Console/Command/GenerateCommandTest.php:79
```
