### PR TITLE
Introduce a "formatted" configuration option

### DIFF
--- a/docs/en/reference/configuration.rst
+++ b/docs/en/reference/configuration.rst
@@ -39,6 +39,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
 
             'all_or_nothing' => true,
             'transactional' => true,
+            'formatted' => true,
             'check_database_platform' => true,
             'organize_migrations' => 'none',
             'connection' => null,
@@ -60,6 +61,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
 
         all_or_nothing: true
         transactional: true
+        formatted: true
         check_database_platform: true
         organize_migrations: none
 
@@ -93,6 +95,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
 
             <all-or-nothing>true</all-or-nothing>
             <transactional>true</transactional>
+            <formatted>true</formatted>
 
             <check-database-platform>true</check-database-platform>
             <organize_migrations>none</organize_migrations>
@@ -116,6 +119,7 @@ Now, in the root of your project place a file named ``migrations.php``, ``migrat
 
             "all_or_nothing": true,
             "transactional": true,
+            "formatted": true,
             "check_database_platform": true,
             "organize_migrations": "none",
 
@@ -141,6 +145,8 @@ Here are details about what each configuration option does:
 | all_or_nothing                   | no       | false    | Whether or not to wrap multiple migrations in a single transaction.                                                         |
 +----------------------------------+----------+----------+-----------------------------------------------------------------------------------------------------------------------------+
 | transactional                    | no       | true     | Whether or not to wrap migrations in a single transaction.                                                                  |
++----------------------------------+----------+----------+-----------------------------------------------------------------------------------------------------------------------------+
+| formatted                        | no       | false    | Whether or not to format generated SQL.                                                                                     |
 +----------------------------------+----------+----------+-----------------------------------------------------------------------------------------------------------------------------+
 | migrations                       | no       | []       | Manually specify the array of migration versions instead of finding migrations.                                             |
 +----------------------------------+----------+----------+-----------------------------------------------------------------------------------------------------------------------------+

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -48,6 +48,8 @@ final class Configuration
 
     private bool $frozen = false;
 
+    private bool $formatted = false;
+
     public function freeze(): void
     {
         $this->frozen = true;
@@ -208,5 +210,16 @@ final class Configuration
             self::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH => $this->setMigrationsAreOrganizedByYearAndMonth(),
             default => throw UnknownConfigurationValue::new('organize_migrations', $migrationOrganization),
         };
+    }
+
+    public function setFormatted(bool $formatted): void
+    {
+        $this->assertNotFrozen();
+        $this->formatted = $formatted;
+    }
+
+    public function isFormatted(): bool
+    {
+        return $this->formatted;
     }
 }

--- a/src/Tools/Console/Command/DiffCommand.php
+++ b/src/Tools/Console/Command/DiffCommand.php
@@ -60,7 +60,7 @@ EOT)
             ->addOption(
                 'formatted',
                 null,
-                InputOption::VALUE_NONE,
+                InputOption::VALUE_NEGATABLE,
                 'Format the generated SQL.',
             )
             ->addOption(
@@ -107,7 +107,7 @@ EOT)
             $filterExpression = null;
         }
 
-        $formatted       = filter_var($input->getOption('formatted'), FILTER_VALIDATE_BOOLEAN);
+        $formatted       = filter_var($input->getOption('formatted') ?? $this->getDependencyFactory()->getConfiguration()->isFormatted(), FILTER_VALIDATE_BOOLEAN);
         $nowdocOutput    = $input->getOption('nowdoc');
         $nowdocOutput    = $nowdocOutput === null ? null : filter_var($input->getOption('nowdoc'), FILTER_VALIDATE_BOOLEAN);
         $lineLength      = (int) $input->getOption('line-length');

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -107,4 +107,11 @@ class ConfigurationTest extends TestCase
 
         self::assertFalse($config->isAllOrNothing());
     }
+
+    public function testFormattedConfigDefaultOption(): void
+    {
+        $config = new Configuration();
+
+        self::assertFalse($config->isFormatted());
+    }
 }

--- a/tests/Tools/Console/Command/DiffCommandTest.php
+++ b/tests/Tools/Console/Command/DiffCommandTest.php
@@ -182,6 +182,59 @@ final class DiffCommandTest extends TestCase
         self::assertStringContainsString(sprintf('You have selected the "%s" namespace', $namespace), $output);
     }
 
+    public function testFormattedInputHasPrecedenceOverConfig(): void
+    {
+        $this->migrationStatusCalculator
+            ->method('getNewMigrations')
+            ->willReturn(new AvailableMigrationsList([]));
+
+        $this->migrationStatusCalculator
+            ->method('getExecutedUnavailableMigrations')
+            ->willReturn(new ExecutedMigrationsList([]));
+
+        $this->configuration->setFormatted(false);
+        $this->migrationDiffGenerator->expects(self::once())
+            ->method('generate')
+            ->with(self::anything(), self::anything(), true);
+
+        $this->diffCommandTester->execute(['--formatted' => true]);
+    }
+
+    public function testFormattedConfigIsFallback(): void
+    {
+        $this->migrationStatusCalculator
+            ->method('getNewMigrations')
+            ->willReturn(new AvailableMigrationsList([]));
+
+        $this->migrationStatusCalculator
+            ->method('getExecutedUnavailableMigrations')
+            ->willReturn(new ExecutedMigrationsList([]));
+
+        $this->configuration->setFormatted(true);
+        $this->migrationDiffGenerator->expects(self::once())
+            ->method('generate')
+            ->with(self::anything(), self::anything(), true);
+
+        $this->diffCommandTester->execute([]);
+    }
+
+    public function testFormattedConfigIsFalseByDefault(): void
+    {
+        $this->migrationStatusCalculator
+            ->method('getNewMigrations')
+            ->willReturn(new AvailableMigrationsList([]));
+
+        $this->migrationStatusCalculator
+            ->method('getExecutedUnavailableMigrations')
+            ->willReturn(new ExecutedMigrationsList([]));
+
+        $this->migrationDiffGenerator->expects(self::once())
+            ->method('generate')
+            ->with(self::anything(), self::anything(), false);
+
+        $this->diffCommandTester->execute([]);
+    }
+
     protected function setUp(): void
     {
         $this->migrationDiffGenerator    = $this->createMock(DiffGenerator::class);


### PR DESCRIPTION

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | 

#### Summary

Adds a "formatted" config option to set the default behaviour for formatting generated SQL.
Changes the current command option to be negatable to be able to override the config option.
