### PR TITLE
Add migration version completion to commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/deprecations": "^0.5.3 || ^1",
         "doctrine/event-manager": "^1.2 || ^2.0",
         "psr/log": "^1.1.3 || ^2 || ^3",
-        "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/console": "^5.4.2 || ^6.0 || ^7.0 || ^8.0",
         "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/var-exporter": "^6.2 || ^7.0 || ^8.0"
     },

--- a/src/Tools/Console/Command/ExecuteCommand.php
+++ b/src/Tools/Console/Command/ExecuteCommand.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Migrations\Tools\Console\Command;
 
+use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -174,5 +177,21 @@ EOT);
     private function isPathWritable(string $path): bool
     {
         return is_writable($path) || is_dir($path) || is_writable(dirname($path));
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('versions')) {
+            $availableMigrations = $this->getDependencyFactory()->getMigrationPlanCalculator()->getMigrations();
+
+            /** @var list<string> $availableVersions */
+            $availableVersions = array_map(static function (AvailableMigration $availableMigration): string {
+                return (string) $availableMigration->getVersion();
+            }, $availableMigrations->getItems());
+
+            $suggestions->suggestValues($availableVersions);
+
+            return;
+        }
     }
 }

--- a/src/Tools/Console/Command/MigrateCommand.php
+++ b/src/Tools/Console/Command/MigrateCommand.php
@@ -7,15 +7,20 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 use Doctrine\Migrations\Exception\NoMigrationsFoundWithCriteria;
 use Doctrine\Migrations\Exception\NoMigrationsToExecute;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
+use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Tools\Console\ConsoleInputMigratorConfigurationFactory;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_map;
+use function array_merge;
 use function count;
 use function dirname;
 use function getcwd;
@@ -304,5 +309,21 @@ EOT);
     private function isPathWritable(string $path): bool
     {
         return is_writable($path) || is_dir($path) || is_writable(dirname($path));
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('version')) {
+            $availableMigrations = $this->getDependencyFactory()->getMigrationPlanCalculator()->getMigrations();
+
+            /** @var list<string> $availableVersions */
+            $availableVersions = array_map(static function (AvailableMigration $availableMigration): string {
+                return (string) $availableMigration->getVersion();
+            }, $availableMigrations->getItems());
+
+            $suggestions->suggestValues(array_merge(['current', 'latest', 'first', 'next', 'prev'], $availableVersions));
+
+            return;
+        }
     }
 }

--- a/src/Tools/Console/Command/VersionCommand.php
+++ b/src/Tools/Console/Command/VersionCommand.php
@@ -6,6 +6,7 @@ namespace Doctrine\Migrations\Tools\Console\Command;
 
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
 use Doctrine\Migrations\Exception\UnknownMigrationVersion;
+use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\ExecutedMigrationsList;
 use Doctrine\Migrations\Tools\Console\Exception\InvalidOptionUsage;
 use Doctrine\Migrations\Tools\Console\Exception\VersionAlreadyExists;
@@ -14,11 +15,14 @@ use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function array_map;
 use function sprintf;
 
 /**
@@ -255,6 +259,22 @@ EOT);
                 "<info>%s</info> deleted from the version table.\n",
                 (string) $version,
             ));
+        }
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('version')) {
+            $availableMigrations = $this->getDependencyFactory()->getMigrationPlanCalculator()->getMigrations();
+
+            /** @var list<string> $availableVersions */
+            $availableVersions = array_map(static function (AvailableMigration $availableMigration): string {
+                return (string) $availableMigration->getVersion();
+            }, $availableMigrations->getItems());
+
+            $suggestions->suggestValues($availableVersions);
+
+            return;
         }
     }
 }

--- a/tests/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/Tools/Console/Command/ExecuteCommandTest.php
@@ -9,6 +9,8 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
 use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
 use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsList;
 use Doctrine\Migrations\Metadata\MigrationPlan;
 use Doctrine\Migrations\Metadata\MigrationPlanList;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
@@ -22,9 +24,14 @@ use Doctrine\Migrations\Version\MigrationPlanCalculator;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function array_map;
 use function getcwd;
 use function sys_get_temp_dir;
 use function trim;
@@ -195,6 +202,39 @@ class ExecuteCommandTest extends MigrationTestCase
 
         self::assertSame(0, $this->executeCommandTester->getStatusCode());
         self::assertStringContainsString('[notice] Executing 1 up', trim($this->executeCommandTester->getDisplay(true)));
