### PR TITLE
Use executeStatement for migration SQL

### DIFF
--- a/src/Version/DbalExecutor.php
+++ b/src/Version/DbalExecutor.php
@@ -271,8 +271,8 @@ final class DbalExecutor implements Executor
             $this->outputSqlQuery($query, $configuration);
 
             $stopwatchEvent = $this->stopwatch->start('query');
-            // executeQuery() must be used here because $query might return a result set, for instance REPAIR does
-            $this->connection->executeQuery($query->getStatement(), $query->getParameters(), $query->getTypes());
+            // executeStatement() must be used here because executeQuery() is for READ operations only
+            $this->connection->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
             $stopwatchEvent->stop();
 
             if (! $configuration->getTimeAllQueries()) {

--- a/tests/Version/ExecutorTest.php
+++ b/tests/Version/ExecutorTest.php
@@ -99,6 +99,26 @@ class ExecutorTest extends TestCase
 
     public function testExecuteUp(): void
     {
+        $call = 0;
+        $this->connection
+            ->expects(self::exactly(2))
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $statement, array $parameters = [], array $types = []) use (&$call): int {
+                $call++;
+                if ($call === 1) {
+                    self::assertSame('SELECT 1', $statement);
+                    self::assertSame([1], $parameters);
+                    self::assertSame([3], $types);
+                }
+
+                if ($call === 2) {
+                    self::assertSame('SELECT 2', $statement);
+                    self::assertSame([], $parameters);
+                    self::assertSame([], $types);
+                }
+                return 1;
+            });
+
         $this->metadataStorage
             ->expects(self::once())
             ->method('complete')->willReturnCallback(static function (ExecutionResult $result): void {
@@ -160,6 +180,26 @@ class ExecutorTest extends TestCase
 
     public function testExecuteDown(): void
     {
+        $call = 0;
+        $this->connection
+            ->expects(self::exactly(2))
+            ->method('executeStatement')
+            ->willReturnCallback(function (string $statement, array $parameters = [], array $types = []) use (&$call): int {
+                $call++;
+                if ($call === 1) {
+                    self::assertSame('SELECT 3', $statement);
+                    self::assertSame([5], $parameters);
+                    self::assertSame([7], $types);
+                }
+
+                if ($call === 2) {
+                    self::assertSame('SELECT 4', $statement);
+                    self::assertSame([6], $parameters);
+                    self::assertSame([8], $types);
+                }
+                return 1;
+            });
+
         $this->metadataStorage
             ->expects(self::once())
             ->method('complete')->willReturnCallback(static function (ExecutionResult $result): void {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1551

#### Summary

DbalExecutor now uses Connection::executeStatement (instead of executeQuery) because executeQuery is intended for read-only operations in DBAL.

See https://github.com/doctrine/dbal/blob/05f3985a266bb75c44e621e6a647027016061265/src/Connections/PrimaryReadReplicaConnection.php#L43