### PR TITLE
use native lazy objects in tests with PHP 8.4+

### DIFF
--- a/tests/Configuration/EntityManager/_files/em-loader.php
+++ b/tests/Configuration/EntityManager/_files/em-loader.php
@@ -15,9 +15,14 @@ return new class () implements EntityManagerLoader {
         $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
 
         $conf = new Configuration();
-        $conf->setProxyDir(__DIR__);
-        $conf->setProxyNamespace('Foo');
         $conf->setMetadataDriverImpl(new PHPDriver(''));
+
+        if (PHP_VERSION_ID > 80400) {
+            $conf->enableNativeLazyObjects(true);
+        } else {
+            $conf->setProxyDir(__DIR__);
+            $conf->setProxyNamespace('Foo');
+        }
 
         return new EntityManager($conn, $conf);
     }

--- a/tests/Configuration/EntityManager/_files/migrations-em.php
+++ b/tests/Configuration/EntityManager/_files/migrations-em.php
@@ -10,8 +10,13 @@ use Doctrine\Persistence\Mapping\Driver\PHPDriver;
 $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
 
 $conf = new Configuration();
-$conf->setProxyDir(__DIR__);
-$conf->setProxyNamespace('Foo');
 $conf->setMetadataDriverImpl(new PHPDriver(''));
+
+if (PHP_VERSION_ID > 80400) {
+    $conf->enableNativeLazyObjects(true);
+} else {
+    $conf->setProxyDir(__DIR__);
+    $conf->setProxyNamespace('Foo');
+}
 
 return new EntityManager($conn, $conf);

--- a/tests/Provider/OrmSchemaProviderTest.php
+++ b/tests/Provider/OrmSchemaProviderTest.php
@@ -14,6 +14,8 @@ use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\ORMSetup;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
+use const PHP_VERSION_ID;
+
 /**
  * Tests the OrmSchemaProvider using a real entity manager.
  */
@@ -53,6 +55,10 @@ class OrmSchemaProviderTest extends MigrationTestCase
     {
         $this->config = ORMSetup::createXMLMetadataConfiguration([__DIR__ . '/_files'], true);
         $this->config->setClassMetadataFactoryName(ClassMetadataFactory::class);
+
+        if (PHP_VERSION_ID >= 80400) {
+            $this->config->enableNativeLazyObjects(true);
+        }
 
         $this->conn          = $this->getSqliteConnection();
         $this->entityManager = new EntityManager($this->conn, $this->config);

--- a/tests/Tools/Console/config/cli-config.php
+++ b/tests/Tools/Console/config/cli-config.php
@@ -11,9 +11,14 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\Persistence\Mapping\Driver\PHPDriver;
 
 $conf = new Configuration();
-$conf->setProxyDir(__DIR__);
-$conf->setProxyNamespace('Foo');
 $conf->setMetadataDriverImpl(new PHPDriver(''));
+
+if (PHP_VERSION_ID > 80400) {
+    $conf->enableNativeLazyObjects(true);
+} else {
+    $conf->setProxyDir(__DIR__);
+    $conf->setProxyNamespace('Foo');
+}
 
 $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
 


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

fixes the deprecation emitted by CI jobs using PHP 8.4+:

```
1 test triggered 1 deprecation:

1) /home/runner/work/migrations/migrations/vendor/doctrine/deprecations/src/Deprecation.php:208
Calling Doctrine\ORM\Configuration::setProxyDir is deprecated and will not be possible in Doctrine ORM 4.0. (Configuration.php:68 called by em-loader.php:18, https://github.com/doctrine/orm/pull/12005, package doctrine/orm)

Triggered by:

* Doctrine\Migrations\Tests\Configuration\EntityManager\EntityManagerTest::testArrayEntityManagerConfigurationLoader
  /home/runner/work/migrations/migrations/tests/Configuration/EntityManager/EntityManagerTest.php:37
  ```