+    }
+
+    /**
+     * @param list<string> $args
+     * @param list<string> $expectedSuggestions
+     */
+    #[TestWith([['console'], ['A', 'B']])]
+    #[TestWith([['console', 'A'], ['A', 'B']])]
+    public function testComplete(array $args, array $expectedSuggestions): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $this->planCalculator
+            ->expects(self::once())
+            ->method('getMigrations')
+            ->willReturn(new AvailableMigrationsList([
+                new AvailableMigration(new Version('A'), $migration),
+                new AvailableMigration(new Version('B'), $migration),
+            ]));
+
+        $input = CompletionInput::fromTokens($args, 1);
+        $input->bind($this->executeCommand->getDefinition());
+        $suggestions = new CompletionSuggestions();
+
+        $this->executeCommand->complete($input, $suggestions);
+
+        self::assertSame(
+            $expectedSuggestions,
+            array_map(
+                static fn (Suggestion $suggestion): string => $suggestion->getValue(),
+                $suggestions->getValueSuggestions(),
+            ),
+        );
     }
 
     protected function setUp(): void

--- a/tests/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/Tools/Console/Command/MigrateCommandTest.php
@@ -35,12 +35,17 @@ use Doctrine\Migrations\Version\Version;
 use Generator;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function array_map;
 use function class_exists;
 use function getcwd;
 use function in_array;
@@ -55,6 +60,7 @@ class MigrateCommandTest extends MigrationTestCase
 
     private DependencyFactory $dependencyFactory;
     private Configuration $configuration;
+    private MigrateCommand $migrateCommand;
     private CommandTester $migrateCommandTester;
     private MetadataStorage $storage;
     private QueryWriter&MockObject $queryWriter;
@@ -430,6 +436,32 @@ class MigrateCommandTest extends MigrationTestCase
         );
     }
 
+    /**
+     * @param list<string> $args
+     * @param list<string> $expectedSuggestions
+     */
+    #[TestWith([['console'], ['current', 'latest', 'first', 'next', 'prev', 'A', 'B']])]
+    #[TestWith([['console', 'A'], ['current', 'latest', 'first', 'next', 'prev', 'A', 'B']])]
+    public function testComplete(array $args, array $expectedSuggestions): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('B'), $migration);
+
+        $input = CompletionInput::fromTokens($args, 1);
+        $input->bind($this->migrateCommand->getDefinition());
+        $suggestions = new CompletionSuggestions();
+
+        $this->migrateCommand->complete($input, $suggestions);
+
+        self::assertSame(
+            $expectedSuggestions,
+            array_map(
+                static fn (Suggestion $suggestion): string => $suggestion->getValue(),
+                $suggestions->getValueSuggestions(),
+            ),
+        );
+    }
+
     public function testExecuteMigrateCancelExecutedUnavailableMigrations(): void
     {
         $result = new ExecutionResult(new Version('345'));
@@ -498,12 +530,12 @@ class MigrateCommandTest extends MigrationTestCase
 
         $this->dependencyFactory->setService(MigrationsRepository::class, $this->migrationRepository);
 
-        $migrateCommand = new MigrateCommand($this->dependencyFactory);
+        $this->migrateCommand = new MigrateCommand($this->dependencyFactory);
 
         $questions = $this->createMock(QuestionHelper::class);
-        $migrateCommand->setHelperSet(new HelperSet(['question' => $questions]));
+        $this->migrateCommand->setHelperSet(new HelperSet(['question' => $questions]));
 
-        $this->migrateCommandTester = new CommandTester($migrateCommand);
+        $this->migrateCommandTester = new CommandTester($this->migrateCommand);
 
         $this->storage = new TableMetadataStorage(
             $this->connection,

--- a/tests/Tools/Console/Command/MigrationVersionTest.php
+++ b/tests/Tools/Console/Command/MigrationVersionTest.php
@@ -18,11 +18,16 @@ use Doctrine\Migrations\Version\Direction;
 use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Version;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Log\NullLogger;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function array_map;
 use function sys_get_temp_dir;
 
 class MigrationVersionTest extends MigrationTestCase
@@ -364,5 +369,32 @@ class MigrationVersionTest extends MigrationTestCase
         );
 
         self::assertStringContainsString('1233 deleted from the version table.', $this->commandTester->getDisplay(true));
+    }
+
+    /**
+     * @param list<string> $args
+     * @param list<string> $expectedSuggestions
+     */
+    #[TestWith([['console'], ['1233', '1234']])]
+    #[TestWith([['console', '1233'], ['1233', '1234']])]
+    public function testComplete(array $args, array $expectedSuggestions): void
+    {
+        $migration = self::createStub(AbstractMigration::class);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1233'), $migration);
+        Helper::registerMigrationInstance($this->migrationRepository, new Version('1234'), $migration);
+
+        $input = CompletionInput::fromTokens($args, 1);
+        $input->bind($this->command->getDefinition());
+        $suggestions = new CompletionSuggestions();
+
+        $this->command->complete($input, $suggestions);
+
+        self::assertSame(
+            $expectedSuggestions,
+            array_map(
+                static fn (Suggestion $suggestion): string => $suggestion->getValue(),
+                $suggestions->getValueSuggestions(),
+            ),
+        );
     }
 }


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | feature
| BC Break     | no
| Fixed issues | -

#### Summary

Adds completion of migration versions to commands that have `version(s)` as an argument. 