### PR TITLE
Handle schema names in table metadata

### DIFF
--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -28,11 +28,14 @@ use Doctrine\Migrations\Version\Version;
 use InvalidArgumentException;
 
 use function array_change_key_case;
+use function assert;
 use function class_exists;
+use function explode;
 use function floatval;
 use function method_exists;
 use function round;
 use function sprintf;
+use function str_contains;
 use function strlen;
 use function strpos;
 use function strtolower;
@@ -209,7 +212,16 @@ final class TableMetadataStorage implements MetadataStorage
 
         /** @phpstan-ignore function.alreadyNarrowedType */
         if (method_exists($this->schemaManager, 'introspectTableByUnquotedName')) {
-            $currentTable = $this->schemaManager->introspectTableByUnquotedName($this->configuration->getTableName());
+            if (str_contains($this->configuration->getTableName(), '.')) {
+                [$namespace, $tableName] = explode('.', $this->configuration->getTableName(), 2);
+                assert($namespace !== '' && $tableName !== '');
+                $currentTable = $this->schemaManager->introspectTableByUnquotedName(
+                    $tableName,
+                    $namespace,
+                );
+            } else {
+                $currentTable = $this->schemaManager->introspectTableByUnquotedName($this->configuration->getTableName());
+            }
         } else {
             /** @phpstan-ignore method.deprecated */
             $currentTable = $this->schemaManager->introspectTable($this->configuration->getTableName());


### PR DESCRIPTION
Fixes #1566

In a previous commit, I switched from `introspectTable()`, which handles this with a single argument to `introspectTableByUnquotedName()`, which handles it with 2 arguments.

I could not find a way to test this since we use SQLite and that the corresponding DBAL platform does not support schemas.